### PR TITLE
v5.5.0 [AO-9660, AO-9715, AO-9739, AO-9864]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -273,12 +273,24 @@ const modeMap = {
 // Load dependencies
 //
 // TODO BAM consider not loading these at all if not enabled.
-if (env.AO_CLS) {
-  exports.contextProvider = 'continuation-local-storage'
+const semver = require('semver')
+const contextProviders = {
+  cls: 'continuation-local-storage',
+  clsHooked: 'cls-hooked'
+}
+// if set via environment variable use that context provider otherwise
+// base the decision on the node version.
+if (env.AO_CLS in contextProviders) {
+  exports.contextProvider = contextProviders[env.AO_CLS]
 } else {
-  exports.contextProvider = 'cls-hooked'
+  if (semver.lt(process.version, '8.0.0')) {
+    exports.contextProvider = contextProviders.cls
+  } else {
+    exports.contextProvider = contextProviders.clsHooked
+  }
 }
 log.debug('using context provider:', exports.contextProvider)
+
 const cls = require(exports.contextProvider)
 const WeakMap = require('es6-weak-map')
 const shimmer = require('shimmer')

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ const configDefaults = {
 }
 
 const debug = require('debug')
+exports.debug = debug
 
 // initialize log settings (internally 'appoptics:' is stripped)
 let logLevel = []

--- a/lib/index.js
+++ b/lib/index.js
@@ -273,9 +273,13 @@ const modeMap = {
 // Load dependencies
 //
 // TODO BAM consider not loading these at all if not enabled.
-const contextProvider = env.CLS ? 'continuation-local-storage' : 'cls-hooked'
-log.debug('using context by:', contextProvider)
-const cls = require(contextProvider)
+if (env.AO_CLS) {
+  exports.contextProvider = 'continuation-local-storage'
+} else {
+  exports.contextProvider = 'cls-hooked'
+}
+log.debug('using context provider:', exports.contextProvider)
+const cls = require(exports.contextProvider)
 const WeakMap = require('es6-weak-map')
 const shimmer = require('shimmer')
 const fs = require('fs')

--- a/lib/probes/express.js
+++ b/lib/probes/express.js
@@ -80,7 +80,9 @@ function routeProfiling (express, version) {
                 span.exit()
                 return next.apply(this, arguments)
               }
-            } else {
+            } else if (ao.probes.express.enabled) {
+              // the build function will never be called by instrumentHttp if
+              // the probe is disabled.
               log.error('express.profiledRoute failed to build span')
             }
           } catch (e) {

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const patchEmitter = require('event-unshift')
+const patchEmitter = require('event-pre-handler')
 const extend = require('util')._extend
 const shimmer = require('shimmer')
 const url = require('url')
@@ -100,10 +100,10 @@ function patchClient (module, protocol) {
         patchEmitter(ret)
 
         // Report socket errors
-        ret.unshift('error', error => span.error(error))
+        ret._preHandle('error', error => span.error(error))
 
         // Ensure our exit is pushed to the FRONT of the event list
-        ret.unshift('response', res => {
+        ret._preHandle('response', res => {
           // Continue from X-Trace header, if present
           const xtrace = res.headers['x-trace']
           // validate that task ID matches and op ID is not all zeros.
@@ -128,7 +128,7 @@ function patchClient (module, protocol) {
           patchEmitter(res)
 
           // Report socket errors
-          res.unshift('error', error => last.error(error))
+          res._preHandle('error', error => last.error(error))
 
           // Send exit event with response status
           span.exit({
@@ -316,8 +316,8 @@ function patchServer (module, protocol) {
 
   function wrapRequestResponse (span, req, res) {
     // Report socket errors
-    req.unshift('error', error => span.error(error))
-    res.unshift('error', error => span.error(error))
+    req._preHandle('error', error => span.error(error))
+    res._preHandle('error', error => span.error(error))
 
     // Ensure response is patched and add exit finalizer
     ao.patchResponse(res)

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -36,9 +36,12 @@ function patchClient (module, protocol) {
   // http.get function in node 8 does not call exports.request, so patching
   // request is not sufficient.
   const wrapper = fn => function (options, callback) {
-    // If not tracing, disabled or a call from https.request, just bind
+    // If no context just execute the fn with an unbound callback
+    // else execute the function with a bound callback.
     const last = Span.last
-    if (!last || !conf.enabled || isHttpsFromHttp(options)) {
+    if (!last) {
+      return fn(options, callback)
+    } else if (!conf.enabled || isHttpsFromHttp(options)) {
       return fn(options, ao.bind(callback))
     }
 

--- a/lib/probes/koa.js
+++ b/lib/probes/koa.js
@@ -6,8 +6,10 @@ const ao = require('../')
 const conf = ao.probes.koa
 
 module.exports = koa => {
-  return () => {
-    const app = koa()
+  // allow the caller to invoke this with or without "new" by
+  // not using an arrow function.
+  return function () {
+    const app = new koa()
     wrapApp(app)
     return app
   }

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -6,9 +6,11 @@ const semver = require('semver')
 const ao = require('..')
 const conf = ao.probes['mongodb-core']
 const log = ao.loggers
-var protocols
-var clientVersion = requirePatch.relativeRequire('mongodb-core/package').version
-var majorVersion = semver.major(clientVersion)
+
+const clientVersion = requirePatch.relativeRequire('mongodb-core/package').version
+const majorVersion = semver.major(clientVersion)
+
+let protocols
 
 module.exports = function (mongodb) {
   protocols = {
@@ -83,7 +85,7 @@ function protocolVersion (t) {
   if (t.wireProtocolHandler) {
     wph = t.wireProtocolHandler
   } else if (t.s && t.s.replicaSetState) {
-    let rs = t.s.replicaSetState
+    const rs = t.s.replicaSetState
     if (rs.primary && rs.primary.wireProtocolHandler) {
       wph = rs.primary.wireProtocolHandler
     } else {
@@ -109,7 +111,7 @@ function makeWrapper (obj, name, addData) {
     return
   }
   shimmer.wrap(obj, name, handler => function (ns, cmd, opts, cb) {
-    let version = protocolVersion(this)
+    const version = protocolVersion(this)
     //log.debug('wire protocol is %s', version, ns, cmd)
     // client version 1 cannot handle wire protocols greater
     // than 2.4.
@@ -212,7 +214,7 @@ function notUndef (...args) {
   }
 }
 
-function serverDetails ({ s = {} }) {
+function serverDetails ({s = {}}) {
   if (s.serverDetails) {
     return s.serverDetails
   } else if (s.replState && s.replState.primary) {

--- a/lib/probes/pg.js
+++ b/lib/probes/pg.js
@@ -9,6 +9,8 @@ const log = ao.loggers
 const Sanitizer = ao.addon.Sanitizer
 const conf = ao.probes.pg
 
+const debugging = false
+
 module.exports = function (postgres) {
   const {version} = requirePatch.relativeRequire('pg/package.json')
 
@@ -70,7 +72,7 @@ function patchClientQuery (client) {
     return
   }
   shimmer.wrap(client, 'query', query => function (...args) {
-    log.debug('pg - patchClientQuery args', args)
+    debugging && log.debug('pg - patchClientQuery args', args)
     const cb = getCallback(args)
 
     return ao.instrument(

--- a/lib/probes/redis.js
+++ b/lib/probes/redis.js
@@ -2,11 +2,17 @@
 
 const shimmer = require('shimmer')
 const ao = require('..')
+const log = ao.loggers
 const conf = ao.probes.redis
 
 module.exports = function (redis) {
   const proto = redis.RedisClient && redis.RedisClient.prototype
-  if (proto) patchSendCommand(proto)
+  if (proto) {
+    patchSendCommand(proto)
+    patchAddListener(proto)
+  } else {
+    log.patching('redis - cannot find RedisClient.prototype')
+  }
   return redis
 }
 
@@ -27,7 +33,10 @@ function lastFn (args) {
 }
 
 function patchSendCommand (client) {
-  if (typeof client.send_command !== 'function') return
+  if (typeof client.send_command !== 'function') {
+    log.patching('redis - client.send_command is not a function')
+    return
+  }
   let isMulti = false
   shimmer.wrap(client, 'send_command', fn => function (...args) {
     const [cmd, values] = args
@@ -63,7 +72,7 @@ function patchSendCommand (client) {
 
         if (lowCmd === 'eval') {
           data.Script = values[0].substr(0, 100)
-        } else {
+        } else if (lowCmd !== 'multi' && lowCmd !== 'exec') {
           data.KVKey = values[0]
         }
 
@@ -80,5 +89,20 @@ function patchSendCommand (client) {
       conf,
       cb
     )
+  })
+}
+
+function patchAddListener (client) {
+  if (typeof client.on !== 'function') {
+    log.patching('redis - client.on is not a function')
+    return
+  }
+  shimmer.wrap(client, 'on', fn => function (event, cb) {
+    if (event === 'subscribe' || event === 'message') {
+      return fn.call(this, event, ao.bind(cb))
+    }
+
+    // if it's not subscribe or message then just call the function
+    return fn.call(this, event, cb)
   })
 }

--- a/lib/probes/zlib.js
+++ b/lib/probes/zlib.js
@@ -8,6 +8,9 @@ const Span = ao.Span
 const conf = ao.probes.zlib
 const log = ao.loggers
 
+// turn this on for debugging checks and output.
+const debugging = false
+
 const nodeVersion = +process.version.slice(1, process.version.indexOf('.'))
 
 const classes = [
@@ -57,7 +60,7 @@ function wrapClassEmit (proto) {
           span.exit()
         }
       } else {
-        ao.clsCheck(`wrapClassEmit.${name}`)
+        debugging && ao.clsCheck(`wrapClassEmit.${name}`)
       }
     } catch (e) {
       log.patching('failed to exit zlib.span on %s', name)

--- a/lib/require-patch.js
+++ b/lib/require-patch.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const debug = require('debug')('appoptics:require-patch')
+const logPatched = require('debug')('appoptics:require-patch')
 const WeakMap = require('es6-weak-map')
 const Module = require('module')
 const glob = require('glob')
@@ -52,7 +52,7 @@ function patchedRequire (name) {
       require.cache[path].exports = module
     }
 
-    debug(`patched ${name}`)
+    logPatched(`patched ${name}`)
   }
 
   return module
@@ -73,6 +73,6 @@ probes.forEach(file => {
   if (m && m.length == 2) {
     const name = m[1]
     exports.register(name, path.join(__dirname, 'probes', name))
-    debug(`found ${name} probe`)
+    logPatched(`found ${name} probe`)
   }
 })

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "continuation-local-storage": "^3.2.1",
     "debug": "^3.1.0",
     "es6-weak-map": "^2.0.1",
-    "event-unshift": "^1.0.0",
+    "event-pre-handler": "^1.0.0",
     "glob": "^7.0.3",
     "hapi": "^16.6.3",
     "methods": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "5.4.3-debug",
+  "version": "5.4.3-rc1",
   "description": "Agent for AppOptics APM",
   "main": "dist/index.js",
   "bin": {
@@ -45,6 +45,7 @@
   "dependencies": {
     "array-flatten": "^2.1.0",
     "cls-hooked": "^4.2.2",
+    "continuation-local-storage": "^3.2.1",
     "debug": "^3.1.0",
     "es6-weak-map": "^2.0.1",
     "event-unshift": "^1.0.0",
@@ -71,7 +72,7 @@
     "director": "^1.2.8",
     "ejs": "^2.4.1",
     "express": "^4.16.3",
-    "generic-pool": "^2.5.4",
+    "generic-pool": "^3.4.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-istanbul": "^0.10.0",
@@ -105,6 +106,6 @@
     "vision": "^4.1.0"
   },
   "optionalDependencies": {
-    "appoptics-bindings": "5.3.0"
+    "appoptics-bindings": "5.4.1"
   }
 }

--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -4,6 +4,7 @@ const should = require('should') // eslint-disable-line no-unused-vars
 const debug = require('debug')
 const ao = require('..')
 const Span = ao.Span
+const helper = require('./helper')
 
 let ifaob    // execute or skip test depending on whether bindings are loaded.
 let ALWAYS
@@ -50,8 +51,16 @@ describe('basics', function () {
   })
 
   ifaob('should handle invalid sample rates correctly', function () {
+
+    const logChecks = [
+      {level: 'warn', message: 'Invalid sample rate: %s, not changed', values: [NaN]},
+      {level: 'warn', message: 'Sample rate (%s) out of range, using %s', values: [2000000, 1000000]},
+      {level: 'warn', message: 'Sample rate (%s) out of range, using %s', values: [-10, 0]},
+    ]
+    helper.checkLogMessages(debug, logChecks)
+
     ao.sampleRate = NaN
-    ao.sampleRate.should.equal(100, 'when trying to set to NaN')
+    ao.sampleRate.should.equal(100, '(unchanged) when trying to set to NaN')
     ao.sampleRate = 2000000
     ao.sampleRate.should.equal(1000000, 'when trying to set to 2000000')
     ao.sampleRate = -10
@@ -168,6 +177,10 @@ describe('basics', function () {
   })
 
   it('should not re-execute appoptics even if deleted from the require.cache', function () {
+    const logChecks = [
+      {level: 'warn', message: 'appoptics-apm is being executed more than once'},
+    ]
+    helper.checkLogMessages(debug, logChecks)
     const key = require.resolve('..')
     delete require.cache[key]
     const ao2 = require('..')

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -242,6 +242,11 @@ describe('error', function () {
   it('should not send error events when not in a span', function () {
     const span = new Span('test', null, {})
 
+    const logChecks = [
+      {level: 'error', message: 'test span error call could not find last event'},
+    ]
+    helper.checkLogMessages(ao.debug, logChecks)
+
     const send = Event.prototype.send
     Event.prototype.send = function () {
       Event.prototype.send = send

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -88,13 +88,16 @@ describe('event', function () {
     event.should.have.property('Foo', 'bar')
   })
 
-  it('should support data in send function', function () {
+  it('should support data in send function', function (done) {
     const event = new Event('test', 'entry')
-    let called = false
-    event.set = function () {
-      called = true
-    }
-    event.sendReport({Foo: 'bar'})
-    called.should.equal(true)
+
+    emitter.once('message', function (msg) {
+      msg.should.have.property('Foo')
+      msg.Foo.should.equal('fubar')
+      done()
+    })
+    ao.requestStore.run(function () {
+      event.sendReport({Foo: 'fubar'})
+    })
   })
 })

--- a/test/helper.js
+++ b/test/helper.js
@@ -409,7 +409,7 @@ function checkLogMessages (debug, checks) {
     // catch errors so this logger isn't left in place after an error is found
     try {
       assert('appoptics:' + check.level === level, 'message level should be ' + check.level)
-      assert(text.indexOf(check.message) === 0, 'found: ' + text + ' expected ' + check.message)
+      assert(text.indexOf(check.message) === 0, 'found: "' + text + '" expected "' + check.message + '"')
       if (check.values) {
         for (let i = 0; i < check.values.length; i++) {
           if (isNaN(check.values[i])) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -5,7 +5,6 @@ const realPort = ao.port
 ao.skipSample = true
 
 const Emitter = require('events').EventEmitter
-const debug = require('debug')('appoptics:test:helper')
 const extend = require('util')._extend
 const bson = require('bson')
 const dgram = require('dgram')
@@ -76,7 +75,7 @@ if (process.env.APPOPTICS_REPORTER_UDP) {
   if (parts.length == 2) udpPort = parts[1]
 }
 
-debug('helper found real port = ' + realPort)
+log.test.info('helper found real port = ' + realPort)
 
 function udpSend (msg, port, host) {
   const client = dgram.createSocket('udp4')
@@ -118,7 +117,7 @@ exports.appoptics = function (done) {
     const port = server.address().port
     ao.port = port.toString()
     emitter.port = port
-    debug('mock appoptics (port ' + port + ') listening')
+    log.test.info('mock appoptics (port ' + port + ') listening')
     process.nextTick(done)
   })
 
@@ -132,7 +131,7 @@ exports.appoptics = function (done) {
   emitter.close = function (done) {
     const port = server.address().port
     server.on('close', function () {
-      debug('mock appoptics (port ' + port + ') closed')
+      log.test.info('mock appoptics (port ' + port + ') closed')
       process.nextTick(done)
     })
     server.close()
@@ -145,7 +144,7 @@ exports.doChecks = function (emitter, checks, done) {
   const addr = emitter.server.address()
   emitter.removeAllListeners('message')
 
-  debug('doChecks invoked - server address ' + addr.address + ':' + addr.port)
+  log.test.info('doChecks invoked - server address ' + addr.address + ':' + addr.port)
 
   function onMessage (msg) {
     if (!emitter.__aoActive) {
@@ -165,7 +164,7 @@ exports.doChecks = function (emitter, checks, done) {
     msg.should.have.property('X-Trace').and.match(/^2B[0-9A-F]{58}$/)
     if (msg.Edge) msg.Edge.should.match(/^[0-9A-F]{16}$/)
 
-    debug(checks.length + ' checks left')
+    log.test.info(checks.length + ' checks left')
     if (!checks.length) {
       // NOTE: This is only needed because some
       // tests have less checks than messages
@@ -181,12 +180,12 @@ const check = {
   'http-entry': function (msg) {
     msg.should.have.property('Layer', 'nodejs')
     msg.should.have.property('Label', 'entry')
-    debug('entry is valid')
+    log.test.info('entry is valid')
   },
   'http-exit': function (msg) {
     msg.should.have.property('Layer', 'nodejs')
     msg.should.have.property('Label', 'exit')
-    debug('exit is valid')
+    log.test.info('exit is valid')
   }
 }
 
@@ -215,9 +214,9 @@ exports.test = function (emitter, test, validations, done) {
 
 exports.httpTest = function (emitter, test, validations, done) {
   const server = http.createServer(function (req, res) {
-    debug('test started')
+    log.test.info('test started')
     test(function (err, data) {
-      debug('test ended')
+      log.test.info('test ended')
       if (err) return done(err)
       res.end(data)
     })
@@ -231,7 +230,7 @@ exports.httpTest = function (emitter, test, validations, done) {
 
   server.listen(function () {
     const port = server.address().port
-    debug('test server listening on port ' + port)
+    log.test.info('test server listening on port ' + port)
     http.get('http://localhost:' + port, function (res) {
       res.resume()
     }).on('error', done)
@@ -240,9 +239,9 @@ exports.httpTest = function (emitter, test, validations, done) {
 
 exports.httpsTest = function (emitter, options, test, validations, done) {
   const server = https.createServer(options, function (req, res) {
-    debug('test started')
+    log.test.info('test started')
     test(function (err, data) {
-      debug('test ended')
+      log.test.info('test ended')
       if (err) return done(err)
       res.end(data)
     })
@@ -256,7 +255,7 @@ exports.httpsTest = function (emitter, options, test, validations, done) {
 
   server.listen(function () {
     const port = server.address().port
-    debug('test server listening on port ' + port)
+    log.test.info('test server listening on port ' + port)
     https.get('https://localhost:' + port, function (res) {
       res.resume()
     }).on('error', done)
@@ -397,7 +396,6 @@ function checkData (data, fn) {
   }
 }
 
-//*
 exports.checkLogMessages = checkLogMessages
 function checkLogMessages (debug, checks) {
   const defaultLogger = debug.log
@@ -441,4 +439,3 @@ function getLevelAndText (text) {
   }
   return ['', '']
 }
-// */

--- a/test/probes/crypto.test.js
+++ b/test/probes/crypto.test.js
@@ -82,7 +82,7 @@ describe('probes.crypto', function () {
     it('should support pbkdf2Sync', function (done) {
       helper.test(emitter, function (done) {
         try {
-          crypto.pbkdf2Sync('secret', 'salt', 4096, 512)
+          crypto.pbkdf2Sync('secret', 'salt', 4096, 512, 'sha1')
         } catch (e) {}
         done()
       }, [

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -180,10 +180,11 @@ describe('probes.fs', function () {
         if (mode === 'sync') {
           return [span('open'), span('ftruncate'), span('close')]
         } else {
-          // if cls-hooked
-          return [span('open'), span('close')]
-          // if continuation-local-storage
-          // return [span('open')]
+          const expected = [span('open')]
+          if (ao.contextProvider === 'cls-hooked') {
+            expected.push(span('close'))
+          }
+          return expected
         }
       }
     },

--- a/test/probes/koa.js
+++ b/test/probes/koa.js
@@ -1,21 +1,23 @@
-var Resource = require('koa-resource-router')
-var router = require('koa-router')
-var _ = require('koa-route')
-var koa = require('koa')
+'use strict'
 
-var helper = require('../helper')
-var request = require('request')
+const Resource = require('koa-resource-router')
+const router = require('koa-router')
+const _ = require('koa-route')
+const koa = require('koa')
 
-var ao = require('../..')
+const helper = require('../helper')
+const request = require('request')
 
-var views = require('co-views')
+const ao = require('../..')
 
-var render = views('test/probes', {
-  map: { ejs: 'ejs' },
+const views = require('co-views')
+
+const render = views('test/probes', {
+  map: {ejs: 'ejs'},
   ext: 'ejs'
 })
 
-var check = {
+const check = {
   'http-entry': function (msg) {
     msg.should.have.property('Layer', 'nodejs')
     msg.should.have.property('Label', 'entry')
@@ -43,7 +45,7 @@ var check = {
 }
 
 function controllerValidations (controller, action) {
-  var profileName = controller + ' ' + action
+  const profileName = controller + ' ' + action
   return [
     function (msg) {
       check['http-entry'](msg)
@@ -73,7 +75,7 @@ function controllerValidations (controller, action) {
 }
 
 exports.basic = function (emitter, done) {
-  var app = koa()
+  const app = koa()
 
   app.use(function* () {
     this.body = 'done'
@@ -88,15 +90,15 @@ exports.basic = function (emitter, done) {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port + '/hello/world')
   })
 }
 
 exports.disabled = function (emitter, done) {
   ao.probes.koa.enabled = false
-  var app = koa()
+  const app = koa()
 
   app.use(function* () {
     this.body = 'done'
@@ -110,33 +112,33 @@ exports.disabled = function (emitter, done) {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port)
   })
 }
 
 exports.route = function (emitter, done) {
-  var app = koa()
+  const app = koa()
 
   app.use(_.get('/hello/:name', function* hello () {
     this.body = 'done'
   }))
 
-  var validations = controllerValidations('get /hello/:name', 'hello')
+  const validations = controllerValidations('get /hello/:name', 'hello')
   helper.doChecks(emitter, validations, function () {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port + '/hello/world')
   })
 }
 
 exports.route_disabled = function (emitter, done) {
   ao.probes['koa-route'].enabled = false
-  var app = koa()
+  const app = koa()
 
   app.use(_.get('/hello/:name', function* hello () {
     this.body = 'done'
@@ -152,21 +154,21 @@ exports.route_disabled = function (emitter, done) {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port + '/hello/world')
   })
 }
 
 exports.router = function (emitter, done) {
-  var app = koa()
+  const app = koa()
 
   function* hello () {
     this.body = 'done'
   }
 
   // Mount router
-  var r = router(app)
+  const r = router(app)
   if (typeof r.routes === 'function') {
     app.use(r.routes())
     r.get('/hello/:name', hello)
@@ -175,27 +177,27 @@ exports.router = function (emitter, done) {
     app.get('/hello/:name', hello)
   }
 
-  var validations = controllerValidations('get /hello/:name', 'hello')
+  const validations = controllerValidations('get /hello/:name', 'hello')
   helper.doChecks(emitter, validations, function () {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port + '/hello/world')
   })
 }
 
 exports.router_disabled = function (emitter, done) {
   ao.probes['koa-router'].enabled = false
-  var app = koa()
+  const app = koa()
 
   function* hello () {
     this.body = 'done'
   }
 
   // Mount router
-  var r = router(app)
+  const r = router(app)
   if (typeof r.routes === 'function') {
     app.use(r.routes())
     r.get('/hello/:name', hello)
@@ -214,16 +216,16 @@ exports.router_disabled = function (emitter, done) {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port + '/hello/world')
   })
 }
 
 exports.resourceRouter = function (emitter, done) {
-  var app = koa()
+  const app = koa()
 
-  var res = new Resource('hello', {
+  const res = new Resource('hello', {
     index: function* index () {
       this.body = 'done'
     }
@@ -231,22 +233,22 @@ exports.resourceRouter = function (emitter, done) {
 
   app.use(res.middleware())
 
-  var validations = controllerValidations('hello', 'index')
+  const validations = controllerValidations('hello', 'index')
   helper.doChecks(emitter, validations, function () {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port + '/hello')
   })
 }
 
 exports.resourceRouter_disabled = function (emitter, done) {
   ao.probes['koa-resource-router'].enabled = false
-  var app = koa()
+  const app = koa()
 
-  var res = new Resource('hello', {
+  const res = new Resource('hello', {
     index: function* index () {
       this.body = 'done'
     }
@@ -264,14 +266,14 @@ exports.resourceRouter_disabled = function (emitter, done) {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port + '/hello')
   })
 }
 
 exports.render = function (emitter, done) {
-  var app = koa()
+  const app = koa()
 
   app.use(function* () {
     this.body = yield render('hello', {
@@ -279,7 +281,7 @@ exports.render = function (emitter, done) {
     })
   })
 
-  var validations = [
+  const validations = [
     function (msg) {
       check['http-entry'](msg)
     },
@@ -306,15 +308,15 @@ exports.render = function (emitter, done) {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port)
   })
 }
 
 exports.render_disabled = function (emitter, done) {
   ao.probes['co-render'].enabled = false
-  var app = koa()
+  const app = koa()
 
   app.use(function* () {
     this.body = yield render('hello', {
@@ -322,7 +324,7 @@ exports.render_disabled = function (emitter, done) {
     })
   })
 
-  var validations = [
+  const validations = [
     function (msg) {
       check['http-entry'](msg)
     },
@@ -342,63 +344,8 @@ exports.render_disabled = function (emitter, done) {
     server.close(done)
   })
 
-  var server = app.listen(function () {
-    var port = server.address().port
+  const server = app.listen(function () {
+    const port = server.address().port
     request('http://localhost:' + port)
   })
 }
-
-/* TODO BAM remove
-exports.rum = function (emitter, done) {
-  ao.rumId = 'foo'
-  var app = koa()
-
-  var exit
-
-  app.use(function* () {
-    exit = this.res._ao_http_span.events.exit
-    this.body = yield render('rum')
-  })
-
-  var validations = [
-    function (msg) {
-      check['http-entry'](msg)
-    },
-    function (msg) {
-      check['koa-entry'](msg)
-    },
-    function (msg) {
-      check['render-entry'](msg)
-      msg.should.have.property('TemplateFile')
-      msg.should.have.property('TemplateLanguage', 'ejs')
-    },
-    function (msg) {
-      check['render-exit'](msg)
-    },
-    function (msg) {
-      check['koa-exit'](msg)
-    },
-    function (msg) {
-      check['http-exit'](msg)
-    }
-  ]
-
-  // Delay completion until both test paths end
-  var complete = helper.after(2, function () {
-    server.close(done)
-    delete ao.rumId
-  })
-
-  helper.doChecks(emitter, validations, complete)
-
-  var server = app.listen(function () {
-    var port = server.address().port
-    request('http://localhost:' + port, function (a, b, body) {
-      // Verify that the rum scripts are included in the body
-      body.should.containEql(rum.header(ao.rumId, exit.toString()))
-      body.should.containEql(rum.footer(ao.rumId, exit.toString()))
-      complete()
-    })
-  })
-}
-// */

--- a/test/probes/koa.test.js
+++ b/test/probes/koa.test.js
@@ -1,10 +1,13 @@
-var helper = require('../helper')
-var ao = helper.ao
-var addon = ao.addon
+'use strict'
 
-var pkg = require('koa/package')
+const helper = require('../helper')
+const ao = helper.ao
+const assert = require('assert')
 
-var canGenerator = false
+const koa = require('koa')
+const pkg = require('koa/package')
+
+let canGenerator = false
 try {
   eval('(function* () {})()')
   canGenerator = true
@@ -14,8 +17,8 @@ try {
 function noop () {}
 
 describe('probes/koa ' + pkg.version, function () {
-  var emitter
-  var tests = canGenerator && require('./koa')
+  let emitter
+  const tests = canGenerator && require('./koa')
 
   //
   // Intercept appoptics messages for analysis
@@ -39,17 +42,38 @@ describe('probes/koa ' + pkg.version, function () {
       ao.instrument('fake', function () { })
       done()
     }, [
-        function (msg) {
-          msg.should.have.property('Label').oneOf('entry', 'exit'),
-            msg.should.have.property('Layer', 'fake')
-        }
-      ], done)
+      function (msg) {
+        msg.should.have.property('Label').oneOf('entry', 'exit'),
+        msg.should.have.property('Layer', 'fake')
+      }
+    ], done)
+  })
+
+  it('should allow creating the app with or without "new"', function () {
+    let app = undefined
+    let error = false
+    try {
+      app = new koa()
+    } catch (e) {
+      error = e
+    }
+    assert (app !== undefined, 'a koa app should be returned')
+    assert (error === false, 'should allow "new koa()"')
+
+    app = undefined
+    try {
+      app = koa()
+    } catch (e) {
+      error = e
+    }
+    assert (app !== undefined, 'a koa app should be returned')
+    assert (error === false, 'should allow "koa()"')
   })
 
   //
   // Tests
   //
-  if ( ! canGenerator) {
+  if (!canGenerator) {
     it.skip('should support koa outer span', noop)
     it.skip('should skip when disabled', noop)
   } else {

--- a/test/probes/redis.test.js
+++ b/test/probes/redis.test.js
@@ -1,27 +1,24 @@
-var helper = require('../helper')
-var Address = helper.Address
-var ao = helper.ao
-var noop = helper.noop
-var addon = ao.addon
+'use strict'
 
-var should = require('should')
+const helper = require('../helper')
+const Address = helper.Address
+const ao = helper.ao
+const noop = helper.noop
+const addon = ao.addon
 
-var request = require('request')
-var http = require('http')
+const redis = require('redis')
+const pkg = require('redis/package')
 
-var redis = require('redis')
-var pkg = require('redis/package')
-
-var parts = (process.env.AO_TEST_REDIS_3_0 || 'redis:6379').split(':')
-var host = parts.shift()
-var port = parts.shift()
-var addr = new Address(host, port)
-var client = redis.createClient(addr.port, addr.host, {})
+const parts = (process.env.AO_TEST_REDIS_3_0 || 'redis:6379').split(':')
+const host = parts.shift()
+const port = parts.shift()
+const addr = new Address(host, port)
+const client = redis.createClient(addr.port, addr.host, {})
 
 describe('probes.redis ' + pkg.version, function () {
-  var ctx = { redis: client }
-  var emitter
-  var realSampleTrace
+  const ctx = {redis: client}
+  let emitter
+  let realSampleTrace
 
   //
   // Intercept appoptics messages for analysis
@@ -32,7 +29,7 @@ describe('probes.redis ' + pkg.version, function () {
     ao.sampleMode = 'always'
     realSampleTrace = ao.addon.Context.sampleTrace
     ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
+      return {sample: true, source: 6, rate: ao.sampleRate}
     }
   })
   after(function (done) {
@@ -40,7 +37,7 @@ describe('probes.redis ' + pkg.version, function () {
     emitter.close(done)
   })
 
-  var check = {
+  const check = {
     'redis-entry': function (msg) {
       msg.should.have.property('Layer', 'redis')
       msg.should.have.property('Label', 'entry')
@@ -57,11 +54,11 @@ describe('probes.redis ' + pkg.version, function () {
       ao.instrument('fake', noop)
       done()
     }, [
-        function (msg) {
-          msg.should.have.property('Label').oneOf('entry', 'exit'),
-            msg.should.have.property('Layer', 'fake')
-        }
-      ], done)
+      function (msg) {
+        msg.should.have.property('Label').oneOf('entry', 'exit'),
+        msg.should.have.property('Layer', 'fake')
+      }
+    ], done)
   })
 
   //
@@ -85,7 +82,7 @@ describe('probes.redis ' + pkg.version, function () {
   // Test a simple res.end() call in an http server
   //
   it('should support multi', function (done) {
-    var steps = [
+    const steps = [
       function (msg) {
         check['redis-entry'](msg)
         msg.should.have.property('KVOp', 'multi')

--- a/test/probes/redis/pubsub.js
+++ b/test/probes/redis/pubsub.js
@@ -1,12 +1,14 @@
-var redis = require('redis')
+'use strict'
+
+const redis = require('redis')
 
 function hostAndPort (ctx) {
-  var possibilities = [
+  const possibilities = [
     ctx.redis,
     ctx.redis.options,
     ctx.redis.connectionOption,
   ]
-  var o
+  let o
   while (o = possibilities.shift()) {
     if (o.host && o.port) {
       return {
@@ -18,8 +20,8 @@ function hostAndPort (ctx) {
 }
 
 exports.run = function (ctx, done) {
-  var addr = hostAndPort(ctx)
-  var producer = redis.createClient(Number(addr.port), addr.host, {})
+  const addr = hostAndPort(ctx)
+  const producer = redis.createClient(Number(addr.port), addr.host, {})
 
   ctx.redis.on('subscribe', function () {
     producer.publish('foo', 'bar')

--- a/test/span.test.js
+++ b/test/span.test.js
@@ -2,6 +2,7 @@
 
 const helper = require('./helper')
 const should = require('should')
+const debug = require('debug')
 const ao = require('..')
 const addon = ao.addon
 const Span = ao.Span
@@ -335,6 +336,15 @@ describe('span', function () {
 
     helper.doChecks(emitter, checks, done)
 
+    const logChecks = [
+      {level: 'error', message: 'Invalid type for KV'},
+      {level: 'error', message: 'Invalid type for KV'},
+      {level: 'error', message: 'Invalid type for KV'},
+      {level: 'error', message: 'Invalid type for KV'},
+    ]
+
+    helper.checkLogMessages(debug, logChecks)
+
     span.run(function () {
       span.info(data)
     })
@@ -349,6 +359,11 @@ describe('span', function () {
       Event.prototype.send = send
       throw new Error('should not send when not in a span')
     }
+
+    const logChecks = [
+      {level: 'error', message: 'test span info call could not find last event'}
+    ]
+    helper.checkLogMessages(debug, logChecks)
 
     span.info(data)
     Event.prototype.send = send


### PR DESCRIPTION
- Fixes possible file corruption by http instrumentation [AO-9715, AO-9739]
- Add support for koa@2 [AO-9864]
- Use cls-hooked for node versions 8+
- Maintain context for redis pub/sub.
- Logging improvements.
- Testing improvements.
- Use appoptics-bindings@5.4.1 for host metadata changes