### PR TITLE
Fix mongodb-core tests to use unique DB names [AO-8024]

### DIFF
--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -130,7 +130,6 @@ function makeTests (db_host, host, isReplicaSet) {
     })
 
     ao.logLevel = 'error,warn,debug,patching'
-    ao.loggers.debug(`using AO_IX=${process.env.AO_IX}`)
 
     let server
     if (hosts.length > 1) {


### PR DESCRIPTION
When running multiple matrix tests in parallel the mongo tests would cause others to fail because they all used the same database and collection names.

mongodb-core is the last of the database tests to use unique names. All the tests to depend on the environment variable `AO_IX` to be set - that is used to construct the unique names. Running locally there is no need to set `AO_IX` because only one test runs at a time. These commits just add some debugging output that allows makes it easier to see what is happening.
