### PR TITLE
Fix bindEmitter bug.

### DIFF
--- a/lib/probes/zlib.js
+++ b/lib/probes/zlib.js
@@ -49,7 +49,7 @@ function wrapClassEmit (proto) {
   }
   shimmer.wrap(proto, 'emit', fn => function (name, err) {
     try {
-      if (0 !== ~['close', 'error', 'end'].indexOf(name)) {
+      if (['close', 'error', 'end'].indexOf(name) >= 0) {
         const span = spans.get(this)
         if (span) {
           if (err) span.events.exit.error = err
@@ -62,7 +62,7 @@ function wrapClassEmit (proto) {
     } catch (e) {
       log.patching('failed to exit zlib.span on %s', name)
     }
-    ao.bindEmitter(fn)
+
     return fn.apply(this, arguments)
   })
 }


### PR DESCRIPTION
Remove incorrect call to bindEmitter().
Make indexOf test easier to read.