### PR TITLE
Probe improvements

### DIFF
--- a/lib/probes/amqplib.js
+++ b/lib/probes/amqplib.js
@@ -162,7 +162,7 @@ function patchConsume (proto) {
             URL: `/amqplib/${msg.fields.routingKey}`,
             Controller: 'amqplib',
             Action: fnName,
-            SourceTrace: SourceTrace || ''
+            SourceTrace: SourceTrace
           })
         },
         () => cb.call(this, msg),

--- a/lib/probes/cassandra-driver.js
+++ b/lib/probes/cassandra-driver.js
@@ -81,7 +81,7 @@ module.exports = function (cassandra) {
       )
       patchPrepareHandler(PrepareHandler)
     } catch (e) {
-      ao.loggers.info('probe.cassandra-driver failed to patch >=3.3.0')
+      ao.loggers.patching('probe.cassandra-driver failed to patch >=3.3.0')
     }
   } else {
     patchSendOnConnection(RequestHandler, sendOnConnection, connection)
@@ -98,7 +98,7 @@ module.exports = function (cassandra) {
 
 function patchSendOnConnection (where, sendName, connName) {
   if (typeof where[sendName] !== 'function') {
-    logMissing(sendName)
+    logMissing(sendName + '()')
     return
   }
   shimmer.wrap(where, sendName, method => function () {
@@ -113,7 +113,7 @@ function patchSendOnConnection (where, sendName, connName) {
 
 function patchPrepareHandler (prepareHandler) {
   if (typeof prepareHandler.getPrepared !== 'function') {
-    logMissing('PrepareHandler.getPrepared')
+    logMissing('PrepareHandler.getPrepared()')
     return
   }
 
@@ -130,7 +130,7 @@ function patchPrepareHandler (prepareHandler) {
 //
 function patchClientConnect (client) {
   if (typeof client.connect !== 'function') {
-    logMissing('client.connect')
+    logMissing('client.connect()')
     return
   }
   shimmer.wrap(client, 'connect', method => function (...args) {
@@ -159,7 +159,7 @@ function serializeList (list) {
 //
 function patchClientStream (client, consistencies) {
   if (typeof client.stream !== 'function') {
-    logMissing('client.stream')
+    logMissing('client.stream()')
     return
   }
 
@@ -171,7 +171,7 @@ function patchClientStream (client, consistencies) {
 
 function patchClientInnerExecute (client, consistencies) {
   if (typeof client._innerExecute !== 'function') {
-    logMissing('client._innerExecute')
+    logMissing('client._innerExecute()')
     return
   }
   shimmer.wrap(client, '_innerExecute', execute => function (...args) {
@@ -231,7 +231,7 @@ function patchClientInnerExecute (client, consistencies) {
 //
 function patchClientBatch (client, consistencies) {
   if (typeof client.batch !== 'function') {
-    logMissing('client.batch')
+    logMissing('client.batch()')
     return
   }
   shimmer.wrap(client, 'batch', fn => function (...args) {


### PR DESCRIPTION
Minor corrections
- amqplib was defaulting the `SourceTrace` message header twice.
- cassandra-driver is patching logs to patching and uses `()` for functions that are missing.