### PR TITLE
Add support for Koa 2's new Koa constructor

### DIFF
--- a/lib/probes/koa.js
+++ b/lib/probes/koa.js
@@ -5,11 +5,11 @@ const Span = require('../span')
 const ao = require('../')
 const conf = ao.probes.koa
 
-module.exports = koa => {
-  return () => {
-    const app = koa()
-    wrapApp(app)
-    return app
+module.exports = Koa => {
+  return function () {
+    const app = new Koa();
+    wrapApp(app);
+    return app;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gulp-istanbul": "^0.10.0",
     "gulp-mocha": "^3.0.1",
     "hapi": "^13.5.3",
-    "koa": "^1.6.0",
+    "koa": "^2.0.0",
     "koa-resource-router": "^0.4.0",
     "koa-route": "^2.4.2",
     "koa-router": "^5.4.2",


### PR DESCRIPTION
Need to return a classic function so it can be called with the
`new` keyword, just as Koa is.