### PR TITLE
fix for esm needing .native functions [AO-10300]

### DIFF
--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -114,24 +114,30 @@ function patchPathMethods (fs) {
 
 function patchPathMethod (fs, method) {
   if (typeof fs[method] === 'function') {
-    shimmer.wrap(fs, method, fn => function (...args) {
-      const cb = args.pop()
-      let span
-      return ao.instrument(
-        last => (span = last.descend('fs', {
-          Spec: 'filesystem',
-          Operation: method,
-          FilePath: args[0]
-        })),
-        cb => fn.apply(this, args.concat(function (err, fd) {
-          if (span && method === 'open') {
-            span.events.exit.FileDescriptor = fd
-          }
-          return cb.apply(this, arguments)
-        })),
-        conf,
-        cb
-      )
+    shimmer.wrap(fs, method, fn => {
+      const f = function (...args) {
+        const cb = args.pop()
+        let span
+        return ao.instrument(
+          last => (span = last.descend('fs', {
+            Spec: 'filesystem',
+            Operation: method,
+            FilePath: args[0]
+          })),
+          cb => fn.apply(this, args.concat(function (err, fd) {
+            if (span && method === 'open') {
+              span.events.exit.FileDescriptor = fd
+            }
+            return cb.apply(this, arguments)
+          })),
+          conf,
+          cb
+        )
+      }
+      if (method === 'realpath') {
+        f.native = fn.native
+      }
+      return f
     })
   } else {
     log.patching('fs.%s not a function', method)
@@ -139,23 +145,29 @@ function patchPathMethod (fs, method) {
 
   const syncMethod = method + 'Sync'
   if (typeof fs[syncMethod] === 'function') {
-    shimmer.wrap(fs, syncMethod, fn => function (...args) {
-      let span
-      return ao.instrument(
-        last => (span = last.descend('fs', {
-          Spec: 'filesystem',
-          Operation: syncMethod,
-          FilePath: args[0]
-        })),
-        () => {
-          const ret = fn.apply(this, args)
-          if (span && method === 'open') {
-            span.events.exit.FileDescriptor = ret
-          }
-          return ret
-        },
-        conf
-      )
+    shimmer.wrap(fs, syncMethod, fn => {
+      const f = function (...args) {
+        let span
+        return ao.instrument(
+          last => (span = last.descend('fs', {
+            Spec: 'filesystem',
+            Operation: syncMethod,
+            FilePath: args[0]
+          })),
+          () => {
+            const ret = fn.apply(this, args)
+            if (span && method === 'open') {
+              span.events.exit.FileDescriptor = ret
+            }
+            return ret
+          },
+          conf
+        )
+      }
+      if (method === 'realpath') {
+        f.native = fn.native
+      }
+      return f
     })
   } else {
     log.patching('fs.%s not a function', syncMethod)


### PR DESCRIPTION
propagate .native functions to patched functions
for realpath and realpathSync.

this change prevents the esm package from core dumping.