### PR TITLE
use cls-hooked, retire continuation-local-storage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -273,7 +273,7 @@ const modeMap = {
 // Load dependencies
 //
 // TODO BAM consider not loading these at all if not enabled.
-const cls = require('continuation-local-storage')
+const cls = require('cls-hooked')
 const WeakMap = require('es6-weak-map')
 const shimmer = require('shimmer')
 const fs = require('fs')

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "array-flatten": "^2.1.0",
-    "continuation-local-storage": "^3.2.1",
+    "cls-hooked": "^4.2.2",
     "debug": "^3.1.0",
     "es6-weak-map": "^2.0.1",
     "event-unshift": "^1.0.0",

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -7,6 +7,7 @@ const noop = helper.noop
 const semver = require('semver')
 const path = require('path')
 const fs = require('fs')
+ao.probes.fs.collectBacktraces = false
 
 describe('probes.fs once', function () {
   let emitter
@@ -178,8 +179,12 @@ describe('probes.fs', function () {
       subs: function () {
         if (mode === 'sync') {
           return [span('open'), span('ftruncate'), span('close')]
+        } else {
+          // if cls-hooked
+          return [span('open'), span('close')]
+          // if continuation-local-storage
+          // return [span('open')]
         }
-        return [span('open')]
       }
     },
     // fs.appendFile


### PR DESCRIPTION
In order to support async/await it is necessary to move to `async-hooks`. `cls-hooked` uses `async_hooks`, which enables handling async/await. It falls back to `AsyncWrap` for versions of node prior to 8. `AsyncWrap` is unsupported but so is `async-listener`, what `continuation-local-storage` uses now.h

I have run the test matrix using `cls-hooked` and the results are identical to those obtained using `continuation-local-storage`. I have modified the `generic-pool` probe/patching and testing to test their new version 3, promise-based API. It passes the test when using `cls-hooked` but fails when using `continuation-local-storage` (even for node version 6, so `AsyncWrap` handles some things that `async-listener` doesn't.

The only real alternative to this is to implement a combination of `async-listener`, `AsyncWrap`, and `async_hooks` directly in our code and stop using `cls-hooked` or `continuation-local-storage`.

This PR addresses [AO-9514] Support async/await. That doesn't imply that every API we instrument is automatically supported - some, like `generic-pool`, change their APIs completely which requires changes to our probe code.