### PR TITLE
Mongo updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -402,7 +402,11 @@ const ao = exports   // eslint-disable-line no-unused-vars
 // Create a reporter
 //
 try {
-  exports.reporter = new bindings.Reporter()
+  if (typeof bindings.Reporter === 'function') {
+    exports.reporter = new bindings.Reporter()
+  } else {
+    exports.reporter = bindings.Reporter
+  }
 } catch (e) {
   const zoreReporter = function () {return 0}     // zero or error
   const torfReporter = function () {return true}  // true or false
@@ -638,10 +642,10 @@ exports.bind = function (fn) {
       const e = new Error('CLS NOT ACTIVE')
       log.warn('ao.bind(%s) - no context', name, e.stack)
     } else if (!exports.tracing) {
-      log.warn('ao.bind %s - not tracing', name)
+      log.warn('ao.bind(%s) - not tracing', name)
     } else if (fn !== undefined) {
       const e = new Error('Not a function')
-      log.warn('ao.bind %s - not a function', fn, e.stack)
+      log.warn('ao.bind(%s) - not a function', fn, e.stack)
     }
   } catch (e) {
     log.error('failed to bind callback', e.stack)
@@ -1233,8 +1237,8 @@ if (!enabled) {
       return run(exports.bind(cb))
     }
 
-    // If already tracing, continue the existing trace independently of
-    // the xtrace passed as the first argument.
+    // If already tracing, continue the existing trace ignoring
+    // any xtrace passed as the first argument.
     const last = Span.last
     if (last) {
       return runInstrument(last, build, run, opts, cb)

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -255,6 +255,8 @@ const dataMakers = [
       data.Group_Reduce = cmd.group.$reduce.toString()
     } else if (typeof cmd.group.$reduce === 'object') {
       data.Group_Reduce = cmd.group.$reduce.code.toString()
+    } else {
+      data.Group_Reduce = cmd.group.$reduce.toString()
     }
     data.Group_Key = JSON.stringify(cmd.group.key)
   }],
@@ -267,17 +269,8 @@ const dataMakers = [
     }
   }],
   [notUndef('aggregate'), function (data, cmd) {
-    const p = cmd.pipeline
-    if (p[0].$match && p[1].$group) {
-      const p1 = p[1].$group
-      if (p1._id === null && p1.n && p1.n.$sum === 1) {
-        data.QueryOp = 'count'
-        data.Query = JSON.stringify(p[0].$match)
-        return
-      }
-    }
-    data.QueryOp = 'command'
-    data.Command = JSON.stringify(cmd)
+    data.QueryOp = 'aggregate'
+    data.Pipeline = JSON.stringify(cmd.pipeline)
   }]
 ]
 

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -273,8 +273,11 @@ const dataMakers = [
       if (p1._id === null && p1.n && p1.n.$sum === 1) {
         data.QueryOp = 'count'
         data.Query = JSON.stringify(p[0].$match)
+        return
       }
     }
+    data.QueryOp = 'command'
+    data.Command = JSON.stringify(cmd)
   }]
 ]
 
@@ -284,6 +287,7 @@ function makeData (ctx, ns, cmd) {
   for (let i = 0; i < dataMakers.length; i++) {
     const [test, make] = dataMakers[i]
     if (test(cmd)) {
+      ao.loggers.debug(`${JSON.stringify(cmd)} - ${JSON.stringify(data)}`)
       make(data, cmd)
       return data
     }

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -709,8 +709,8 @@ describe('custom', function () {
     function noop () {}
 
     const logChecks = [
-      {level: 'warn', message: 'ao.bind %s - no context', values: ['noop']},
-      {level: 'warn', message: 'ao.bind %s - not a function', values: [null]},
+      {level: 'warn', message: 'ao.bind(%s) - no context', values: ['noop']},
+      {level: 'warn', message: 'ao.bind(%s) - not a function', values: [null]},
     ]
     helper.checkLogMessages(debug, logChecks)
 

--- a/test/probes/mongoose.test.js
+++ b/test/probes/mongoose.test.js
@@ -130,8 +130,7 @@ describe('probes/mongoose ' + pkg.version, function () {
   // mongoose api. that's what the mongoose probe does.
   //
 
-  ['callback', 'promise'].forEach(type => {
-
+  function runTests (type) {
     //
     // connect
     //
@@ -416,6 +415,14 @@ describe('probes/mongoose ' + pkg.version, function () {
       )
     })
 
+  }
+
+  describe('promises', function () {
+    runTests('promise')
+  })
+
+  describe('callbacks', function () {
+    runTests('callback')
   })
 
   function ids (x) {return [x.substr(2, 40), x.substr(42, 16)]}


### PR DESCRIPTION
- handle old `Group_Reduce` KV source in addition to new.
- add `aggregate` `QueryOp` (stop synthesizing `count`)
- handle class and object versions of `bindings.Reporter` (allowed testing with N-API bindings)
- minor binding error message changes