### PR TITLE
Add support for koa-router >=7.0.0

### DIFF
--- a/lib/probes/koa-router.js
+++ b/lib/probes/koa-router.js
@@ -2,13 +2,27 @@
 
 const shimmer = require('ximmer')
 const methods = require('methods')
+const semver = require('semver')
+
 const utility = require('../utility')
 const ao = require('../')
+const requirePatch = require('../require-patch')
 const Span = ao.Span
 const conf = ao.probes['koa-router']
 
-module.exports = function (router) {
-  return app => patchApp(app, router)
+const {version} = requirePatch.relativeRequire('koa-router/package.json')
+
+module.exports = function (_router) {
+  if (semver.gte(version, '7.0.0')) {
+    // allow the caller to invoke this with or without "new" by
+    // not using an arrow function.
+    return function () {
+      const router = _router.apply(this, arguments)
+      wrapRouter(router)
+      return router
+    }
+  }
+  return app => patchApp(app, _router)
 }
 
 function patchApp (app, router) {
@@ -17,7 +31,7 @@ function patchApp (app, router) {
   methods.concat('del').forEach(method => {
     // For 5.x+, the methods are on a router, not patched onto the app
     //Check if app exists, only use handler otherwise
-    patchMethod(
+    patchGeneratorFunction(
       (app ? [handler, app] : [handler]).filter(v => typeof v[method] === 'function')[0],
       method
     )
@@ -26,7 +40,38 @@ function patchApp (app, router) {
   return handler
 }
 
+function wrapRouter (router) {
+  methods.concat('del', 'all').forEach(method => {
+    patchAsyncMethod([router].filter(v => typeof v[method] === 'function')[0], method)
+  })
+}
+
 function patchHandler (Controller, Action, route) {
+  return async (ctx, next) => {
+    // Check if there is a trace to continue
+    const last = Span.last
+    if (!last || !conf.enabled) {
+      return await route.call(this, ctx, next)
+    }
+
+    let span
+    try {
+      // Build controller/action data, assign to http
+      // span exit, and create koa-router profile
+      const data = {Controller, Action}
+      this.res._ao_http_span.events.exit.set(data)
+      span = last.profile(`${Controller} ${Action}`, data)
+    } catch (e) {}
+
+    // Enter, run and exit
+    if (span) span.enter()
+    const res = await route.call(this, ctx, next)
+    if (span) span.exit()
+    return res
+  }
+}
+
+function patchGeneratorHandler (Controller, Action, route) {
   return function* (next) {
     // Check if there is a trace to continue
     const last = Span.last
@@ -37,7 +82,7 @@ function patchHandler (Controller, Action, route) {
     let span
     try {
       // Build controller/action data, assign to http
-      // span exit, and reate koa-route profile
+      // span exit, and create koa-route profile
       const data = {Controller, Action}
       this.res._ao_http_span.events.exit.set(data)
       span = last.profile(`${Controller} ${Action}`, data)
@@ -51,14 +96,35 @@ function patchHandler (Controller, Action, route) {
   }
 }
 
-function patchMethod (target, method) {
+function patchAsyncMethod (target, method) {
+  if (typeof target[method] !== 'function') return
+
+  shimmer.wrap(target, method, fn => {
+    return function (name, url, route) {
+      if (arguments.length === 3) {
+        return fn.call(this, name, url, patchHandler(
+          method + ' ' + url,
+          utility.fnName(route),
+          route
+        ))
+      }
+      return fn.call(this, name, patchHandler(
+        method + ' ' + name,
+        utility.fnName(url),
+        url
+      ))
+    }
+  })
+}
+
+function patchGeneratorFunction (target, method) {
   // The method might not exist at all
   if (typeof target[method] !== 'function') return
 
   shimmer.wrap(target, method, fn => {
     return function (url, route) {
       // Define controller/action at assignment time
-      return fn.call(this, url, patchHandler(
+      return fn.call(this, url, patchGeneratorHandler(
         method + ' ' + url,
         utility.fnName(route),
         route

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "5.9.4",
+  "version": "5.10.0",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {
@@ -76,7 +76,7 @@
     "koa": "^2.6.2",
     "koa-resource-router": "^0.4.0",
     "koa-route": "^2.4.2",
-    "koa-router": "^5.4.2",
+    "koa-router": "^7.4.0",
     "level": "^4.0.0",
     "memcached": "^2.2.2",
     "method-override": "^2.3.10",

--- a/test/docker/mac-os-test-env/README.md
+++ b/test/docker/mac-os-test-env/README.md
@@ -1,11 +1,11 @@
-#Running Tests and Debugging on Mac
+# Running Tests and Debugging on Mac
 
 The node agent uses bindings from a c-library, that doesn't compile on MacOS.
 Therefor we need to run the tests in a docker container.
 Furthermore the tests require access to a number of databases and services, 
 which will also run in containers with the setup provided here.
 
-##Preconditions
+## Preconditions
 The environment variable `AO_TOKEN_STG` needs to be set and can be set to 
 something like `1234567890123456789012345678901234567890123456789012345678901234` 
 (length must be 64 characters, allowed characters A-Za-z0-9)
@@ -13,7 +13,7 @@ something like `1234567890123456789012345678901234567890123456789012345678901234
 A real token is only needed if debugging involves looking at traces in 
 `https://my-stg.appoptics.com/`.
 
-##Starting the containers
+## Starting the containers
 
 The command
 
@@ -27,19 +27,19 @@ This container mounts the code from the `appoptics-apm-node` directory on the
 host. The code can be edited in the usual IDE and the changes tested in the 
 `node_main` container without having to restart or reload.
 
-##Testing
+## Testing
 
 In the shell in `node_main` type `mocha` or `mocha <path-to-test-file>` to 
 run tests.
 
-##Debugging
+## Debugging
 
 In the shell in `node_main` type `debug` or `debug <path-to-test-file>` to 
 start tests in debug mode. Then go to a Chrome browser window and open 
 `chrome://inspect` to access the debugging tools.
 Breakpoints can be set in Chrome or by adding a line `debugger` in the code.
 
-##Other `./dc.sh` commands
+## Other `./dc.sh` commands
 `./dc.sh config`  shows the whole docker-compose configuration
 `./dc.sh down` stops the containers and removes orphans
 `./dc.sh logs` streams the logs from all containers

--- a/test/docker/main.yml
+++ b/test/docker/main.yml
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get -y install gcc-4.9 g++-4.9 \
 && rm -rf /var/lib/apt/lists/*
 
 # get node
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs
 
 #ENV NVM_VERSION=v0.33.8

--- a/test/probes/koa.js
+++ b/test/probes/koa.js
@@ -163,16 +163,18 @@ exports.route_disabled = function (emitter, done) {
 exports.router = function (emitter, done) {
   const app = koa()
 
-  function* hello () {
-    this.body = 'done'
-  }
-
   // Mount router
   const r = router(app)
   if (typeof r.routes === 'function') {
-    app.use(r.routes())
+    const hello = (ctx) => {
+      ctx.body = 'done'
+    }
     r.get('/hello/:name', hello)
+    app.use(r.routes())
   } else {
+    function* hello () {
+      this.body = 'done'
+    }
     app.use(r)
     app.get('/hello/:name', hello)
   }


### PR DESCRIPTION
In order to evaluate the AppOptics service (still ongoing) I have to update the node library to work with koa-router >= 7.0.0. This is what I've got so far so please consider this WIP, but I'm happy to make changes to fit in with better practices, or simply hand it over if you'd prefer to implement the changes differently. 

The most WIP aspect is definitely the testing as it fails. I get this, which I'm not sure about:

```
Uncaught AssertionError: expected Object {
  Edge: '96F5D47AEEC559FC',
  Hostname: 'a6bb577c405f',
  Label: 'exit',
  Layer: 'koa',
  TID: 40,
  Timestamp_u: 1547563758829518,
  'X-Trace': '2B366D0D686BD1363D43CF16E7702B281EEEA953383EE5E6EC5D598D9901',
  _V: '1'
} to have property Label of 'profile_entry' (got 'exit')
```
I imagine it's something fairly obvious to those in the know. The updates appear to be working in our app so it seems to work.

The version number got bumped by me just so that I could double check I had my version installed after forking. 

I had to install a later version of node as the docker image building failed otherwise.

Thank you for the Mac setup, it was very helpful!