### PR TITLE
Generic pool fixes

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -3,6 +3,9 @@ env:
   es6: true
   mocha: true # NOTE: Tests don't pass eslint yet. I'll fix that later.
 
+parserOptions:
+  ecmaVersion: 2017
+
 rules:
   # Possible Errors
   # http://eslint.org/docs/rules/#possible-errors

--- a/lib/probes/generic-pool.js
+++ b/lib/probes/generic-pool.js
@@ -2,16 +2,43 @@
 
 const shimmer = require('shimmer')
 const ao = require('..')
+const log = ao.loggers
+
+const requirePatch = require('../require-patch')
+const semver = require('semver')
+const clientVersion = requirePatch.relativeRequire('generic-pool/package').version
+const majorVersion = semver.major(clientVersion)
 
 module.exports = function (gp) {
-  const proto = gp.Pool && gp.Pool.prototype
-  if (proto) patchAcquire(proto)
-  else patchPool(gp)
+  // version 3 is a major overhaul. see:
+  // https://github.com/coopernurse/node-pool/blob/master/CHANGELOG.md
+  if (majorVersion < 3) {
+    const proto = gp.Pool && gp.Pool.prototype
+    if (proto) {
+      patchAcquire(proto)
+    } else {
+      patchPool(gp)
+    }
+  } else {
+    // if it's not a function there is nothing to do
+    if (typeof gp.createPool !== 'function') {
+      log.patching('generic-pool v3 - createPool is not a function: %s', typeof gp.createPool)
+      return
+    }
+
+    patchCreatePool(gp)
+  }
   return gp
 }
 
+//
+// v2
+//
 function patchPool (proto) {
-  if (typeof proto.Pool !== 'function') return
+  if (typeof proto.Pool !== 'function') {
+    log.patching('generic-pool - Pool is not a function')
+    return
+  }
   shimmer.wrap(proto, 'Pool', fn => function (factory) {
     const pool = fn.call(this, factory)
     patchAcquire(pool)
@@ -20,8 +47,45 @@ function patchPool (proto) {
 }
 
 function patchAcquire (proto) {
-  if (typeof proto.acquire !== 'function') return
+  if (typeof proto.acquire !== 'function') {
+    log.patching('generic-pool - acquire is not a function')
+    return
+  }
   shimmer.wrap(proto, 'acquire', fn => function (callback, priority) {
     return fn.call(this, ao.bind(callback), priority)
+  })
+}
+
+//
+// v3
+//
+function patchCreatePool (gp) {
+  if (typeof gp.createPool !== 'function') {
+    log.patching('generic-pool - createPool is not a function')
+    return
+  }
+
+  if (typeof gp.Pool.prototype.acquire !== 'function' || typeof gp.Pool.prototype.release !== 'function') {
+    log.patching('generic-pool - acquire/release not found on prototype')
+    return
+  }
+
+  shimmer.wrap(gp, 'createPool', original => function (factory, config) {
+    // create the pool then patch the functions that acquire and release
+    // pooled resources. they return promises so they need to have
+    // appoptics cls context.
+    const pool = original.call(this, factory, config)
+
+    shimmer.wrap(pool, 'acquire', fn => function () {
+      const bound = ao.bind(fn)
+      return bound.call(this)
+    })
+
+    shimmer.wrap(pool, 'release', fn => function (resource) {
+      const bound = ao.bind(fn)
+      return bound.call(this, resource)
+    })
+
+    return pool
   })
 }

--- a/test/probes/generic-pool.test.js
+++ b/test/probes/generic-pool.test.js
@@ -1,44 +1,210 @@
-var helper = require('../helper')
-var ao = helper.ao
+'use strict'
 
-var Pool = require('generic-pool').Pool
-var pkg = require('generic-pool/package')
+const helper = require('../helper')
+const semver = require('semver')
+const should = require('should')
+const ao = helper.ao
+const log = ao.loggers
 
-var foo = { bar: 'baz' }
+const gp = require('generic-pool')
 
-var pool = new Pool({
-  name: 'test',
-  create: function (cb) {
-    cb(null, foo)
-  },
-  max: 1,
-  min: 1
-})
+// execute tests conditionally
+const pkg = require('generic-pool/package')
+const v3 = semver.satisfies(pkg.version, '>= 3')
+const ifv3 = v3 ? it : it.skip
+const ifv2 = v3 ? it.skip : it
+
+let n = 0
+const max = 2
+const foo = {bar: 'baz'}
+
+let pool
+if (!v3) {
+  // v2 signature
+  pool = new gp.Pool({
+    name: 'test',
+    create: function (cb) {
+      if (n >= max) {
+        cb('done')
+      } else {
+        n += 1
+        cb(null, {bar: n})
+      }
+      cb(null, foo)
+    },
+    max: 2,
+    min: 2
+  })
+} else {
+  // v3 signature
+  const factory = {
+    create: function () {
+      if (n >= max) {
+        return Promise.reject()
+      }
+      n += 1
+      return Promise.resolve({bar: n})
+    },
+    destroy: function (resource) {
+      return Promise.resolve(true)
+    }
+  }
+  const options = {
+    max: 2,
+    min: 2
+  }
+  pool = gp.createPool(factory, options)
+}
+
 
 describe('probes/generic-pool ' + pkg.version, function () {
-  it('should trace through generic-pool acquire', function (done) {
-    var acquiring = false
+  ifv2('should trace through generic-pool acquire for versions < 3', function (done) {
+    //
+    // v2 uses callbacks
+    //
+    let okToRelease = false
 
-    pool.acquire(function (err, foo2) {
-      var t = setInterval(function () {
-        if (acquiring) {
-          pool.release(foo2)
-          clearInterval(t)
+    function spanRunner (done) {
+      log.debug('%s spanRunner %e', ao.lastEvent.Layer, ao.lastEvent)
+
+      // use taskId and layer name to verify that the correct context is maintained across calls
+      const span = ao.lastEvent.Layer
+      const taskId = ao.lastEvent.taskId
+      should.exist(taskId)
+      ao.requestStore.set('key', span)
+
+      pool.acquire(function (err, resource) {
+        if (err) {
+          done(err)
+          return
         }
-      }, 10)
-    })
+        log.debug('%s acquired(queue) %o for %e', span, resource, ao.lastEvent)
 
-    ao.requestStore.run(function () {
-      // Hack to look like there's a previous span
-      ao.requestStore.set('lastEvent', true)
+        should.exist(ao.lastEvent.Layer)
+        ao.lastEvent.Layer.should.equal(span)
+        taskId.should.be.equal(ao.lastEvent.taskId)
 
-      ao.requestStore.set('foo', 'bar')
-      pool.acquire(function (err) {
-        ao.requestStore.get('foo').should.equal('bar')
+        const t = setInterval(function () {
+          if (okToRelease) {
+            log.debug('releasing %o by %e', resource, ao.lastEvent)
+
+            should.exist(ao.lastEvent.Layer)
+            ao.lastEvent.Layer.should.equal(span)
+            taskId.should.be.equal(ao.lastEvent.taskId)
+
+            pool.release(resource)
+            clearInterval(t)
+          }
+        }, 10)
+      })
+
+      pool.acquire(function (err, resource) {
+        if (err) {
+          done(err)
+          return
+        }
+        log.debug('%s acquired %o for %e', span, resource, ao.lastEvent)
+
+        should(ao.requestStore.get('key')).equal(span)
+        should.exist(ao.lastEvent.Layer)
+        ao.lastEvent.Layer.should.equal(span)
+        taskId.should.be.equal(ao.lastEvent.taskId)
+
         done()
       })
-    })
+    }
 
-    acquiring = true
+    let count = 0
+    function bothDone (e) {
+      count += 1
+      if (count === 2 || e) {
+        done(e)
+      }
+    }
+
+    ao.startOrContinueTrace('', 'generic-pool-1', spanRunner, function (e) {log.debug('gp-1'); bothDone(e)})
+    ao.startOrContinueTrace('', 'generic-pool-2', spanRunner, function (e) {log.debug('gp-2'); bothDone(e)})
+
+    okToRelease = true
+  })
+
+  ifv3('should trace through generic-pool acquire for versions > 3', function (done) {
+    //
+    // v3 uses promises
+    //
+    let okToRelease = false
+
+    function spanRunner (done) {
+      log.debug('%s spanRunner %e', ao.lastEvent.Layer, ao.lastEvent)
+
+      // use taskId and layer name to verify that the correct context is maintained across calls
+      const span = ao.lastEvent.Layer
+      const taskId = ao.lastEvent.taskId
+      should.exist(taskId)
+      ao.requestStore.set('key', span)
+
+      // acquire an entry in the pool and release it after an event loop interval.
+      // this causes the the 'generic-pool-1' span to acquire both resources from the
+      // pool and forces 'generic-pool-2' to wait until a resource is freed before its
+      // promise is resolved.
+      pool.acquire().then(function (resource) {
+        log.debug('%s acquired(queue) %o for %e', span, resource, ao.lastEvent)
+
+        should.exist(ao.lastEvent.Layer)
+        ao.lastEvent.Layer.should.equal(span)
+        taskId.should.be.equal(ao.lastEvent.taskId)
+
+        const t = setInterval(function () {
+          if (okToRelease) {
+            log.debug('releasing %o by %e', resource, ao.lastEvent)
+
+            should.exist(ao.lastEvent.Layer)
+            ao.lastEvent.Layer.should.equal(span)
+            taskId.should.be.equal(ao.lastEvent.taskId)
+
+            pool.release(resource)
+            clearInterval(t)
+          }
+        }, 10)
+      }).catch(function (e) {
+        done(e)
+      })
+
+      async function acquire () {
+        return await pool.acquire()
+      }
+
+      //
+      // now get the second resource when it's available. it should be available
+      // immediately for the first trace but the second trace will have to wait until
+      // the interval timer pops.
+      //
+      //pool.acquire().then(function (resource) {
+      acquire().then(function (resource) {
+        log.debug('%s acquired %o for %e', span, resource, ao.lastEvent)
+
+        should(ao.requestStore.get('key')).equal(span)
+        should.exist(ao.lastEvent.Layer)
+        ao.lastEvent.Layer.should.equal(span)
+        taskId.should.be.equal(ao.lastEvent.taskId)
+
+        done()
+      }).catch(function (e) {
+        done(e)
+      })
+    }
+
+    let count = 0
+    function bothDone (e) {
+      count += 1
+      if (count === 2 || e) {
+        done(e)
+      }
+    }
+
+    ao.startOrContinueTrace('', 'generic-pool-1', spanRunner, function (e) {log.debug('gp-1'); bothDone(e)})
+    ao.startOrContinueTrace('', 'generic-pool-2', spanRunner, function (e) {log.debug('gp-2'); bothDone(e)})
+
+    okToRelease = true
   })
 })


### PR DESCRIPTION
Change patching for promise-based version 3 of generic-pool.
Create real test for generic pool that detects incorrect context through promises.
Add single async/await test for node version 8 and above.