### PR TITLE
Custom test cleanup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -983,7 +983,7 @@ if (!enabled) {
   function runInstrument (last, make, run, options, callback) {
     // Verify that a builder function or span name is given
     if (!~['function', 'string'].indexOf(typeof make)) {
-      log.debug('ao.runInstrument found no span name or builder')
+      log.warn('ao.runInstrument found no span name or builder')
       return run(callback)
     }
 

--- a/lib/span.js
+++ b/lib/span.js
@@ -100,7 +100,7 @@ Object.defineProperty(Span, 'last', {
     try {
       last = ao.requestStore.get('lastSpan')
     } catch (e) {
-      log.error('Can not access cls.lastSpan. Context may be lost.')
+      log.error('Can not get cls.lastSpan. Context may be lost.')
     }
     return last
   },
@@ -108,7 +108,7 @@ Object.defineProperty(Span, 'last', {
     try {
       ao.requestStore.set('lastSpan', value)
     } catch (e) {
-      log.error('Can not access cls.lastSpan. Context may be lost.')
+      log.error('Can not set cls.lastSpan. Context may be lost.')
     }
   }
 })

--- a/test/helper.js
+++ b/test/helper.js
@@ -12,6 +12,7 @@ const https = require('https')
 const http = require('http')
 const path = require('path')
 const assert = require('assert')
+const should = require('should')
 
 Error.stackTraceLimit = 25
 
@@ -412,8 +413,8 @@ function checkLogMessages (debug, checks) {
       assert(text.indexOf(check.message) === 0, 'found: "' + text + '" expected "' + check.message + '"')
       if (check.values) {
         for (let i = 0; i < check.values.length; i++) {
-          if (isNaN(check.values[i])) {
-            assert(isNaN(arguments[i + 1])), 'argument ' + i + ' should be NaN'
+          if (Number.isNaN(check.values[i])) {
+            assert(Number.isNaN(arguments[i + 1])), 'argument ' + i + ' should be NaN'
           } else {
             assert(check.values[i] === arguments[i + 1], 'argument ' + i + ' should be ', check.values[i])
           }


### PR DESCRIPTION
- Change "no span name or builder" from debug to warn.
- Distinguish between set and get errors for last span.
- custom.test.js now tests for expected logging.