### PR TITLE
Move toError from Utility to Span.

### DIFF
--- a/lib/span.js
+++ b/lib/span.js
@@ -214,6 +214,8 @@ Span.prototype.runAsync = function (fn) {
   const span = this
   let ctx
 
+  log.debug('runAsync')
+
   try {
     ctx = ao.requestStore.createContext()
     ao.requestStore.enter(ctx)
@@ -222,10 +224,17 @@ Span.prototype.runAsync = function (fn) {
   }
 
   span.enter()
+  // fn is a function that accepts our wrapper, wraps the user's callback with it,
+  // then runs the user's runner function. That way our wrapper is invoked before
+  // the user's callback. handler is used only for memcached. No other callback
+  // function supplies it.
   const ret = fn.call(span, (cb, handler) => ao.bind(function (err) {
     if (handler) {
+      // handler is present only for some memcached functions.
       handler.apply(this, arguments)
     } else {
+      // the normal path, error can be a string or Error
+      // TODO BAM this contradicts docs "if not error is passed through"
       span.exitWithError(err)
     }
     return cb.apply(this, arguments)
@@ -252,6 +261,9 @@ Span.prototype.runAsync = function (fn) {
  * })
  */
 Span.prototype.runSync = function (fn) {
+
+  log.debug('runSync')
+
   let ctx = null
   try {
     if (!this.descended) {
@@ -367,7 +379,7 @@ Span.prototype.exitWithError = function (error, data) {
  */
 Span.prototype.setExitError = function (error) {
   try {
-    error = utility.toError(error)
+    error = Span.toError(error)
     if (error) this.events.exit.error = error
   } catch (e) {
     log.error(`${this.name} span failed to set exit error`, e.stack)
@@ -441,7 +453,7 @@ Span.prototype.error = function (error) {
   log.span(`${this.name} span error call`)
 
   try {
-    error = utility.toError(error)
+    error = Span.toError(error)
     if (!error) {
       log.info('invalid input to span.error(...)')
       return
@@ -450,5 +462,19 @@ Span.prototype.error = function (error) {
     this._internal('error', { error: error })
   } catch (e) {
     log.error(`${this.name} span failed to send error event`, e.stack)
+  }
+}
+
+//
+// Convert a string to an error, return an Error instance
+// or return undefined.
+//
+Span.toError = function (error) {
+  if (typeof error === 'string') {
+    return new Error(error)
+  }
+
+  if (error instanceof Error) {
+    return error
   }
 }

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -5,16 +5,6 @@ module.exports = {
     return fn.name || '(anonymous)'
   },
 
-  toError (error) {
-    if (typeof error === 'string') {
-      return new Error(error)
-    }
-
-    if (error instanceof Error) {
-      return error
-    }
-  },
-
   once (fn) {
     let used = false
     return function () {


### PR DESCRIPTION
Move the toError function from utility.js to static Span method in span.js.
Span is the only user of this function and it converts string as well as passes Errors.