### PR TITLE
v6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,10 @@ Features
 - enable inserting trace IDs into logs automatically (bunyan)
 - `insertTraceIdsIntoLogs` options expanded to `false`, `true`, `'traced'`, `'sampledOnly'`, `'always'`
 
+#### v6.3.0
+
+Features and bug fixes
+- add `insertTraceIdsIntoMorgan` to enable appending `ao.traceId=...` format morgan's text output.
+- add `createTraceIdsToken`. Set to `'morgan'` to have the token `ao-auto-trace-id` token created. Use as `:ao-auto-trace-id` in morgan formats.
+- set config to service key that was used.
+- fix aws-sdk bad signature error on transaction retry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,18 @@ Features and bug fixes
 
 Breaking changes
 - all breaking changes are in the API. See `guides/migration-5to6.md` for details.
+
+#### v6.1.0
+
+Features and bug fixes
+- enable inserting trace IDs into logs automatically (pino, winston)
+- new API function, `ao.getFormattedTraceId()` to get trace IDs using code.
+- new API function, `ao.sendMetric()` for sending custom metrics.
+- fix config file not found bug.
+
+#### v6.2.0
+
+Features
+- enable inserting trace IDs into logs automatically (bunyan)
+- `insertTraceIdsIntoLogs` options expanded to `false`, `true`, `'traced'`, `'sampledOnly'`, `'always'`
+

--- a/archived/working-notes.md
+++ b/archived/working-notes.md
@@ -44,10 +44,21 @@ working notes
 30. [API BREAKING] removed sugary mode detectors, e.g., ao.always. use ao.traceMode === 'enabled' or ao.traceMode === 'disabled'
 31. use native WeakMap replacing 'es6-weak-map' package.
 
+### 6.3.0
+
+1. delete requestStore.topSpan on exit topSpan.
+2. Fix reversed API docs.
+3. aws-sdk fixes and tests.
+4. log unsampled task IDs don't match at debug level.
+5. make task IDs don't match message more clear.
+6. log insertion: winston, pino, morgan, bunyan
+7. log insertion tests
+8. add async-dump file (devDependency) consider wtfnode.
+9. set cfg to service key used, not the one specified.
+
 
 ### next up
 
-morgan test
 move api out of index and into api
 
-back from vacation - learn how to configure and build oboe
+back from vacation - configure and build oboe

--- a/archived/working-notes.md
+++ b/archived/working-notes.md
@@ -1,3 +1,7 @@
+working notes
+
+### 6.0.0 rearchitecture
+
 1. removed RUM artifacts
 2. removed Profiles
 3. moved sampling decision from Event constructor to function calling Span constructor.
@@ -39,3 +43,11 @@
 29. [deprecated] traceMode 'always' and 'never'; use 'enabled' and 'disabled'
 30. [API BREAKING] removed sugary mode detectors, e.g., ao.always. use ao.traceMode === 'enabled' or ao.traceMode === 'disabled'
 31. use native WeakMap replacing 'es6-weak-map' package.
+
+
+### next up
+
+morgan test
+move api out of index and into api
+
+back from vacation - learn how to configure and build oboe

--- a/guides/api.md
+++ b/guides/api.md
@@ -391,7 +391,7 @@ HTTP headers or message queue headers.
 | --- | --- | --- | --- |
 | xtrace | <code>string</code> |  | X-Trace ID to continue from or null |
 | span | <code>string</code> \| [<code>spanInfoFunction</code>](#spanInfoFunction) |  | name or function returning spanInfo |
-| run | <code>function</code> |  | the promise-returning function to run |
+| run | <code>function</code> |  | run this function. sync if no arguments, async if one. |
 | [opts] | <code>object</code> |  | options |
 | [opts.enabled] | <code>boolean</code> | <code>true</code> | enable tracing |
 | [opts.collectBacktraces] | <code>boolean</code> | <code>false</code> | collect backtraces |
@@ -450,7 +450,7 @@ source, e.g., HTTP headers or message queue headers.
 | --- | --- | --- | --- |
 | xtrace | <code>string</code> |  | X-Trace ID to continue from or null |
 | span | <code>string</code> \| [<code>spanInfoFunction</code>](#spanInfoFunction) |  | name or function returning spanInfo |
-| run | <code>function</code> |  | run the code. if sync, no arguments, else one |
+| run | <code>function</code> |  | the promise-returning function to instrument |
 | [opts] | <code>object</code> |  | options |
 | [opts.enabled] | <code>boolean</code> | <code>true</code> | enable tracing |
 | [opts.collectBacktraces] | <code>boolean</code> | <code>false</code> | collect backtraces |

--- a/lib/api.js
+++ b/lib/api.js
@@ -116,7 +116,7 @@ function sendMetric (name, options) {
  */
 function getFormattedTraceId (options = {}) {
   const format = options.format || aob.Metadata.fmtLog;
-  return ao.Event.last ? ao.Event.last.event.toString(format) : '0000000000000000000000000000000000000000-0';
+  return ao.Span.last ? ao.Span.last.events.exit.event.toString(format) : '0000000000000000000000000000000000000000-0';
 }
 
 /**

--- a/lib/api.js
+++ b/lib/api.js
@@ -116,7 +116,7 @@ function sendMetric (name, options) {
  */
 function getFormattedTraceId (options = {}) {
   const format = options.format || aob.Metadata.fmtLog;
-  return ao.Span.last ? ao.Span.last.events.exit.event.toString(format) : '0000000000000000000000000000000000000000-0';
+  return ao.Event.last ? ao.Event.last.event.toString(format) : '0000000000000000000000000000000000000000-0';
 }
 
 /**

--- a/lib/event.js
+++ b/lib/event.js
@@ -77,7 +77,7 @@ function Event (span, label, parent, edge) {
     if (this.taskId !== taskId) {
       // if not sampling log at debug level even though it's unexpected.
       const level = this.event.getSampleFlag() ? 'error' : 'debug';
-      log[level]('task IDs don\'t match (%e vs %e)', this, val);
+      log[level]('task IDs don\'t match this %e vs edge %s)', this, taskId);
       return true
     }
     target[prop] = val

--- a/lib/event.js
+++ b/lib/event.js
@@ -65,11 +65,19 @@ function Event (span, label, parent, edge) {
     }
     let taskId = val
     if (val) {
-      taskId = (val.event ? val.event : val).toString().slice(2, 42)
+      // if it's an event let toString() return the task ID directly. if not
+      // presume it's something that can be stringified even if it's a string.
+      if (val.event) {
+        taskId = val.event.toString(2);
+      } else {
+        taskId = val.toString().slice(2, 42);
+      }
     }
 
     if (this.taskId !== taskId) {
-      log.error('task IDs don\'t match (%e vs %e)', this, val)
+      // if not sampling log at debug level even though it's unexpected.
+      const level = this.event.getSampleFlag() ? 'error' : 'debug';
+      log[level]('task IDs don\'t match (%e vs %e)', this, val);
       return true
     }
     target[prop] = val
@@ -126,7 +134,7 @@ Object.defineProperty(Event.prototype, 'error', {
  */
 Object.defineProperty(Event.prototype, 'taskId', {
   get () {
-    return this.event.toString().substr(2, 40)
+    return this.event.toString(2)
   }
 })
 
@@ -139,7 +147,7 @@ Object.defineProperty(Event.prototype, 'taskId', {
  */
 Object.defineProperty(Event.prototype, 'opId', {
   get () {
-    return this.event.toString().substr(42, 16)
+    return this.event.toString(4)
   }
 })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,10 @@ const env = process.env
 const udp = env.APPOPTICS_REPORTER === 'udp'
 exports.nodeEnv = env.NODE_ENV
 
+// don't insert headers in outbound http requests with this field truthy.
+const omitTraceId = Symbol('ao.omitTraceId');
+exports.omitTraceId = omitTraceId;
+
 const {logger, loggers} = require('./loggers')
 exports.logger = logger
 const log = exports.loggers = loggers

--- a/lib/index.js
+++ b/lib/index.js
@@ -269,6 +269,9 @@ const cleansedKey = serviceKey.toLowerCase()
  */
 exports.serviceKey = cleansedKey
 
+// and update the config with the key we actually used.
+config.serviceKey = cleansedKey;
+
 // now go through a sequence of checks and tests that can result in
 // appoptics being disabled. accumulate the errors so a single message
 // with the enabled status can be output at the end of the checks.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1230,7 +1230,7 @@ if (!enabled) {
    * @method ao.startOrContinueTrace
    * @param {string} xtrace - X-Trace ID to continue from or null
    * @param {string|spanInfoFunction} span - name or function returning spanInfo
-   * @param {function} run - the promise-returning function to run
+   * @param {function} run - run this function. sync if no arguments, async if one.
    * @param {object}  [opts] - options
    * @param {boolean} [opts.enabled=true] - enable tracing
    * @param {boolean} [opts.collectBacktraces=false] - collect backtraces
@@ -1369,7 +1369,7 @@ if (!enabled) {
    * @method ao.pStartOrContinueTrace
    * @param {string} xtrace - X-Trace ID to continue from or null
    * @param {string|spanInfoFunction} span - name or function returning spanInfo
-   * @param {function} run - run the code. if sync, no arguments, else one
+   * @param {function} run - the promise-returning function to instrument
    * @param {object}  [opts] - options
    * @param {boolean} [opts.enabled=true] - enable tracing
    * @param {boolean} [opts.collectBacktraces=false] - collect backtraces

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,8 +131,8 @@ const defaults = {
     ignoreConflicts: false,
     domainPrefix: false,
     insertTraceIdsIntoLogs: false,
-    createTraceIdsToken: false,
-    insertTraceIdsIntoMorgan: false,
+    insertTraceIdsIntoMorgan: false,    // separate setting because this mucks with log formats directly
+    createTraceIdsToken: false,         // 'morgan' to create for morgan. no others supported yet, nor multiple.
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -320,18 +320,23 @@ if (enabled && !env.AO_TEST_NO_BINDINGS) {
   try {
     bindings = require('appoptics-bindings')
   } catch (e) {
-    log.error('Can\'t load bindings', e.stack)
+    const args = ['Can\'t load bindings'];
+    if (e.code !== 'MODULE_NOT_FOUND') {
+      args.push(e.stack);
+    }
+    log.error.apply(log, args);
     errors.push('bindings not loaded')
   }
+} else {
+  const msg = `appoptics-bindings intentionally not loaded via ${enabled ? 'env' : 'config'}`;
+  log.debug(msg);
+  errors.push(msg);
 }
 
 // whether because explicitly disabled or an error get the essentials
 if (!bindings) {
   enabled = false
   bindings = require('./addon-sim')
-  // issue message that bindings are disabled intentionally
-  log.debug('appoptics-bindings intentionally disabled')
-  errors.push('bindings intentionally not loaded')
 }
 exports.addon = bindings
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,6 +131,8 @@ const defaults = {
     ignoreConflicts: false,
     domainPrefix: false,
     insertTraceIdsIntoLogs: false,
+    createTraceIdsToken: false,
+    insertTraceIdsIntoMorgan: false,
   }
 }
 
@@ -149,6 +151,13 @@ config = require('./parse-config')(config, defaults)
 exports.probes = config.probes
 exports.specialUrls = config.transactionSettings && config.transactionSettings.filter(s => s.type === 'url')
 exports.cfg = config = config.global
+
+// if inserting into morgan then a token must be created.
+// TODO BAM need to make config setter so this can be done even
+// when changed dynamically.
+if (config.insertTraceIdsIntoMorgan) {
+  config.createTraceIdsToken = true;
+}
 
 //
 // there isn't really a better place to put this

--- a/lib/probes/aws-sdk.js
+++ b/lib/probes/aws-sdk.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const shimmer = require('ximmer');
+const ao = require('..');
+const requirePatch = require('../require-patch');
+
+const logMissing = ao.makeLogMissing('aws-sdk');
+
+//function patchHandleRequest (proto) {
+//
+//  shimmer.wrap(proto, 'handleRequest', fn => {
+//    return function wrappedHandleRequest (httpRequest) {
+//      if (httpRequest) {
+//        if (!httpRequest.headers) {
+//          httpRequest.headers = Object.create(null);
+//        }
+//        httpRequest.headers[ao.omitTraceId] = true;
+//      } else {
+//        logMissing('httpRequest argument');
+//      }
+//
+//      return fn.apply(this, arguments);
+//    }
+//  })
+//}
+//
+//module.exports = function (awsSdk) {
+//  if (typeof awsSdk.NodeHttpClient !== 'function') {
+//    logMissing('NodeHttpClient()');
+//  } else if (typeof awsSdk.NodeHttpClient.prototype.handleRequest !== 'function') {
+//    logMissing('NodeHttpClient.prototype.handleRequest()');
+//  } else {
+//    patchHandleRequest(awsSdk.NodeHttpClient.prototype);
+//  }
+//  return awsSdk;
+//}
+
+module.exports = function (awsSdk) {
+  const signerV4 = requirePatch.relativeRequire('aws-sdk/lib/signers/v4');
+
+  if (!signerV4 || !signerV4.prototype || !Array.isArray(signerV4.prototype.unsignableHeaders)) {
+    logMissing('v4 unsignableHeaders');
+  } else {
+    signerV4.prototype.unsignableHeaders.push('x-trace');
+  }
+  return awsSdk;
+}

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -51,7 +51,7 @@ function patchClient (module, protocol) {
     } else if (typeof url.URL === 'function' && args[0] instanceof url.URL || args[0].searchParams) {
       options = urlToOptions(args.shift())
     } else  if (typeof url.URL !== 'function') {
-      ao.loggers.error('url.URL is not a function, url keys:', url === undefined ? 'undefined' : Object.keys(url))
+      log.error('url.URL is not a function, url keys:', url === undefined ? 'undefined' : Object.keys(url))
     }
 
     if (args[0] && typeof args[0] !== 'function') {

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -75,9 +75,11 @@ function patchClient (module, protocol) {
       span = last.descend(name)
       span.async = true
 
-      // Add X-Trace header to trace hops
-      options.headers = options.headers || {}
-      options.headers['X-Trace'] = span.events.entry.toString()
+      options.headers = options.headers || {};
+      // Add X-Trace header to trace hops unless omit is set.
+      if (!options.headers[ao.omitTraceId]) {
+        options.headers['x-trace'] = span.events.entry.toString();
+      }
 
       // Set default protocol
       options.protocol = options.protocol || protocol + ':'
@@ -187,7 +189,7 @@ function patchClient (module, protocol) {
 }
 
 //
-// patch the server - it creates a root span
+// patch the server - it creates a topLevel span
 //
 function patchServer (module, protocol) {
   const conf = ao.probes[protocol]

--- a/lib/probes/morgan.js
+++ b/lib/probes/morgan.js
@@ -7,7 +7,10 @@ const logMissing = ao.makeLogMissing('morgan');
 let token;
 
 //
-// patch morgan so the arguments can be mucked with
+// patch morgan so the arguments can be mucked with. this is a proxy
+// because 1) morgan is typically only called once or maybe twice and
+// 2) it will let us intercept token and format calls at some point if
+// we choose to do so.
 //
 module.exports = function (morgan) {
 
@@ -35,10 +38,10 @@ function getAutoTraceTokenString () {
   const last = ao.Event.last;
   const mode = ao.cfg.insertTraceIdsIntoMorgan;
   if ((!last && mode !== 'always') || !mode) {
-    return ' ';
-  // now there we know there is a last event.
+    return '';
+  // now we know there is a last event.
   } else if (mode === 'sampledOnly' && !last.event.getSampleFlag()) {
-    return ' ';
+    return '';
   }
   return ` ao.traceId=${ao.getFormattedTraceId()}`;
 }
@@ -83,13 +86,15 @@ function tryInsertion (morgan, args) {
   if (typeof fmt === 'function') {
     // the caller is passing a custom format function
     const wrapped = function () {
+      // generate the log line.
       const string = fmt.apply(this, arguments);
-      // don't apply this if it's already there - the format gets repetitive.
-      if (!string.endsWith(autoToken)) {
-        return `${string}${autoToken}`;
+      // don't apply this if it's already there - the function could have inserted it.
+      if (string.indexOf(ao.getFormattedTraceId()) >= 0) {
+        return string;
       }
-      return string;
+      return `${string}${getAutoTraceTokenString()}`;
     }
+    // substitute the wrapper for the caller's function.
     args[0] = wrapped;
     args[1] = opts;
   } else if (fmt in morgan) {

--- a/lib/probes/morgan.js
+++ b/lib/probes/morgan.js
@@ -1,31 +1,26 @@
 'use strict'
 
 const ao = require('..')
-//const conf = ao.probes.hapi
 
 const logMissing = ao.makeLogMissing('morgan');
 
+let token;
+
 //
-// patch morgan so the logs can be mucked with
-//
-// morgan, compile, format, token
+// patch morgan so the arguments can be mucked with
 //
 module.exports = function (morgan) {
-  //const {version} = requirePatch.relativeRequire('morgan/package.json')
-  let token
 
   const pmorgan = new Proxy(morgan, {
     // call target/morgan as a function
     apply (target, thisArg, argumentsList) {
       if (ao.cfg.insertTraceIdsIntoMorgan) {
+        argumentsList = tryInsertion(morgan, argumentsList);
+      } else if (ao.cfg.createTraceIdsToken === 'morgan') {
         if (!token) {
-          token = morgan.token('ao-trace-id', () => `ao.traceId=${ao.getFormattedTraceId()}`);
+          token = createToken(morgan);
         }
       }
-      if (ao.cfg.insertTraceIdsIntoMorgan) {
-        argumentsList = tryInsertion(morgan, argumentsList);
-      }
-
       return Reflect.apply(morgan, thisArg, argumentsList);
     },
   })
@@ -33,8 +28,39 @@ module.exports = function (morgan) {
   return pmorgan;
 }
 
-// try to insert the trace ID.
+//
+// get the string to insert into the morgan log output
+//
+function getAutoTraceTokenString () {
+  const last = ao.Event.last;
+  const mode = ao.cfg.insertTraceIdsIntoMorgan;
+  if ((!last && mode !== 'always') || !mode) {
+    return ' ';
+  // now there we know there is a last event.
+  } else if (mode === 'sampledOnly' && !last.event.getSampleFlag()) {
+    return ' ';
+  }
+  return ` ao.traceId=${ao.getFormattedTraceId()}`;
+}
+
+//
+// token creation
+//
+const autoToken = ':ao-auto-trace-id';
+
+function createToken (morgan) {
+  return morgan.token(`${autoToken.slice(1)}`, () => getAutoTraceTokenString())
+}
+
+//
+// try to insert the trace ID. this is where morgan's various calling
+// sequences get decoded.
+//
 function tryInsertion (morgan, args) {
+  // make sure the token is defined
+  if (!token) {
+    token = createToken(morgan);
+  }
 
   // the first argument can be a string name, a string format, or a custom format function.
   // it can also be an options argument (deprecated).
@@ -58,7 +84,11 @@ function tryInsertion (morgan, args) {
     // the caller is passing a custom format function
     const wrapped = function () {
       const string = fmt.apply(this, arguments);
-      return `${string} ao.traceId=${ao.insertLogObject().ao.traceId}`;
+      // don't apply this if it's already there - the format gets repetitive.
+      if (!string.endsWith(autoToken)) {
+        return `${string}${autoToken}`;
+      }
+      return string;
     }
     args[0] = wrapped;
     args[1] = opts;
@@ -76,7 +106,10 @@ function tryInsertion (morgan, args) {
         const dev = morgan.dev;
         const wrapped = function () {
           const string = dev.apply(this, arguments);
-          return `${string} ao.traceId=${ao.insertLogObject().ao.traceId}`;
+          if (!string.endsWith(autoToken)) {
+            return `${string}${autoToken}`;
+          }
+          return string;
         }
         morgan[fmt] = wrapped;
         args[0] = 'dev';
@@ -91,18 +124,22 @@ function tryInsertion (morgan, args) {
       // our token at the end. in this case modify the calling signature to the standard form
       // of morgan('format', options) not matter how it was originally called.
       if (typeof morgan[fmt] === 'string') {
-        morgan[fmt] = `${morgan[fmt]} :ao-trace-id`;
+        if (!morgan[fmt].endsWith(autoToken)) {
+          morgan[fmt] = `${morgan[fmt]}${autoToken}`;
+        }
       } else {
         // not sure we should do this. if the caller is supplying their own format they can
         // insert :ao-trace-id on their own. if they choose not to should we be inserting it?
         // TODO BAM note - this also applies to calling 'morgan.format' to define a format.
         //args[0] = `${fmt} ao.traceId=:ao-trace-id`;
         //args[1] = opts;
+        ao.loggers.debug('morgan.tryInsertion() - no action taken');
       }
     } else {
       logMissing(`expected fmt type (got ${typeof fmt})`);
     }
   }
+
   // return the possibly modified args.
   return args;
 }

--- a/lib/probes/morgan.js
+++ b/lib/probes/morgan.js
@@ -1,0 +1,129 @@
+'use strict'
+
+const ao = require('..')
+//const conf = ao.probes.hapi
+
+const logMissing = ao.makeLogMissing('morgan');
+
+//
+// patch morgan so the logs can be mucked with
+//
+// morgan, compile, format, token
+//
+module.exports = function (morgan) {
+  //const {version} = requirePatch.relativeRequire('morgan/package.json')
+  let token
+
+  const pmorgan = new Proxy(morgan, {
+    // get a property of target
+    //get (target, prop, receiver) {
+    //  const name = typeof prop === 'symbol' ? prop.toString() : prop;
+    //  console.log(`getting ${typeof prop}: ${name}`);
+    //  const thing = Reflect.get(...arguments);
+    //  if (prop === 'format') {
+    //    // hack the format
+    //  } else if (prop === 'compile') {
+    //    // hack the format
+    //  }
+    //  return thing;
+    //  //return Reflect.get(...arguments);
+    //},
+    //set (target, prop, value) {
+    //  console.log(`setting ${prop}`);
+    //  return Reflect.set(...arguments);
+    //},
+    // call target/morgan as a function
+    apply (target, thisArg, argumentsList) {
+      if (ao.cfg.insertTraceIdsIntoMorgan) {
+        if (!token) {
+          token = morgan.token('ao-trace-id', () => `ao.traceId=${ao.insertLogObject().ao.traceId}`);
+        }
+      }
+      if (ao.cfg.insertTraceIdsIntoMorgan) {
+        argumentsList = tryInsertion(morgan, argumentsList);
+      }
+
+      return Reflect.apply(morgan, thisArg, argumentsList);
+    },
+    // fetching the prototype?
+    //getPrototypeOf (target) {
+    //  console.log('getPrototypeOf()');
+    //  return morgan.prototype;
+    //}
+  })
+
+  return pmorgan;
+}
+
+// try to insert the trace ID.
+function tryInsertion (morgan, args) {
+
+  // the first argument can be a string name, a string format, or a custom format function.
+  // it can also be an options argument (deprecated).
+  // the following code is modeled directly after the morgan code to try to handle arguments
+  // as correctly as possible.
+  const [format, options] = args;
+  let fmt = format;
+  let opts = options || {};
+
+  if (format && typeof format === 'object') {
+    opts = format;
+    fmt = opts.format || 'default';
+  }
+
+  if (fmt === undefined) {
+    fmt = 'default';
+  }
+
+  if (typeof fmt === 'function') {
+    // the caller is passing a custom format function
+    const wrapped = function () {
+      const string = fmt.apply(this, arguments);
+      return `${string} ao.traceId=${ao.insertLogObject().ao.traceId}`;
+    }
+    args[0] = wrapped;
+    args[1] = opts;
+  } else if (fmt in morgan) {
+    // the format exists in morgan. it's kind of fragile though, morgan stores all
+    // tokens, formats, and it's own functions as properties on the morgan object so
+    // the fmt name could exist yet not be a format. but that's the way it works. if
+    // it's a function it could be a token, one of morgan's functions, or a compiled
+    // format. either way, all that can be done here is to wrap it. this is particularly
+    // true for the 'dev' format that is precompiled.
+    let needsWrapped = true;
+    if (typeof morgan[fmt] === 'function') {
+      // dev is the only precompiled format so it's the only one that needs to be wrapped.
+      if (fmt === 'dev' && needsWrapped) {
+        const dev = morgan.dev;
+        const wrapped = function () {
+          const string = dev.apply(this, arguments);
+          return `${string} ao.traceId=${ao.insertLogObject().ao.traceId}`;
+        }
+        morgan[fmt] = wrapped;
+        args[0] = 'dev';
+        args[1] = opts;
+        needsWrapped = false;
+      }
+    } else if (typeof fmt === 'string') {
+      // the format doesn't exist so this must be a format string or the property name for
+      // one of morgan's predefined format strings. that's the way morgan is going to interpret
+      // it regardless. that means that there is not going to be a referenceable function to
+      // wrap so the only way to insert our trace ID is to modify the format string by adding
+      // our token at the end. in this case modify the calling signature to the standard form
+      // of morgan('format', options) not matter how it was originally called.
+      if (typeof morgan[fmt] === 'string') {
+        morgan[fmt] = `${morgan[fmt]} :ao-trace-id`;
+      } else {
+        // not sure we should do this. if the caller is supplying their own format they can
+        // insert :ao-trace-id on their own. if they choose not to should we be inserting it?
+        // TODO BAM note - this also applies to calling 'morgan.format' to define a format.
+        //args[0] = `${fmt} ao.traceId=:ao-trace-id`;
+        //args[1] = opts;
+      }
+    } else {
+      logMissing(`expected fmt type (got ${typeof fmt})`);
+    }
+  }
+  // return the possibly modified args.
+  return args;
+}

--- a/lib/probes/morgan.js
+++ b/lib/probes/morgan.js
@@ -15,28 +15,11 @@ module.exports = function (morgan) {
   let token
 
   const pmorgan = new Proxy(morgan, {
-    // get a property of target
-    //get (target, prop, receiver) {
-    //  const name = typeof prop === 'symbol' ? prop.toString() : prop;
-    //  console.log(`getting ${typeof prop}: ${name}`);
-    //  const thing = Reflect.get(...arguments);
-    //  if (prop === 'format') {
-    //    // hack the format
-    //  } else if (prop === 'compile') {
-    //    // hack the format
-    //  }
-    //  return thing;
-    //  //return Reflect.get(...arguments);
-    //},
-    //set (target, prop, value) {
-    //  console.log(`setting ${prop}`);
-    //  return Reflect.set(...arguments);
-    //},
     // call target/morgan as a function
     apply (target, thisArg, argumentsList) {
       if (ao.cfg.insertTraceIdsIntoMorgan) {
         if (!token) {
-          token = morgan.token('ao-trace-id', () => `ao.traceId=${ao.insertLogObject().ao.traceId}`);
+          token = morgan.token('ao-trace-id', () => `ao.traceId=${ao.getFormattedTraceId()}`);
         }
       }
       if (ao.cfg.insertTraceIdsIntoMorgan) {
@@ -45,11 +28,6 @@ module.exports = function (morgan) {
 
       return Reflect.apply(morgan, thisArg, argumentsList);
     },
-    // fetching the prototype?
-    //getPrototypeOf (target) {
-    //  console.log('getPrototypeOf()');
-    //  return morgan.prototype;
-    //}
   })
 
   return pmorgan;
@@ -60,6 +38,7 @@ function tryInsertion (morgan, args) {
 
   // the first argument can be a string name, a string format, or a custom format function.
   // it can also be an options argument (deprecated).
+  //
   // the following code is modeled directly after the morgan code to try to handle arguments
   // as correctly as possible.
   const [format, options] = args;

--- a/lib/probes/winston.js
+++ b/lib/probes/winston.js
@@ -23,9 +23,6 @@ function patchWrite (write) {
 //
 function patchLog (log) {
   return function addTraceId (level, message, meta, cb) {
-    if (!ao.Event.last || !arguments.length) {
-      return log.apply(this, arguments);
-    }
 
     // if there is an object argument (meta) add the trace ID to it
     for (let i = 0; i < arguments.length; i++) {

--- a/lib/span.js
+++ b/lib/span.js
@@ -369,6 +369,8 @@ Span.prototype.enter = function (data) {
 Span.prototype.exit = function (data) {
   log.span('span.exit called for %e', this.events.exit);
   if (this.topSpan) {
+    ao.requestStore.set('topSpan', undefined);
+    Span.last = null;
     Span.entrySpanExits += 1
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -373,6 +373,23 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "aws-sdk": {
+      "version": "2.444.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.444.0.tgz",
+      "integrity": "sha512-3vdC7l5BJ3zHzVNgtIxD+TDviti/sAA/1T8zAXAm2XhZ7AePR5lYIMNAwqu+J44Nm6PFSK1QNSzRQ6A4/6b9eA==",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -402,6 +419,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -1109,6 +1132,25 @@
       "resolved": "http://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
       "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU=",
       "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
     },
     "buffer-alloc": {
       "version": "1.2.0",
@@ -2026,6 +2068,12 @@
       "resolved": "https://registry.npmjs.org/event-pre-handler/-/event-pre-handler-1.0.1.tgz",
       "integrity": "sha512-Po2p38PLl8R0ki+7TnKUNA1LsKVv8kLX1+MWo44mhTx3McX2qdMJNTUYsZklMqltuMgZZKJsWiKnShDpV0XdjA=="
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
     "ewma": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ewma/-/ewma-2.0.1.tgz",
@@ -2600,6 +2648,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
+    },
     "indent-string": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
@@ -2759,6 +2813,12 @@
       "requires": {
         "retry": "0.6.0"
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "joi": {
       "version": "14.3.1",
@@ -5247,6 +5307,12 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
     "querystringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
@@ -5597,6 +5663,12 @@
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -6572,6 +6644,24 @@
       "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==",
       "dev": true
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
     "url-parse": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
@@ -6824,6 +6914,22 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ximmer/-/ximmer-1.2.1.tgz",
       "integrity": "sha512-ObE7WE4D4fGQ2dm6XDY1x0EoBAbtmw1abXYJSdVt4Fe6B1dW2/qS7Yb3P+glh7bEapY/bC3p+/L9CO5kyoZIvw=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
     },
     "xmlcreate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.3.0-rc5",
+  "version": "6.3.0-rc6",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.3.0-rc1",
+  "version": "6.3.0-rc2",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.3.0-rc2",
+  "version": "6.3.0-rc3",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.3.0-rc6",
+  "version": "6.3.0",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.2.1",
+  "version": "6.3.0-rc",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.3.0-rc3",
+  "version": "6.3.0-rc5",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {
@@ -54,6 +54,7 @@
   "devDependencies": {
     "amqp": "^0.2.6",
     "amqplib": "^0.5.3",
+    "aws-sdk": "^2.440.0",
     "bcrypt": "^3.0.4",
     "bluebird": "^3.5.3",
     "body-parser": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.3.0-rc",
+  "version": "6.3.0-rc1",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/test/helper.js
+++ b/test/helper.js
@@ -104,7 +104,7 @@ exports.appoptics = function (done) {
     const parsed = BSON.deserialize(msg)
     log.test.messages('mock appoptics (port ' + port + ') received', parsed)
     if (emitter.log) {
-      console.log(parsed)
+      console.log(parsed)     // eslint-disable-line no-console
     }
     emitter.emit('message', parsed)
 
@@ -277,7 +277,8 @@ exports.test = function (emitter, test, validations, done) {
   }
 
   ao.requestStore.run(function () {
-    const span = ao.Span.makeEntrySpan('outer', exports.makeSettings({doSample: ao.traceMode}))
+    const template = {doSample: ao.traceMode === 'enabled', doMetrics: ao.traceMode === 'enabled'};
+    const span = ao.Span.makeEntrySpan('outer', exports.makeSettings(template))
     // span.async = true
     log.test.span('helper.test outer: %l', span)
     log.test.info('test starting')

--- a/test/probes/aws-sdk.test.js
+++ b/test/probes/aws-sdk.test.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const {ao} = require('../1.test-common.js'); // eslint-disable-line
+const expect = require('chai').expect;
+
+const aws = require('aws-sdk');
+const pkg = require('aws-sdk/package');
+
+describe(`probes/aws-sdk ${pkg.version}`, function () {
+  it('should have included \'x-trace\' in unsignableHeaders', function () {
+    expect(aws.Signers.V4.prototype).property('unsignableHeaders');
+    expect(aws.Signers.V4.prototype.unsignableHeaders).include('x-trace');
+  })
+})

--- a/test/probes/bunyan.test.js
+++ b/test/probes/bunyan.test.js
@@ -77,6 +77,7 @@ function makePost (obj) {
   return Object.assign({}, template2, obj);
 }
 
+// if no traceId is passed then don't expect {ao: {traceId}}
 function checkEventInfo (eventInfo, level, message, traceId) {
   // check time first because it's not a straight compare
   expect(eventInfo.time.valueOf()).within(Date.now() - 150, Date.now() + 100);
@@ -122,6 +123,8 @@ function getTraceIdString () {
   // 2 task, 16 sample bit, 32 separators
   return firstEvent.toString(2 | 16 | 32);
 }
+
+const insertModes = [false, true, 'traced', 'sampledOnly', 'always'];
 
 
 //=================================
@@ -185,8 +188,13 @@ describe(`bunyan v${version}`, function () {
   // Intercept appoptics messages for analysis
   //
   beforeEach(function (done) {
+    // make sure we get sampled traces
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
+    // default to the simple 'true'
+    ao.cfg.insertTraceIdsIntoLogs = true;
+    ao.probes.fs.enabled = false;
+
     emitter = helper.appoptics(done)
   })
   afterEach(function (done) {
@@ -207,34 +215,85 @@ describe(`bunyan v${version}`, function () {
     ], done)
   })
 
-  it('should insert trace IDs in synchronous instrumented code', function (done) {
-    const level = 'info';
-    const message = 'synchronous instrumentation';
-    let traceId;
+  insertModes.forEach(mode => {
+    const maybe = mode === false ? 'not ' : '';
+    eventInfo = undefined;
 
-    function localDone () {
-      checkEventInfo(eventInfo, level, message, traceId);
-      done();
-    }
+    it(`should ${maybe}insert in sync sampled code when mode=${mode}`, function (done) {
+      const level = 'info';
+      const message = `synchronous traced setting = ${mode}`;
+      let traceId;
 
-    helper.test(emitter, function (done) {
-      ao.instrument(spanName, function () {
+      // this gets reset in beforeEach() so set it in the test.
+      ao.cfg.insertTraceIdsIntoLogs = mode;
+
+      function localDone () {
+        // if not trace
+        checkEventInfo(eventInfo, level, message, mode === false ? undefined : traceId);
+        done();
+      }
+
+      helper.test(emitter, function (done) {
+        ao.instrument(spanName, function () {
+          traceId = getTraceIdString();
+          // log
+          logger.info(message);
+        })
+        done()
+      }, [
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'entry')
+        },
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'exit')
+        }
+      ], localDone)
+    })
+  })
+
+  insertModes.forEach(mode => {
+    const maybe = (mode === 'sampledOnly' || mode === false) ? 'not ' : '';
+
+    it(`should ${maybe}insert in sync unsampled code when mode=${mode}`, function () {
+      const level = 'info';
+      const message = `synchronous traced setting = ${mode}`;
+      let traceId;
+
+      // reset in beforeEach() so set in each test.
+      ao.cfg.insertTraceIdsIntoLogs = mode;
+      ao.traceMode = 0;
+      ao.sampleRate = 0;
+
+      function test () {
         traceId = getTraceIdString();
+        expect(traceId[traceId.length - 1] === '0', 'traceId should be unsampled');
         // log
         logger.info(message);
-      })
-      done()
-    }, [
-      function (msg) {
-        msg.should.have.property('Layer', spanName)
-        msg.should.have.property('Label', 'entry')
-      },
-      function (msg) {
-        msg.should.have.property('Layer', spanName)
-        msg.should.have.property('Label', 'exit')
+
+        return 'test-done';
       }
-    ], localDone)
+
+      const xtrace = ao.addon.Metadata.makeRandom(0).toString()
+      const result = ao.startOrContinueTrace(xtrace, spanName, test);
+
+      expect(result).equal('test-done');
+      checkEventInfo(eventInfo, level, message, maybe ? undefined : traceId);
+    })
   })
+
+  it('mode=\'always\' should always insert a trace ID even if not tracing', function () {
+    const level = 'info';
+    const message = 'always insert';
+
+    ao.cfg.insertTraceIdsIntoLogs = 'always';
+
+    logger.info(message);
+
+    checkEventInfo(eventInfo, level, message, `${'0'.repeat(40)}-0`);
+  })
+
 
   it('should insert trace IDs in asynchronous instrumented code', function (done) {
     const level = 'error';

--- a/test/probes/bunyan.test.js
+++ b/test/probes/bunyan.test.js
@@ -14,6 +14,11 @@ const major = semver.major(version);
 
 const {EventEmitter} = require('events');
 
+// helpful:
+// https://medium.com/@tobydigz/logging-in-a-node-express-app-with-morgan-and-bunyan-30d9bf2c07a
+
+// various outputs format from running manually:
+//
 //> child.info('message to love')
 //{"level": 30, "time": 1554384912925, "pid": 31188, "hostname": "uxpanapa", "a": 100, "msg": "message to love", "v": 1}
 //undefined

--- a/test/probes/winston.test.js
+++ b/test/probes/winston.test.js
@@ -15,7 +15,7 @@ if (major < 1 || major > 3) {
 let testTransport;
 let createLogger;
 
-const debugging = true;
+const debugging = false;
 
 //===============================================================
 // version 3

--- a/test/utility/async-dump.js
+++ b/test/utility/async-dump.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const {createHook} = require('async_hooks');
+const {stackTraceFilter} = require('mocha/lib/utils');
+const allResources = new Map();
+
+// consider using wtfnode.
+
+// this will pull Mocha internals out of the stacks
+const filterStack = stackTraceFilter();
+
+const hook = createHook({
+  init (asyncId, type, triggerAsyncId) {
+    allResources.set(asyncId, {type, triggerAsyncId, stack: (new Error()).stack});
+  },
+  destroy (asyncId) {
+    allResources.delete(asyncId);
+  }
+}).enable();
+
+global.asyncDump = module.exports = () => {
+  hook.disable();
+  /* eslint-disable no-console */
+  console.error('STUFF STILL IN THE EVENT LOOP:');
+  allResources.forEach(value => {
+    console.error(`Type: ${value.type}`);
+    console.error(filterStack(value.stack));
+    console.error('\n');
+  });
+};


### PR DESCRIPTION
- aws-sdk fix
- improve "task IDs don't match" logging
- full log insertion support and tests (morgan, winston, pino, bunyan)
- set ao.cfg.serviceKey to service key actually used
- delete requestStore.topSpan on top span exit
- fix reversed API docs