### PR TITLE
Fix express tests for better named route spans

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -47,8 +47,8 @@ elif [[ "$ARG" = "bash" ]]; then
     # this is used primarily for manual interactive testing.
     [[ ":$PATH" != *":$PWD/node_modules/.bin"* ]] && PATH="${PATH}:$PWD/node_modules/.bin"
 
-    # add a simple reset to basic debug output
-    export XDEBUG=appoptics:error,appoptics:warn,appoptics:patching,appoptics:debug
+    # set logging that should be seen during testing.
+    export APPOPTICS_LOG_SETTINGS=error,warn,patching,bind,debug
 
     # these are generally the right settings unless a collector
     # is required.
@@ -130,7 +130,7 @@ elif [[ "$ARG" = "debug" ]]; then
     # LEVEL 2 is most of what you want to see. 6 (highest) is too much.
     export APPOPTICS_DEBUG_LEVEL=2
     # see lib/loggers.js for all the options
-    export DEBUG=appoptics:error,appoptics:warn,appoptics:debug,appoptics:patching
+    export APPOPTICS_LOG_SETTINGS=error,warn,debug,patching,bind
     export APPOPTICS_TOKEN_BUCKET_CAPACITY=1000
     export APPOPTICS_TOKEN_BUCKET_RATE=1000
 elif [[ "$ARG" = "bindings" ]]; then

--- a/lib/index.js
+++ b/lib/index.js
@@ -573,6 +573,7 @@ exports.bind = function (fn) {
 }
 
 const dbBind = new log.Debounce('bind')
+const dbInfo = new log.Debounce('info')
 //const dbNotTracing = new log.Debounce('info')
 //const dbNotEmitter = new log.Debounce('error')
 //const dbUnknown = new log.Debounce('info')
@@ -602,7 +603,7 @@ exports.bindEmitter = function (em) {
     if (!clsCheck()) {
       dbBind.log('ao.bindEmitter - no context', e.stack)
     } else if (!exports.tracing) {
-      dbBind.log('ao.bindEmitter - not tracing')
+      dbInfo.log('ao.bindEmitter - not tracing')
     } else if (!emitter) {
       dbBind.log('ao.bindEmitter - non-emitter', e.stack)
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -557,12 +557,12 @@ exports.bind = function (fn) {
     // it's not quite right so issure diagnostic message
     if (!clsCheck()) {
       const e = new Error('CLS NOT ACTIVE')
-      log.warn('ao.bind(%s) - no context', name, e.stack)
+      log.bind('ao.bind(%s) - no context', name, e.stack)
     } else if (!exports.tracing) {
-      log.warn('ao.bind(%s) - not tracing', name)
+      log.bind('ao.bind(%s) - not tracing', name)
     } else if (fn !== undefined) {
       const e = new Error('Not a function')
-      log.warn('ao.bind(%s) - not a function', fn, e.stack)
+      log.bind('ao.bind(%s) - not a function', fn, e.stack)
     }
   } catch (e) {
     log.error('failed to bind callback', e.stack)
@@ -572,10 +572,10 @@ exports.bind = function (fn) {
   return fn
 }
 
-const dbNoContext = new log.Debounce('warn')
-const dbNotTracing = new log.Debounce('info')
-const dbNotEmitter = new log.Debounce('error')
-const dbUnknown = new log.Debounce('info')
+const dbBind = new log.Debounce('bind')
+//const dbNotTracing = new log.Debounce('info')
+//const dbNotEmitter = new log.Debounce('error')
+//const dbUnknown = new log.Debounce('info')
 
 /**
  * Bind an emitter if tracing
@@ -600,13 +600,13 @@ exports.bindEmitter = function (em) {
 
     const e = new Error('CLS NOT ACTIVE')
     if (!clsCheck()) {
-      dbNoContext.log('ao.bindEmitter - no context', e.stack)
+      dbBind.log('ao.bindEmitter - no context', e.stack)
     } else if (!exports.tracing) {
-      dbNotTracing.log('ao.bindEmitter - not tracing')
+      dbBind.log('ao.bindEmitter - not tracing')
     } else if (!emitter) {
-      dbNotEmitter.log('ao.bindEmitter - non-emitter', e.stack)
+      dbBind.log('ao.bindEmitter - non-emitter', e.stack)
     } else {
-      dbUnknown.log('ao.bindEmitter - couldn\'t bind emitter')
+      dbBind.log('ao.bindEmitter - couldn\'t bind emitter')
     }
   } catch (e) {
     log.error('failed to bind emitter', e.stack)

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -17,7 +17,8 @@ const loggers = {
   span: logger.make('span'),
   info: logger.make('info'),
   patching: logger.make('patching'),            // show errors patching
-  probes: logger.make('probes')                 // show probe information
+  probes: logger.make('probes'),                // show probe information
+  bind: logger.make('bind'),                    // show binding errors
 }
 
 //

--- a/lib/probes/express.js
+++ b/lib/probes/express.js
@@ -10,12 +10,14 @@ const ao = require('..')
 const log = ao.loggers
 const conf = ao.probes.express
 
+const logMissing = ao.makeLogMissing('express')
+
 //
 // Patch routing system to create spans for each routing function
 //
-function routeProfiling (express, version) {
+function patchRoutes (express, version) {
 
-  function buildSpan (req, res, func) {
+  function makeSpanInfo (req, res, func) {
     const httpSpan = res._ao_http_span
 
     // previous
@@ -56,16 +58,20 @@ function routeProfiling (express, version) {
     // Store the latest middleware Controller/Action on exit
     const data = {Controller, Action}
     httpSpan.events.exit.set(data)
-    return {name: 'express-route', kvpairs: data}
+
+    // construct the name of the span.
+    const name = func.name ? `express-route:${func.name}` : 'express-route'
+    return {name, kvpairs: data}
   }
 
+
   //
-  // Each routing callback is patched as a 'express-route' span.
+  // Each routing callback is patched as an 'express-route[:function-name]' span.
   //
   function expressRoute (func) {
     return function (req, res, next) {
       let span
-      const spanInfo = buildSpan(req, res, func)
+      const spanInfo = makeSpanInfo(req, res, func)
       spanInfo.finalize = function (createdSpan) {
         span = createdSpan
       }
@@ -102,7 +108,7 @@ function routeProfiling (express, version) {
   function v3 (express) {
     const proto = express.Router && express.Router.prototype
     if (!proto || typeof proto.route !== 'function') {
-      log.patching('express.v3 Router.route not a function')
+      logMissing('v3 Router.route()')
       return
     }
     shimmer.wrap(proto, 'route', fn => function (method) {
@@ -122,12 +128,12 @@ function routeProfiling (express, version) {
   function v4 (express) {
     const proto = express.Route && express.Route.prototype
     if (!proto) {
-      log.patching('express.v4 Route.prototype not found')
+      logMissing('v4 Route.prototype')
       return
     }
     methods.concat('all').forEach(method => {
       if (typeof proto[method] !== 'function') {
-        log.patching('express.v4 Route.%s not a function', method)
+        logMissing(`v4 Route.${method}()`)
         return
       }
       shimmer.wrap(proto, method, method => function (...args) {
@@ -150,7 +156,7 @@ function routeProfiling (express, version) {
 //
 // Patch rendering system to create spans for render calls
 //
-function renderProfiling (express, version) {
+function patchRendering (express, version) {
 
   //
   // The View constructor is patched to report render timing
@@ -202,7 +208,7 @@ function renderProfiling (express, version) {
 // while for 3.x it is actually in connect itself.
 function patchHandle (app) {
   if (typeof app.handle !== 'function') {
-    log.patching('express.patchHandle app.handle not a function')
+    logMissing('app.handle()')
     return
   }
   shimmer.wrap(app, 'handle', handle => function (req, res, next) {
@@ -245,10 +251,10 @@ module.exports = function (express) {
   express = expressSpan(express)
 
   // make spans for each route callback
-  routeProfiling(express, version)
+  patchRoutes(express, version)
 
-  // make spans for each render calls
-  renderProfiling(express, version)
+  // make spans for each render call
+  patchRendering(express, version)
 
   return express
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.0.1",
+  "version": "6.0.2-alpha",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -9,19 +9,13 @@ const makeSettings = helper.makeSettings
 
 
 let ifaob    // execute or skip test depending on whether bindings are loaded.
-let ALWAYS
-let NEVER
 let MAX_SAMPLE_RATE
 
 if (ao.addon) {
   ifaob = it
-  ALWAYS = ao.addon.TRACE_ALWAYS
-  NEVER = ao.addon.TRACE_NEVER
   MAX_SAMPLE_RATE = ao.addon.MAX_SAMPLE_RATE
 } else {
   ifaob = it.skip
-  ALWAYS = 1
-  NEVER = 0
   MAX_SAMPLE_RATE = 1000000
 }
 


### PR DESCRIPTION
- log bind errors to the the 'bind' logging level, not warn, debug.
- log not-tracing bind emitter to 'info'
- remove always and never references