### PR TITLE
Possible bad port fix [AO-10015]

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -201,14 +201,15 @@ Event.prototype.set = function (data) {
   // (https://developers.google.com/v8/design#fast-property-access)
   const valid = {string: true, boolean: true, number: true}
   for (const k in data) {
-    if (typeof data[k] in valid) {
+    if (typeof data[k] in valid && !Number.isNaN(data[k])) {
       this[k] = data[k]
     } else if (k === 'error' && data[k] instanceof Error) {
       // N.B. this.error (setter) must change to move KVs to this.kvpairs.
       this[k] = data[k]
     } else {
       const stack = ao.stack('Invalid type', 25)
-      log.error('Invalid type for KV %s: %s\n%s', k, typeof data[k], stack)
+      const type = Number.isNaN(data[k]) ? 'NaN' : typeof data[k]
+      log.error('Invalid type for KV %s: %s\n%s', k, type, stack)
     }
   }
   //extend(this, data || {})

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -267,7 +267,14 @@ function patchServer (module, protocol) {
 
   function getPort (req) {
     const {host} = req.headers
-    return Number(host ? host.split(':')[1] : defaultPort[protocol])
+    let port
+    if (host) {
+      port = host.split(':')[1]
+    }
+    if (!port) {
+      port = defaultPort[protocol]
+    }
+    return Number(port)
   }
 
   function getPath ({url}) {

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -3,6 +3,7 @@ const helper = require('./helper')
 const ao = require('..')
 const should = require('should')    // eslint-disable-line no-unused-vars
 const addon = ao.addon
+const debug = ao.debug
 const Event = ao.Event
 
 describe('event', function () {
@@ -80,6 +81,20 @@ describe('event', function () {
     ao.requestStore.run(function () {
       event2.sendReport()
     })
+  })
+
+  it('should not allow setting a NaN value', function () {
+    const event2 = new Event('test', 'exit', event.event)
+
+    const logChecks = [
+      {level: 'error', message: 'Invalid type for KV %s: %s', values: ['Nan', 'NaN']},
+      // there is a stack trace here but issuing the error is enough.
+    ]
+    helper.checkLogMessages(debug, logChecks)
+
+    event2.set({Nan: NaN})
+
+    helper.getLogMessagesChecked().should.equal(1, 'incorrect log message count')
   })
 
   it('should support set function', function () {

--- a/test/helper.js
+++ b/test/helper.js
@@ -400,16 +400,17 @@ function checkData (data, fn) {
   }
 }
 
+let counter
 exports.checkLogMessages = checkLogMessages
 function checkLogMessages (debug, checks) {
   const defaultLogger = debug.log
-  let count = 0
+  counter = 0
 
   // log is called before substitutions are done, so don't check for the final
   // message as output.
   debug.log = function (output) {
     const [level, text] = getLevelAndText(output)
-    const check = checks[count++]
+    const check = checks[counter++]
     // catch errors so this logger isn't left in place after an error is found
     try {
       assert('appoptics:' + check.level === level, 'message level should be ' + check.level)
@@ -428,10 +429,14 @@ function checkLogMessages (debug, checks) {
       throw e
     }
     // restore the default logger when out of messages to check too.
-    if (count >= checks.length) {
+    if (counter >= checks.length) {
       debug.log = defaultLogger
     }
   }
+}
+
+exports.getLogMessagesChecked = function () {
+  return counter
 }
 
 exports.getLevelAndText = getLevelAndText


### PR DESCRIPTION
Via code-inspection it appears that a bad port can happen when the `req.headers.host` is present but does not contain a `:port` component. This PR fixes that by using the default if `:port` is missing.

In the case above the value is being set to NaN which, all logic to the contrary, is considered a number by JavaScript. I also added checks to assure that a KV value is not being set to NaN. That does imply that if someone really wants to set that value they will need to make it a string value. Tests to assure that NaN is not allowed are included.