### PR TITLE
lib/api.js - minor fixes

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -235,7 +235,7 @@ function definePropertiesOn (ao) {
       if (!ao.clsCheck()) {
         const e = new Error('CLS NOT ACTIVE')
         log.bind('ao.bind(%s) - no context', name, e.stack)
-      } else if (!exports.tracing) {
+      } else if (!ao.tracing) {
         log.bind('ao.bind(%s) - not tracing', name)
       } else if (fn !== undefined) {
         const e = new Error('Not a function')
@@ -264,7 +264,7 @@ function definePropertiesOn (ao) {
         // allow binding if tracing or an http emitter (duck-typing check). no
         // last event has been setup when the http instrumentation binds the
         // events but there must be CLS context.
-        if (ao.tracing || (ao.clsCheck() && (em.headers && em.socket))) {
+        if (ao.tracing || ao.clsCheck() && em.socket) {
           ao.requestStore.bindEmitter(em)
           return em
         }

--- a/test/docker/mac-os-test-env/dc.sh
+++ b/test/docker/mac-os-test-env/dc.sh
@@ -9,7 +9,7 @@ case $action in
     ps)
 	docker-compose ps
 	;;
-	test)
+    test)
 	docker-compose down -v --remove-orphans
 	docker-compose run --service-ports --rm --name node_main node_main test/docker/mac-os-test-env/start.sh
 	;;

--- a/test/docker/main.yml
+++ b/test/docker/main.yml
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get -y install gcc-4.9 g++-4.9 \
 && rm -rf /var/lib/apt/lists/*
 
 # get node
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get install -y nodejs
 
 #ENV NVM_VERSION=v0.33.8

--- a/test/docker/main.yml
+++ b/test/docker/main.yml
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get -y install gcc-4.9 g++-4.9 \
 && rm -rf /var/lib/apt/lists/*
 
 # get node
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 
 #ENV NVM_VERSION=v0.33.8


### PR DESCRIPTION
- use ao object, not exports
- loosen emitter check

The loosen emitter check is because web sockets end up with scenarios in which there are not headers in the object. It's a fair question whether bindEmitter() should accept any emitter-like object, i.e., one with an `on` method. At this time the only use is for http client/server and this is sufficient. Maybe have specific calls for `bindHttpReq`, `bindHttpRes`, `bindXyzzy` when other objects need to be supported.