### PR TITLE
rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm install --save appoptics-apm@latest
 
 ## Adding Your Own Spans
 
-Documentation coming soon!
+Our GitHub repository hosts an [overview](https://github.com/appoptics/appoptics-apm-node/blob/master/guides/instrumenting-a-module.md) and a [complete API reference](https://github.com/appoptics/appoptics-apm-node/blob/master/guides/api.md).
 
 ## Support
 

--- a/env.sh
+++ b/env.sh
@@ -120,13 +120,12 @@ elif [[ "$ARG" = "travis" ]]; then
     export AO_TEST_SQLSERVER_EX=mssql:1433
     export AO_TEST_SQLSERVER_EX_USERNAME=sa
 elif [[ "$ARG" = "debug" ]]; then
+    # this section is more for reference than anything else.
     export APPOPTICS_DEBUG_LEVEL=6
-    # see src/loggers.js for all the options
-    export DDEBUG=appoptics:flow,appoptics:metadata,appoptics:test:message
-
-    # Turn on the requestStore debug logging proxy (should work with fs now
-    # that logging uses in memory logger if stdout or stderr are not a TTY.
-    #export AO_TEST_REQUESTSTORE_PROXY=1
+    # see lib/loggers.js for all the options
+    export DEBUG=appoptics:error,appoptics:warn,appoptics:debug
+    export APPOPTICS_TOKEN_BUCKET_CAPACITY=1000
+    export APPOPTICS_TOKEN_BUCKET_RATE=1000
 elif [[ "$ARG" = "bindings" ]]; then
     # use these to provide authentication and specify an alternate branch/tag
     # for use by install-appoptics-bindings.js. the example below, given a git

--- a/lib/event.js
+++ b/lib/event.js
@@ -159,8 +159,7 @@ Object.defineProperty(Event, 'last', {
     try {
       ao.requestStore.set('lastEvent', value)
     } catch (e) {
-      log.error('Lost context before setting lastEvent %e', value)
-      log.error('Can not set cls.lastEvent. Context may be lost.', e)
+      log.error('Lost context before setting lastEvent %e @ %s', value, e)
     }
   }
 })

--- a/lib/index.js
+++ b/lib/index.js
@@ -522,14 +522,19 @@ exports.bind = function (fn) {
 exports.bindEmitter = function (em) {
   try {
     if (exports.tracing && em && typeof em.on === 'function') {
-      return exports.requestStore.bindEmitter(em)
+      // allow binding if tracing or an http emitter. no last event has been setup
+      // when the http instrumentation binds the events
+      if (exports.tracing
+        || (clsCheck() && (em instanceof http.IncomingMessage || em instanceof http.ServerResponse))) {
+        return exports.requestStore.bindEmitter(em)
+      }
     }
 
     if (!clsCheck()) {
       let e = new Error('CLS NOT ACTIVE')
       log.warn('ao.bindEmitter - no context', e.stack)
     } else if (!exports.tracing) {
-      log.warn('ao.bindEmitter - not tracing')
+      log.info('ao.bindEmitter - not tracing')
     } else {
       log.error('ao.bindEmitter - non-emitter')
     }
@@ -806,8 +811,8 @@ if (!enabled) {
    * @example
    * //
    * // A `build` function is run only when tracing; it is used to generate
-   * // a span. It can include custom data, but custom data can not be nested
-   * // and all values must be strings or numbers.
+   * // a span. It can include custom key value pairs, but the values must be
+   * // strings or numbers; the cannot be nested objects.
    * //
    * // The `run` function runs the function which you wish to instrument.
    * // Rather than giving it a callback directly, you give the done argument.

--- a/lib/index.js
+++ b/lib/index.js
@@ -868,7 +868,8 @@ if (!enabled) {
       return run(callback)
     }
 
-    // Build span
+    // Build span. Because last must exist this function cannot be used
+    // for a root span.
     let span
     try {
       span = typeof make === 'function' ? make(last) : last.descend(make)
@@ -884,7 +885,9 @@ if (!enabled) {
   // Set backtrace, if configured to do so, and run already constructed span
   //
   function runSpan (span, run, options, callback) {
-    if (!span) return run(callback)
+    if (!span) {
+      return run(callback)
+    }
 
     // Attach backtrace, if enabled
     if (options.collectBacktraces) {
@@ -897,21 +900,64 @@ if (!enabled) {
       : span.runSync(run)
   }
 
+  //
+  // called by startOrContinueTrace
+  //
+  function runRootSampled (span, run, options, callback) {
+    // Attach backtrace, if enabled
+    if (options.collectBacktraces) {
+      span.events.entry.Backtrace = exports.backtrace()
+    }
+    let opts = {
+      default: options.defaultTxName,
+      txname: options.customTxName
+    }
+    return callback
+      ? span.runAsync(makeWrappedRunner(run, callback), opts)
+      : span.runSync(run, opts)
+  }
+
+  //
+  // Called by startOrContinueTrace
+  //
+  function runRootUnsampled (span, run, options, callback) {
+    // if not sampled no need to even check option for backtraces.
+    let opts = {
+      default: options.defaultTxName,
+      txname: options.customTxName
+    }
+    return callback
+      ? span.runAsync(makeWrappedRunner(run, callback), opts)
+      : span.runSync(run, opts)
+  }
+
+
+  // This makes a callback-wrapping span runner
+  function makeWrappedRunner(run, callback) {
+    return wrap => run(wrap(callback))
+  }
+
   /**
-   * Start or continue a trace
+   * Start or continue a trace. Continue is in the sense of continuing a
+   * trace based on an X-Trace ID received from an external source, e.g.,
+   * HTTP headers or message queue headers.
    *
    * @method ao.startOrContinueTrace
    * @param {string} xtrace - X-Trace ID to continue from or null
    * @param {string|function} build - Name or function to build a span
    * @param {function} run - Code to instrument and run
-   * @param {object}  [options] - Options
-   * @param {boolean} [options.enabled] - Enable tracing
-   * @param {boolean} [options.collectBacktraces] - Collect backtraces
-   * @param {Function} [callback] - Callback, if async
+   * @param {object}  [opts] - Options
+   * @param {boolean} [opts.enabled] - Enable tracing
+   * @param {boolean} [opts.collectBacktraces] - Collect backtraces
+   * @param {string|function} [opts.customTxName] - name or function to return name
+   * @param {function} [callback] - Callback, if async
    */
   exports.startOrContinueTrace = function (xtrace, build, run, opts, cb) {
     // Verify that a run function is given
     if (typeof run !== 'function') return
+
+    // TODO BAM fix inconsistencies - opts could be cb but if no
+    // span-maker this doesn't use it.
 
     // Verify that a builder function or span name is given
     if (!~['function', 'string'].indexOf(typeof build)) {
@@ -936,46 +982,49 @@ if (!enabled) {
       return run(exports.bind(cb))
     }
 
-    // If already tracing, continue the existing trace.
+    // If already tracing, continue the existing trace independently of
+    // the xtrace passed as the first argument.
     const last = Span.last
     if (last) {
       return runInstrument(last, build, run, opts, cb)
     }
 
-    let data
+    //
+    // this is a root span and inbound metrics should be collected.
+    //
+    let maker
     try {
-      // Build data
-      data = typeof build === 'function' ? build({
+      // Build maker
+      maker = typeof build === 'function' ? build({
         descend: spanDataMaker(Span),
         profile: spanDataMaker(Profile)
       }) : {name: build, cons: Span}
     } catch (e) {
-      log.error('ao.startOrContinueTrace failed to build span', e.stack)
+      log.error('ao.startOrContinueTrace failed to make the span maker', e.stack)
     }
 
-    if (!data) {
+    // If no maker then maker.name is not available for the sample check.
+    // There is nothing else to do.
+    if (!maker) {
       return run(cb)
     }
 
-    // Do sampling
+    // Should this be sampled?
     let sample
     try {
-      sample = exports.sample(data.name, xtrace)
+      sample = exports.sample(maker.name, xtrace)
     } catch (e) {
-      log.error('ao.startOrContinueTrace failed to sample', e.stack)
+      log.error('ao.startOrContinueTrace failed to get sample decision', e.stack)
+      sample = {sample: false}
     }
 
-    if (!sample.sample) {
-      log.debug('sampling decision', sample)
-      return run(cb)
-    }
-
+    // Now actually make the span
     let span
     try {
-      // Now make the actual span
-      span = new data.cons(data.name, xtrace, data.data)
+      span = new maker.cons(maker.name, xtrace, maker.data)
 
       // Add sampling data to entry if there was not already an xtrace ID
+      // TODO BAM should this add even if a xtrace ID is present?
       if (sample.sample && !xtrace) {
         span.events.entry.set({
           SampleSource: sample.source,
@@ -986,7 +1035,16 @@ if (!enabled) {
       log.error('ao.startOrContinueTrace failed to build span', e.stack)
     }
 
-    return runSpan(span, run, opts, cb)
+    // if not span can't do inbound metrics - need a context.
+    if (!span) {
+      return run(cb)
+    }
+
+    // supply a default in case the user didn't provide a txname or a
+    // function to return a txname.
+    opts.defaultTxName = 'xyzzy'
+
+    return (sample.sample ? runRootSampled : runRootUnsampled)(span, run, opts, cb)
   }
 
   // This is a helper to map span.descend(...) and span.profile(...) calls
@@ -997,11 +1055,6 @@ if (!enabled) {
     return function (name, data) {
       return {name: name, data: data, cons: cons}
     }
-  }
-
-  // This makes a callback-wrapping span runner
-  function makeWrappedRunner (run, callback) {
-    return wrap => run(wrap(callback))
   }
 
   function noop () {}

--- a/lib/index.js
+++ b/lib/index.js
@@ -840,7 +840,7 @@ if (!enabled) {
     // Normalize dynamic arguments
     try {
       if (typeof options !== 'object') {
-        cb = opts
+        callback = options
         options = {enabled: true}
       } else {
         // default enabled to true if not explicitly false

--- a/lib/index.js
+++ b/lib/index.js
@@ -796,41 +796,42 @@ if (!enabled) {
    * Apply custom instrumentation to a function.
    *
    * @method ao.instrument
-   * @param {string|function} build - Span name or builder function
-   * @param {function} run - Code to instrument and run
-   * @param {object} [options] - Options
-   * @param {boolean} [options.enabled=true] - Enable tracing, on by default
-   * @param {boolean} [options.collectBacktraces=false] - Enable tracing, on by default
-   * @param {function} [callback] - Callback, if async
+   * @param {string|function} build - span name or builder function
+   * @param {function} run - code to instrument and run
+   * @param {object} [options] - options
+   * @param {boolean} [options.enabled=true] - enable tracing, on by default
+   * @param {boolean} [options.collectBacktraces=false] - enable tracing, on by default
+   * @param {function} [callback] - callback, if async
    *
-   * A `build` function is run only when tracing; it is used to generate
-   * a span. It can include custom data, but custom data can not be nested
-   * and all values must be strings or numbers.
+   * @example
+   * //
+   * // A `build` function is run only when tracing; it is used to generate
+   * // a span. It can include custom data, but custom data can not be nested
+   * // and all values must be strings or numbers.
+   * //
+   * // The `run` function runs the function which you wish to instrument.
+   * // Rather than giving it a callback directly, you give the done argument.
+   * // This tells AppOptics when your instrumented code is done running.
+   * //
+   * // The `callback` function is the callback you normally would have given
+   * // directly to the code you want to instrument. It receives the same
+   * // arguments as were received by the `done` callback for the `run` function
+   * // and the same `this` context is also applied to it.
+   * //
+   * function build (last) {
+   *   return last.descend('custom', { Foo: 'bar' })
+   * }
    *
-   * The `run` function runs the function which you wish to instrument.
-   * Rather than giving it a callback directly, you give the done argument.
-   * This tells AppOptics when your instrumented code is done running.
+   * function run (done) {
+   *   fs.readFile('some-file', done)
+   * }
    *
-   * The `callback` function is simply the callback you normally would have
-   * given directly to the code you want to instrument. It receives the same
-   * arguments as were received by the `done` callback for the `run`
-   * function, and the same `this` context is also applied to it.
+   * function callback (err, data) {
+   *   console.log('file contents are: ' + data)
+   * }
    *
-   *     function build (last) {
-   *       return last.descend('custom', { Foo: 'bar' })
-   *     }
+   * ao.instrument(build, run, callback)
    *
-   *     function run (done) {
-   *       fs.readFile('some-file', done)
-   *     }
-   *
-   *     function callback (err, data) {
-   *       console.log('file contents are: ' + data)
-   *     }
-   *
-   *     ao.instrument(build, run, callback)
-   *
-
    */
   exports.instrument = function (build, run, options, callback) {
     // Verify that a run function is given
@@ -860,7 +861,7 @@ if (!enabled) {
       return run(callback)
     }
 
-    // If not enabled, skip
+    // If not enabled, skip but maintain context
     if (!options.enabled) {
       log.info('ao.instrument disabled by option')
       return run(exports.bind(callback))

--- a/lib/index.js
+++ b/lib/index.js
@@ -261,7 +261,7 @@ const fs = require('fs')
 
 exports.version = require('../package.json').version
 
-function clsCheck(msg) {
+function clsCheck (msg) {
   let c = exports.requestStore
   let ok = c && c.active
   if (msg) {
@@ -521,11 +521,14 @@ exports.bind = function (fn) {
  */
 exports.bindEmitter = function (em) {
   try {
-    if (exports.tracing && em && typeof em.on === 'function') {
+    if (em && typeof em.on === 'function') {
       // allow binding if tracing or an http emitter. no last event has been setup
-      // when the http instrumentation binds the events
+      // when the http instrumentation binds the events.
       if (exports.tracing
-        || (clsCheck() && (em instanceof http.IncomingMessage || em instanceof http.ServerResponse))) {
+        || (clsCheck()
+          && (em instanceof http.IncomingMessage || em instanceof http.ServerResponse)
+        )
+      ) {
         return exports.requestStore.bindEmitter(em)
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -938,30 +938,59 @@ if (!enabled) {
    *
    * @method ao.startOrContinueTrace
    * @param {string} xtrace - X-Trace ID to continue from or null
-   * @param {string|function} build - Name or function to build a span
-   * @param {function} run - Code to instrument and run
-   * @param {object}  [opts] - Options
-   * @param {boolean} [opts.enabled] - Enable tracing
-   * @param {boolean} [opts.collectBacktraces] - Collect backtraces
+   * @param {string|function} build - name or function to return a span
+   * @param {function} run - run the code. if sync, no arguments, else one argument
+   * @param {object}  [opts] - options
+   * @param {boolean} [opts.enabled=true] - enable tracing
+   * @param {boolean} [opts.collectBacktraces=false] - collect backtraces
    * @param {string|function} [opts.customTxName] - name or function to return name
    * @param {function} [callback] - Callback, if async
+   *
+   * @example
+   * ao.startOrContinueTrace(
+   *   null,
+   *   'sync-span-name',
+   *   functionToRun,           // synchronous so function takes no arguments
+   *   {customTxName: 'special-span-name'}
+   * )
+   * @example
+   * ao.startOrContinueTrace(
+   *   null,
+   *   'sync-span-name',
+   *   functionToRun,
+   *   // note - no context is provided for the customTxName function. If
+   *   // context is required the caller should wrap the function in a closure.
+   *   {customTxName: customNameFunction}
+   * )
+   * @example
+   * // this is the function that should be instrumented
+   * request('https://www.google.com', function realCallback (err, res, body) {...})
+   * // because asyncFunctionToRun only accepts one parameter it must be
+   * // wrapped, so the function to run becomes
+   * function asyncFunctionToRun (cb) {
+   *   request('https://www.google.com', cb)
+   * }
+   * // and realCallback is supplied as the optional callback parameter
+   *
+   * ao.startOrContinueTrace(
+   *   null,
+   *   'async-span-name',
+   *   asyncFunctionToRun,     // async, so function takes one argument
+   *   // no options this time
+   *   realCallback            // receives request's callback arguments.
+   * )
    */
   exports.startOrContinueTrace = function (xtrace, build, run, opts, cb) {
     // Verify that a run function is given
     if (typeof run !== 'function') return
 
-    // TODO BAM fix inconsistencies - opts could be cb but if no
-    // span-maker this doesn't use it.
-
-    // Verify that a builder function or span name is given
-    if (!~['function', 'string'].indexOf(typeof build)) {
-      return run(cb)
-    }
-
     try {
       if (typeof opts !== 'object') {
         cb = opts
         opts = {enabled: true}
+      } else {
+        // default enabled to true if not explicitly false
+        opts = Object.assign({enabled: true}, opts)
       }
 
       if (!cb && run.length) {
@@ -969,6 +998,11 @@ if (!enabled) {
       }
     } catch (e) {
       log.error('ao.startOrContinueTrace failed to normalize arguments', e.stack)
+    }
+
+    // Verify that a builder function or span name is given
+    if (!~['function', 'string'].indexOf(typeof build)) {
+      return run(cb)
     }
 
     // If not enabled, skip
@@ -1035,8 +1069,9 @@ if (!enabled) {
     }
 
     // supply a default in case the user didn't provide a txname or a
-    // function to return a txname.
-    opts.defaultTxName = 'xyzzy'
+    // function to return a txname. if the span is unnamed then let oboe
+    // provide "unknown"
+    opts.defaultTxName = span.name ? 'custom-' + span.name : ''
 
     return (sample.sample ? runRootSampled : runRootUnsampled)(span, run, opts, cb)
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -531,12 +531,14 @@ exports.bindEmitter = function (em) {
     } else if (!exports.tracing) {
       log.warn('ao.bindEmitter - not tracing')
     } else {
-      log.warn('ao.bindEmitter - non-emitter')
+      log.error('ao.bindEmitter - non-emitter')
     }
-    return em
   } catch (e) {
     log.error('failed to bind emitter', e.stack)
   }
+
+  // return the original if it couldn't be bound for any reason.
+  return em
 }
 
 /**
@@ -709,8 +711,8 @@ if (!enabled) {
    *
    * @ignore
    * @method ao.addResponseFinalizer
-   * @param {HTTPResponse} res HTTP Response to attach a finalizer to
-   * @param {function} finalizer Finalization function
+   * @param {HTTPResponse} res - HTTP Response to attach a finalizer to
+   * @param {function} finalizer - Finalization function
    */
   const responseFinalizers = new WeakMap()
   exports.addResponseFinalizer = function (res, finalizer) {
@@ -725,12 +727,12 @@ if (!enabled) {
    * Instrument HTTP request/response
    *
    * @method ao.instrumentHttp
-   * @param {string|function} build - Span name or builder function
-   * @param {function} run - Code to instrument and run
-   * @param {object} [options] - Options
-   * @param {object} [options.enabled] - Enable tracing, on by default
-   * @param {object} [options.collectBacktraces] - Collect backtraces
-   * @param {HTTPResponse} res - HTTP Response to patch
+   * @param {string|function} build - span name or builder function
+   * @param {function} run - code to instrument and run
+   * @param {object} [options] - options
+   * @param {object} [options.enabled] - enable tracing, on by default
+   * @param {object} [options.collectBacktraces] - collect backtraces
+   * @param {HTTPResponse} res - HTTP response to patch
    */
   exports.instrumentHttp = function (build, run, options, res) {
     // If not tracing, skip
@@ -797,8 +799,8 @@ if (!enabled) {
    * @param {string|function} build - Span name or builder function
    * @param {function} run - Code to instrument and run
    * @param {object} [options] - Options
-   * @param {boolean} [options.enabled] - Enable tracing, on by default
-   * @param {boolean} [options.collectBacktraces] - Enable tracing, on by default
+   * @param {boolean} [options.enabled=true] - Enable tracing, on by default
+   * @param {boolean} [options.collectBacktraces=false] - Enable tracing, on by default
    * @param {function} [callback] - Callback, if async
    *
    * A `build` function is run only when tracing; it is used to generate
@@ -837,8 +839,11 @@ if (!enabled) {
     // Normalize dynamic arguments
     try {
       if (typeof options !== 'object') {
-        callback = options
+        cb = opts
         options = {enabled: true}
+      } else {
+        // default enabled to true if not explicitly false
+        options = Object.assign({enabled: true}, options)
       }
 
       if (!callback && run.length) {
@@ -848,7 +853,7 @@ if (!enabled) {
       log.error('ao.instrument failed to normalize arguments', e.stack)
     }
 
-    // If not tracing, skip
+    // If not tracing, there is some error, skip.
     const last = Span.last
     if (!last) {
       log.info('ao.instrument found no lastSpan')

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,10 +165,17 @@ Object.keys(probeDefaults.probes).forEach(mod => {
 // it takes an http request object argument.
 exports.getDomainPrefix = function (req) {
   let h = req.headers
-  let s = req.socket || {}
+  let s = req.socket || {localPort: 80}
   let prefix = h && h['x-forwarded-host'] || h['host'] || ''
+  let parts = prefix.split(':')
+  // if the port is included in the header then use it
+  if (parts.length === 2 && parts[1]) {
+    return prefix
+  }
+  // use the first part (strips off ':' with nothing after)
+  prefix = parts[0]
   if (s.localPort !== 80 && s.localPort !== 443 && prefix !== '') {
-    prefix = prefix + ':' + localPort
+    prefix = prefix + ':' + s.localPort
   }
   return prefix
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -844,13 +844,13 @@ if (!enabled) {
     // If not tracing, skip
     const last = Span.last
     if (!last) {
-      log.force.status('ao.instrument no lastSpan')
+      log.info('ao.instrument found no lastSpan')
       return run(callback)
     }
 
     // If not enabled, skip
     if (!options.enabled) {
-      log.force.status('ao.instrument disabled by option')
+      log.info('ao.instrument disabled by option')
       return run(exports.bind(callback))
     }
 
@@ -908,13 +908,10 @@ if (!enabled) {
     if (options.collectBacktraces) {
       span.events.entry.Backtrace = exports.backtrace()
     }
-    let opts = {
-      default: options.defaultTxName,
-      txname: options.customTxName
-    }
+
     return callback
-      ? span.runAsync(makeWrappedRunner(run, callback), opts)
-      : span.runSync(run, opts)
+      ? span.runAsync(makeWrappedRunner(run, callback), options)
+      : span.runSync(run, options)
   }
 
   //
@@ -922,13 +919,10 @@ if (!enabled) {
   //
   function runRootUnsampled (span, run, options, callback) {
     // if not sampled no need to even check option for backtraces.
-    let opts = {
-      default: options.defaultTxName,
-      txname: options.customTxName
-    }
+
     return callback
-      ? span.runAsync(makeWrappedRunner(run, callback), opts)
-      : span.runSync(run, opts)
+      ? span.runAsync(makeWrappedRunner(run, callback), options)
+      : span.runSync(run, options)
   }
 
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -85,7 +85,7 @@ Object.defineProperty(exports, 'enabled', {
 // forced output is logged whether enabled or not (but
 // the environment still must be set for it).
 //
-exports.force = {
+var defaultLoggers = {
   flow: debug('appoptics:flow'),
   state: debug('appoptics:state'),
   oboe: debug('appoptics:oboe'),
@@ -96,25 +96,15 @@ exports.force = {
   settings: debug('appoptics:settings'),
   patching: debug('appoptics:patching')     // show errors patching
 }
-//
-// Expose the forced loggers at the top level where they are wrapped so
-// enabled must be true for them to be output.
-//
-var wrap = function (fn) {return function () {enabled && fn.apply(fn, arguments)}}
 
-Object.keys(exports.force).forEach(function (key) {
-  exports[key] = wrap(exports.force[key])
-})
+Object.keys(defaultLoggers).forEach(k => exports[k] = defaultLoggers[k])
 
 //
 // always log errors and info when set, no need to force
 //
 exports.error = debug('appoptics:error')        // used for unexpected errors
-exports.force.error = exports.error
 exports.warn = debug('appoptics:warn')          // warning level
-exports.force.warn = exports.warn
 exports.debug = debug('appoptics:debug')        // no need to force.
-exports.force.debug = exports.debug
 exports.patching = debug('appoptics:patching')  // unexpected findings while patching
 
 //
@@ -152,7 +142,7 @@ exports.addGroup = function (def) {
   let newLoggers = []
 
   def.subNames.forEach(function (name) {
-    g[name] = wrap(debug(fullPrefix + name))
+    g[name] = debug(fullPrefix + name)
     if (def.activate && env.indexOf(fullPrefix + name) < 0) {
       newLoggers.push(groupPrefix + name)
     }

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -139,6 +139,9 @@ function patchClient (module, protocol) {
 
 }
 
+//
+// patch the server - it creates a root span
+//
 function patchServer (module, protocol) {
   const conf = ao.probes[protocol]
 
@@ -192,9 +195,11 @@ function patchServer (module, protocol) {
       patchEmitter(res)
       patchEmitter(res.socket)
 
+      /*
       // Bind streams to the request store
       ao.bindEmitter(req)
       ao.bindEmitter(res)
+      // */
     } catch (e) {
       log.error('http failed to patch request', e)
     }
@@ -202,6 +207,10 @@ function patchServer (module, protocol) {
     let ret
     ao.requestStore.run(() => {
       try {
+        // Bind streams to the request store now that there is a context.
+        ao.bindEmitter(req)
+        ao.bindEmitter(res)
+
         // TODO BAM make this use md, not string. must rethink
         // whole new Span() because the type of the xtrace is
         // an implicit parameter to the function.
@@ -213,7 +222,12 @@ function patchServer (module, protocol) {
         // add a counter to track how many times a custom name's been set
         res._ao_metrics.customNameFuncCalls = 0
 
+        // start keeping the metrics information in CLS. do so in parallel
+        // to until verified that it is correct.
+        //ao.requestStore.set('metrics', res._ao_metrics)
+
         // Keep upper-most span for later
+        // TODO BAM this is for RUM only and should be removed.
         ao.requestStore.set('topSpan', span)
 
         getRequestHeaders(span, req)
@@ -238,7 +252,7 @@ function patchServer (module, protocol) {
     return Number(host ? host.split(':')[1] : defaultPort[protocol])
   }
 
-  function getPath ({ url }) {
+  function getPath ({url}) {
     return conf.includeRemoteUrlParams ? url : url.replace(/\?.*/, '')
   }
 
@@ -302,7 +316,7 @@ function patchServer (module, protocol) {
 
       // set TransactionName now as it could have been set by Express or
       // another framework. If it wasn't set then the URL is also sent
-      // along and oboe will do the right thing.
+      // and oboe will do the right thing.
       let exitKeyValuePairs = {
         TransactionName: res._ao_metrics.txname,
         Status: res.statusCode

--- a/lib/span.js
+++ b/lib/span.js
@@ -203,24 +203,30 @@ Span.prototype.run = function (fn) {
  *
  * @method Span#runAsync
  * @param {function} fn - async function to run within the span context
+ * @param {object} rootOpts - presence indicate that this is a root span
+ * @param {string} rootOpts.defaultTxName - the default transaction name to use
+ * @param {string|function} [rootOpts.customTxName] - string or function returning string
  *
  * @example
  * span.runAsync(function (wrap) {
  *   asyncCallToTrace(wrap(callback))
  * })
  */
-Span.prototype.runAsync = function (fn) {
+Span.prototype.runAsync = function (fn, rootOpts) {
   this.async = true
   const span = this
   let ctx
-
-  log.debug('runAsync')
+  let startTime
 
   try {
     ctx = ao.requestStore.createContext()
     ao.requestStore.enter(ctx)
   } catch (e) {
     log.error(`${this.name} span failed to enter context`, e.stack)
+  }
+
+  if (rootOpts) {
+    startTime = new Date().getTime()
   }
 
   span.enter()
@@ -237,6 +243,25 @@ Span.prototype.runAsync = function (fn) {
       // TODO BAM this contradicts docs "if not error is passed through"
       span.exitWithError(err)
     }
+
+    if (rootOpts) {
+      let txname = rootOpts.defaultTxName
+      if (rootOpts.customTxName) {
+        if (typeof rootOpts.customTxName === 'string') {
+          txname = rootOpts.customTxName
+        } else if (typeof rootOpts.customTxName === 'function') {
+          try {
+            // if the user needs context they need to create a closure.
+            txname = rootOpts.customTxName()
+          } catch (e) {
+            log.error('customTxName function %s', e)
+          }
+        }
+      }
+
+      Span.sendMetrics(txname, (new Date().getTime() - startTime) * 1000, err)
+    }
+
     return cb.apply(this, arguments)
   }))
 
@@ -260,10 +285,7 @@ Span.prototype.runAsync = function (fn) {
  *   syncCallToTrace()
  * })
  */
-Span.prototype.runSync = function (fn) {
-
-  log.debug('runSync')
-
+Span.prototype.runSync = function (fn, txname) {
   let ctx = null
   try {
     if (!this.descended) {
@@ -462,6 +484,15 @@ Span.prototype.error = function (error) {
     this._internal('error', { error: error })
   } catch (e) {
     log.error(`${this.name} span failed to send error event`, e.stack)
+  }
+}
+
+Span.sendMetrics = function (txname, duration, error) {
+  let args = {
+    txname: txname,
+    domain: ao.cfg.domainPrefix ? ao.getDomainPrefix(req) : '',
+    duration: duration,
+    error: !!error
   }
 }
 

--- a/lib/span.js
+++ b/lib/span.js
@@ -508,7 +508,7 @@ Span.prototype.error = function (error) {
 Span.sendNonHttpSpan = function (txname, duration, error) {
   let args = {
     txname: txname,
-    domain: ao.cfg.domainPrefix ? ao.getDomainPrefix(req) : '',
+    //domain: ao.cfg.domainPrefix ? ao.getDomainPrefix(req) : '',
     duration: duration,
     error: !!error
   }

--- a/lib/span.js
+++ b/lib/span.js
@@ -203,8 +203,8 @@ Span.prototype.run = function (fn) {
  *
  * @method Span#runAsync
  * @param {function} fn - async function to run within the span context
- * @param {object} rootOpts - presence indicate that this is a root span
- * @param {string} rootOpts.defaultTxName - the default transaction name to use
+ * @param {object} [rootOpts] - presence indicates that this is a root span
+ * @param {string} [rootOpts.defaultTxName] - the default transaction name to use
  * @param {string|function} [rootOpts.customTxName] - string or function returning string
  *
  * @example
@@ -272,6 +272,9 @@ Span.prototype.runAsync = function (fn, rootOpts) {
  *
  * @method Span#runSync
  * @param {function} fn - sync function to run withing the span context
+ * @param {object} [rootOpts] - presence indicates that this is a root span
+ * @param {string} [rootOpts.defaultTxName] - the default transaction name to use
+ * @param {string|function} [rootOpts.customTxName] - string or function returning string
  *
  * @example
  * span.runSync(function () {
@@ -293,6 +296,9 @@ Span.prototype.runSync = function (fn, rootOpts) {
     log.error(`${this.name} span failed to enter context`, e.stack)
   }
 
+  // rootOpts is only present if it is a root span, so it can
+  // be regarded as a "I am a root span" flag. And span metrics
+  // are only sent for root spans.
   if (rootOpts) {
     startTime = new Date().getTime()
   }
@@ -305,9 +311,6 @@ Span.prototype.runSync = function (fn, rootOpts) {
     this.setExitError(err)
     throw err
   } finally {
-    // rootOpts is only present if it is a root span, so it can
-    // be regarded as a "I am a root span" flag. And span metrics
-    // are only sent for root spans.
     if (rootOpts) {
       let txname = Span.getTransactionName(rootOpts)
       finaltxname = Span.sendNonHttpSpan(txname, (new Date().getTime() - startTime) * 1000, error)

--- a/lib/span.js
+++ b/lib/span.js
@@ -285,7 +285,7 @@ Span.prototype.runSync = function (fn, rootOpts) {
   let ctx = null
   let error
   let startTime
-  let finaltxname
+  let kvpairs = {}
 
   try {
     if (!this.descended) {
@@ -313,10 +313,11 @@ Span.prototype.runSync = function (fn, rootOpts) {
   } finally {
     if (rootOpts) {
       let txname = Span.getTransactionName(rootOpts)
-      finaltxname = Span.sendNonHttpSpan(txname, (new Date().getTime() - startTime) * 1000, error)
+      let finaltxname = Span.sendNonHttpSpan(txname, (new Date().getTime() - startTime) * 1000, error)
+      kvpairs.TransactionName = finaltxname
     }
 
-    this.exit({TransactionName: finaltxname})
+    this.exit(kvpairs)
 
     try {
       if (ctx) {

--- a/lib/span.js
+++ b/lib/span.js
@@ -217,6 +217,7 @@ Span.prototype.runAsync = function (fn, rootOpts) {
   const span = this
   let ctx
   let startTime
+  let finaltxname
 
   try {
     ctx = ao.requestStore.createContext()
@@ -237,30 +238,22 @@ Span.prototype.runAsync = function (fn, rootOpts) {
   const ret = fn.call(span, (cb, handler) => ao.bind(function (err) {
     if (handler) {
       // handler is present only for some memcached functions.
+      // TODO BAM how to handle this with customTxName...
       handler.apply(this, arguments)
     } else {
-      // the normal path, error can be a string or Error
-      // TODO BAM this contradicts docs "if not error is passed through"
-      span.exitWithError(err)
-    }
+      // this is the "normal", i.e., non-memcached path.
 
-    if (rootOpts) {
-      let txname = rootOpts.defaultTxName
-      if (rootOpts.customTxName) {
-        if (typeof rootOpts.customTxName === 'string') {
-          txname = rootOpts.customTxName
-        } else if (typeof rootOpts.customTxName === 'function') {
-          try {
-            // if the user needs context they need to create a closure.
-            txname = rootOpts.customTxName()
-          } catch (e) {
-            log.error('customTxName function %s', e)
-          }
-        }
+      // rootOpts is only present if it is a root span, so it can
+      // be regarded as a "I am a root span" flag. And span metrics
+      // are only sent for root spans.
+      if (rootOpts) {
+        let txname = Span.getTransactionName(rootOpts)
+        finaltxname = Span.sendNonHttpSpan(txname, (new Date().getTime() - startTime) * 1000, err)
       }
 
-      Span.sendMetrics(txname, (new Date().getTime() - startTime) * 1000, err)
+      span.exitWithError(err, {TransactionName: finaltxname})
     }
+
 
     return cb.apply(this, arguments)
   }))
@@ -285,8 +278,12 @@ Span.prototype.runAsync = function (fn, rootOpts) {
  *   syncCallToTrace()
  * })
  */
-Span.prototype.runSync = function (fn, txname) {
+Span.prototype.runSync = function (fn, rootOpts) {
   let ctx = null
+  let error
+  let startTime
+  let finaltxname
+
   try {
     if (!this.descended) {
       ctx = ao.requestStore.createContext()
@@ -296,14 +293,28 @@ Span.prototype.runSync = function (fn, txname) {
     log.error(`${this.name} span failed to enter context`, e.stack)
   }
 
+  if (rootOpts) {
+    startTime = new Date().getTime()
+  }
+
   this.enter()
   try {
     return fn.call(this)
   } catch (err) {
+    error = err
     this.setExitError(err)
     throw err
   } finally {
-    this.exit()
+    // rootOpts is only present if it is a root span, so it can
+    // be regarded as a "I am a root span" flag. And span metrics
+    // are only sent for root spans.
+    if (rootOpts) {
+      let txname = Span.getTransactionName(rootOpts)
+      finaltxname = Span.sendNonHttpSpan(txname, (new Date().getTime() - startTime) * 1000, error)
+    }
+
+    this.exit({TransactionName: finaltxname})
+
     try {
       if (ctx) {
         ao.requestStore.exit(ctx)
@@ -336,7 +347,7 @@ Span.prototype.runSync = function (fn, txname) {
  */
 Span.prototype.enter = function (data) {
   let type = this instanceof Profile ? 'profile' : 'span'
-  log.force.span('%s enter called %e', type, this.events.entry);
+  log.span('%s enter called %e', type, this.events.entry);
 
 
   try {
@@ -354,11 +365,11 @@ Span.prototype.enter = function (data) {
  * Send the exit event
  *
  * @method Span#exit
- * @param {bbject} data - Key/Value pairs of info to add to event
+ * @param {object} data - key-value pairs of info to add to event
  */
 Span.prototype.exit = function (data) {
   let type = this instanceof Profile ? 'profile' : 'span'
-  log.force.span('%s exit called %e', type, this.events.exit);
+  log.span('%s exit called %e', type, this.events.exit);
 
 
   try {
@@ -487,13 +498,44 @@ Span.prototype.error = function (error) {
   }
 }
 
-Span.sendMetrics = function (txname, duration, error) {
+//
+// This is not really associated with a Span now so make it static.
+//
+Span.sendNonHttpSpan = function (txname, duration, error) {
   let args = {
     txname: txname,
     domain: ao.cfg.domainPrefix ? ao.getDomainPrefix(req) : '',
     duration: duration,
     error: !!error
   }
+
+  var finalTxName = ao.reporter.sendNonHttpSpan(args)
+
+  return finalTxName
+}
+
+//
+// Given rootOpts return the transaction name. Only root spans
+// have transaction names.
+//
+Span.getTransactionName = function (rootOpts) {
+  let txname
+  if (rootOpts.customTxName) {
+    if (typeof rootOpts.customTxName === 'string') {
+      txname = rootOpts.customTxName
+    } else if (typeof rootOpts.customTxName === 'function') {
+      try {
+        // if the user needs context they need to create a closure.
+        txname = rootOpts.customTxName()
+      } catch (e) {
+        log.error('customTxName function %s', e)
+      }
+    }
+  }
+  if (!txname) {
+    txname = rootOpts.defaultTxName
+  }
+  return txname
 }
 
 //
@@ -501,6 +543,9 @@ Span.sendMetrics = function (txname, duration, error) {
 // or return undefined.
 //
 Span.toError = function (error) {
+  // error can be a string or Error
+  // TODO BAM this contradicts docs "if not error is passed through"
+
   if (typeof error === 'string') {
     return new Error(error)
   }

--- a/lib/span.js
+++ b/lib/span.js
@@ -217,7 +217,7 @@ Span.prototype.runAsync = function (fn, rootOpts) {
   const span = this
   let ctx
   let startTime
-  let finaltxname
+  let kvpairs = {}
 
   try {
     ctx = ao.requestStore.createContext()
@@ -248,12 +248,12 @@ Span.prototype.runAsync = function (fn, rootOpts) {
       // are only sent for root spans.
       if (rootOpts) {
         let txname = Span.getTransactionName(rootOpts)
-        finaltxname = Span.sendNonHttpSpan(txname, (new Date().getTime() - startTime) * 1000, err)
+        let finaltxname = Span.sendNonHttpSpan(txname, (new Date().getTime() - startTime) * 1000, err)
+        kvpairs.TransactionName = finaltxname
       }
 
-      span.exitWithError(err, {TransactionName: finaltxname})
+      span.exitWithError(err, kvpairs)
     }
-
 
     return cb.apply(this, arguments)
   }))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "4.4.0-rc1",
+  "version": "4.4.1-rc1",
   "description": "Agent for AppOptics APM",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "4.3.2-beta",
+  "version": "4.4.0-rc1",
   "description": "Agent for AppOptics APM",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "vision": "^4.1.0"
   },
   "optionalDependencies": {
-    "appoptics-bindings": "appoptics-bindings@5.0.1"
+    "appoptics-bindings": "5.1.0-rc1"
   },
   "unused": {
     "dev-dependency-oracledb-1.13.1": "^1.13.1",


### PR DESCRIPTION
Custom transaction name [AO-7777]
- Use final transaction name on exit event.
- depends on appoptics-bindings@5 [AO-7992]
- domain prefix [AO-8104]
- default TransactionName for custom spans is 'custom-' prefix to the span name.

Bug fixes
- don't duplicate domain port if already in header
- never prefix domain for non-http traces [AO-8104]
- bind http emitters from active CLS context. [AO-8454]

General
- remove log.force functions and concept [AO-8224]
- add TOKEN_BUCKET env vars to env.sh
- move docs to jsdoc via jsdoc2md [AO-7403]
- add more examples to SDK/API documentation
- README links to github for "adding your own spans" docs.
- add tests in appoptics-apm and todo application

Examples

Using custom transaction name with SDK `startOrContinueTrace` pass an options object with the property `customTxName` with a value of either a string (use that name) or a function that returns the string name to be used.

```
  ao.startOrContinueTrace(
    null,
    'sync-span-name',
    functionToRun,
    // note - no context is provided for the customTxName function. If
    // context is required the caller should wrap the function in a closure.
    {customTxName: customNameFunction}
  )
```

To set a custom transaction name for autoinstrumented code, set a callback function for that instrumented package, e.g., `express` (the initial package supporting custom transaction names). The signature of callbacks is dependent on the specific package being instrumented but HTTP-based callbacks receive the `req` and `res` objects typically passed to callbacks.

```
ao.setCustomTxNameFunction('express', customNameFunction)

function customNameFunction (req, res) {
  // make a custom transaction name. the express default is
  // 'express.' + func.name + '.' + req.method + req.route.path
  // where func.name is the name of the function handling the route or 'anonymous'
}
```
