### PR TITLE
Cleanse service name [AO-10253, AO-10347]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,9 +13,9 @@ if (global[aoOnce]) {
   module.exports.loggers.warn('appoptics-apm is being executed more than once')
 } else {
 
-// disable eslint's indent it doesn't complain because everything in the else
-// (all of the file when it's required the first time) isn't indented.
 /* eslint-disable indent */
+// disable eslint's indent so it doesn't complain because everything in the else
+// (all of the file when it's required the first time) isn't indented.
 
 /**
  * @class ao
@@ -236,15 +236,36 @@ if (!config.ignoreConflicts) {
 // if the service key is defined in the environment then use that. if
 // not see if it is defined in the config file.
 //
-let serviceKey = env.APPOPTICS_SERVICE_KEY || config.serviceKey
-exports.serviceKey = serviceKey
+const environmentKey = process.env.APPOPTICS_SERVICE_KEY
+let serviceKey = environmentKey
+// make sure service key is not undefined and use config value if present
+if (!serviceKey) {
+  serviceKey =  ''
+  if (config.serviceKey) {
+    log.debug('using config.serviceKey')
+    serviceKey = config.serviceKey
+  }
+}
+
+// lower case, spaces to hyphens, allow only [a-z0-9.:_-]
+const cleansedKey = serviceKey.toLowerCase()
+  .replace(/ /g, '-')
+  .replace(/[^a-z0-9.:_-]/g, '')
+// save the key that is being used
+exports.serviceKey = cleansedKey
+
+if (cleansedKey && cleansedKey !== serviceKey) {
+  log.warn('Invalid service key "%s", using "%s"', serviceKey, cleansedKey)
+} else {
+  log.debug('Setting ao.serviceKey to %s', cleansedKey)
+}
 
 //
 // Try to load bindings if not disabled. Handle failure or disabled
 // gracefully.
 //
 let bindings
-let enabled = serviceKey && config.enabled
+let enabled = cleansedKey && config.enabled
 
 if (config.traceMode !== undefined && !(config.traceMode in modeMap)) {
   enabled = false
@@ -310,7 +331,7 @@ function clsCheck (msg) {
 
 exports.clsCheck = clsCheck
 
-if (!serviceKey) {
+if (!cleansedKey) {
   log.error('No serviceKey present, disabling AppOptics')
 }
 
@@ -355,6 +376,7 @@ let sampleMode, sampleRate, sampleSource
  * @name ao.serviceKey
  * @property {string} - the service key
  */
+/*
 Object.defineProperty(exports, 'serviceKey', {
   get () {return serviceKey},
   // this sets the service key as well but isn't useful
@@ -363,6 +385,7 @@ Object.defineProperty(exports, 'serviceKey', {
     serviceKey = value
   }
 })
+// */
 
 /**
  * Check whether the appoptics agent is ready to sample. It will wait up to
@@ -717,7 +740,13 @@ if (!enabled) {
   if (exports.cfg.hostnameAlias) {
     options.hostnameAlias = exports.cfg.hostnameAlias
   }
-  bindings.oboeInit(serviceKey, options)
+
+  // delete the environment variable, init oboe, and restore it. this is
+  // done because oboe will prefer the environment variable to anything
+  // specified here.
+  delete env.APPOPTICS_SERVICE_KEY
+  bindings.oboeInit(cleansedKey, options)
+  env.APPOPTICS_SERVICE_KEY = environmentKey
 
   /**
    * @typedef {object} SampleInfo

--- a/lib/index.js
+++ b/lib/index.js
@@ -251,11 +251,26 @@ if (!serviceKey) {
 const cleansedKey = serviceKey.toLowerCase()
   .replace(/ /g, '-')
   .replace(/[^a-z0-9.:_-]/g, '')
+
 // save the key that is being used
+/**
+ * @name ao.serviceKey
+ * @property {string} - the service key
+ */
 exports.serviceKey = cleansedKey
 
-if (cleansedKey && cleansedKey !== serviceKey) {
-  log.warn('Invalid service key "%s", using "%s"', serviceKey, cleansedKey)
+// now go through a sequence of checks and tests that can result in
+// appoptics being disabled. accumulate the errors so a single message
+// with the enabled status can be output at the end of the checks.
+let enabled = config.enabled
+const errors = []
+
+if (!cleansedKey) {
+  enabled = false
+  log.error('No valid serviceKey')
+  errors.push('no valid service key')
+} else if (cleansedKey !== serviceKey) {
+  log.warn('Invalid service key specified: "%s", using: "%s"', serviceKey, cleansedKey)
 } else {
   log.debug('Setting ao.serviceKey to %s', cleansedKey)
 }
@@ -265,19 +280,20 @@ if (cleansedKey && cleansedKey !== serviceKey) {
 // gracefully.
 //
 let bindings
-let enabled = cleansedKey && config.enabled
 
 if (config.traceMode !== undefined && !(config.traceMode in modeMap)) {
   enabled = false
-  log.error('disabling AppOptics-APM: invalid traceMode: %s', config.traceMode)
+  log.error('invalid traceMode: %s', config.traceMode)
+  errors.push('invalid traceMode')
 }
 
 if (enabled) {
   try {
     bindings = require('appoptics-bindings')
   } catch (e) {
-    log.error('Can\'t load bindings, disabling AppOptics\n\n', e.stack)
     enabled = false
+    log.error('Can\'t load bindings', e.stack)
+    errors.push('bindings not loaded')
   }
 }
 
@@ -313,7 +329,15 @@ if (env.AO_CLS in contextProviders) {
 }
 log.debug('using context provider:', exports.contextProvider)
 
-const cls = require(exports.contextProvider)
+let cls
+try {
+  cls = require(exports.contextProvider)
+} catch (e) {
+  enabled = false
+  log.error('Can\'t load %s', exports.contextProvider, e.stack)
+  errors.push('context provider not loaded')
+}
+
 const WeakMap = require('es6-weak-map')
 const shimmer = require('ximmer')
 const fs = require('fs')
@@ -331,8 +355,8 @@ function clsCheck (msg) {
 
 exports.clsCheck = clsCheck
 
-if (!cleansedKey) {
-  log.error('No serviceKey present, disabling AppOptics')
+if (!enabled) {
+  log.error('AppopticsAPM disabled due to: %s', errors.join(', '))
 }
 
 
@@ -370,22 +394,6 @@ try {
 // Abstract settings with setters and getters
 //
 let sampleMode, sampleRate, sampleSource
-
-
-/**
- * @name ao.serviceKey
- * @property {string} - the service key
- */
-/*
-Object.defineProperty(exports, 'serviceKey', {
-  get () {return serviceKey},
-  // this sets the service key as well but isn't useful
-  // to the end user as it can't be changed once initialized.
-  set (value) {
-    serviceKey = value
-  }
-})
-// */
 
 /**
  * Check whether the appoptics agent is ready to sample. It will wait up to
@@ -746,7 +754,9 @@ if (!enabled) {
   // specified here.
   delete env.APPOPTICS_SERVICE_KEY
   bindings.oboeInit(cleansedKey, options)
-  env.APPOPTICS_SERVICE_KEY = environmentKey
+  if (environmentKey || environmentKey === '') {
+    env.APPOPTICS_SERVICE_KEY = environmentKey
+  }
 
   /**
    * @typedef {object} SampleInfo

--- a/lib/index.js
+++ b/lib/index.js
@@ -232,6 +232,21 @@ if (!config.ignoreConflicts) {
   }
 }
 
+function validKey (key) {
+  return !!key.match(/^[A-Fa-f0-9]{64}:[a-z0-9.:_-]{1,255}$/)
+}
+
+// mask the service key so it's not revealed when logging. do not presume a
+// a valid service key, i.e., 64-hex-digits:1-to-255-valid-name
+function mask (key) {
+  const parts = key.split(':')
+  let keyOnly = parts.shift()
+  if (keyOnly.length < 8) {
+    keyOnly += '.'.repeat(8 - key.length)
+  }
+  return keyOnly.slice(0, 4) + '...' + keyOnly.slice(-4) + ':' + parts.join(':')
+}
+
 //
 // if the service key is defined in the environment then use that. if
 // not see if it is defined in the config file.
@@ -246,6 +261,10 @@ if (!serviceKey) {
     serviceKey = config.serviceKey
   }
 }
+
+// remember if the original key is valid so if the only modification
+// is lowercasing it we don't log a warning.
+const originalKeyValid = validKey(serviceKey)
 
 // lower case, spaces to hyphens, allow only [a-z0-9.:_-]
 const cleansedKey = serviceKey.toLowerCase()
@@ -265,14 +284,14 @@ exports.serviceKey = cleansedKey
 let enabled = config.enabled
 const errors = []
 
-if (!cleansedKey) {
+if (!validKey(cleansedKey)) {
   enabled = false
   log.error('No valid serviceKey')
   errors.push('no valid service key')
-} else if (cleansedKey !== serviceKey) {
-  log.warn('Invalid service key specified: "%s", using: "%s"', serviceKey, cleansedKey)
+} else if (!originalKeyValid) {
+  log.warn('Invalid service key specified: "%s", using: "%s"', mask(serviceKey), mask(cleansedKey))
 } else {
-  log.debug('Setting ao.serviceKey to %s', cleansedKey)
+  log.debug('Setting ao.serviceKey to %s', mask(cleansedKey))
 }
 
 //

--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -26,7 +26,14 @@ function fdSpan (method, fd) {
     }
 
     if (fdOf(last, 'entry') === fd || fdOf(last, 'exit') === fd) {
-      data.FilePath = last.events.entry.FilePath
+      // if there is a file path then store it. there is at least one place
+      // in node/lib/internal/fs.js for SyncWriteStream.prototype._write where
+      // fs.writeSync is called. SyncWriteStream is a "temporary hack for
+      // process.stdout and process.stderr when piped to files", so the need
+      // for this *might* go away.
+      if (last.events.entry.FilePath || last.events.entry.FilePath === '') {
+        data.FilePath = last.events.entry.FilePath
+      }
     }
 
     return last.descend('fs', data)


### PR DESCRIPTION
- cleans service per https://swicloud.atlassian.net/browse/AO-10242
- sidesteps oboe validation by deleting/restoring APPOPTICS_SERVICE_KEY env var, if present
  - eliminates ambiguous oboe logs (overriding default using env var)
- tested using old version of oboe that doesn't transform bad service names.
  - oboe log 'client id' value verifies transformed name without override log message.
- fixes undefined FilePath error [AO-10347]