### PR TITLE
Package cleanup

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -1,7 +1,23 @@
 #!/bin/sh
 
+# don't even try install these in production
+[ $NODE_ENV = "production" ] && exit 0
+
+# they're all optional, so ignore failures
 {
-  npm install oracledb@0.3.1
+    npm install oracledb@0.3.1
 } || {
-  exit 0
+    echo "unable to install optional oracledb package"
+}
+
+{
+    npm install pg@4.5.7
+} || {
+    echo "unable to install optional pg package"
+}
+
+{
+    npm install pg-native@1.10.0
+} || {
+    echo "unable to install optional pg-native package"
 }

--- a/deps.sh
+++ b/deps.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # don't even try install these in production
-[ $NODE_ENV = "production" ] && exit 0
+[ "$NODE_ENV" = "production" ] && exit 0
 
 # they're all optional, so ignore failures
 {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "should": "^8.3.1",
     "supertest": "^3.0.0",
     "tedious": "^2.3.1",
-    "testeachversion": "^5.1.1",
+    "testeachversion": "^6.0.0",
     "vision": "^4.1.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "node-ao": "./bin/node-ao"
   },
   "scripts": {
-    "postinstall": "node install-appoptics-bindings.js",
     "test": "gulp test",
     "docs": "jsdoc2md -f lib/index.js -f lib/span.js -f lib/event.js > guides/api.md",
     "install-deps": "./deps.sh",
+    "postinstall": "./deps.sh",
     "coverage": "gulp coverage",
     "support-matrix": "gulp support-matrix",
     "watch": "gulp watch",
@@ -103,9 +103,7 @@
     "vision": "^4.1.0"
   },
   "optionalDependencies": {
-    "appoptics-bindings": "5.2.0",
-    "pg": "^4.5.7",
-    "pg-native": "^1.10.0"
+    "appoptics-bindings": "5.2.0"
   },
   "unused": {
     "dev-dependency-oracledb-1.13.1": "^1.13.1",


### PR DESCRIPTION
- change postinstall script from appoptics-bindings to install dependencies
- put production check in `deps.sh` (they are dev dependencies).
- move dev-dependencies from`optionalDependencies` to `deps.sh`
- update `testeachversion` to 6.0.0