### PR TITLE
use native function for prepending listeners [AO-12085]

### DIFF
--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const patchEmitter = require('event-pre-handler')
 const shimmer = require('ximmer')
 const url = require('url')
 const os = require('os')
@@ -124,14 +123,12 @@ function patchClient (module, protocol) {
       ret = fn(...args)
 
       try {
-        // Patch emitter
-        patchEmitter(ret)
 
         // Report socket errors
-        ret._preHandle('error', error => span.error(error))
+        ret.prependListener('error', error => span.error(error));
 
         // Ensure our exit is pushed to the FRONT of the event list
-        ret._preHandle('response', res => {
+        ret.prependListener('response', res => {
           // Continue from X-Trace header, if present
           const xtrace = res.headers['x-trace']
           // validate that task ID matches and op ID is not all zeros.
@@ -152,11 +149,9 @@ function patchClient (module, protocol) {
             }
           }
 
-          // Patch emitter
-          patchEmitter(res)
 
           // Report socket errors
-          res._preHandle('error', error => last.error(error))
+          res.prependListener('error', error => last.error(error));
 
           // Send exit event with response status
           span.exit({
@@ -164,7 +159,7 @@ function patchClient (module, protocol) {
           })
         })
       } catch (e) {
-        log.error('cannot patch http-client request emitter')
+        log.error('cannot patch http-client request emitter', e)
       }
     })
 
@@ -237,12 +232,6 @@ function patchServer (module, protocol) {
 
     const args = arguments
     try {
-      // Patch request and response emitters to support unshifting
-      patchEmitter(req)
-      patchEmitter(res)
-      if (!patchEmitter(res.socket)) {
-        log.warn('probes/http - res.socket not present')
-      }
 
       /*
       // Bind streams to the request store
@@ -344,12 +333,13 @@ function patchServer (module, protocol) {
 
   function wrapRequestResponse (span, req, res) {
     // Report socket errors
-    req._preHandle('error', error => span.error(error))
-    res._preHandle('error', error => span.error(error))
+    req.prependListener('error', error => span.error(error));
+    res.prependListener('error', error => span.error(error));
 
     // Ensure response is patched and add exit finalizer
     ao.patchResponse(res)
-    ao.addResponseFinalizer(res, () => {
+
+    ao.addResponseFinalizer(res, ao.bind(() => {
       const {last} = Event
       if (last && last !== span.events.entry && !last.Async) {
         span.events.exit.edges.push(last)
@@ -422,7 +412,7 @@ function patchServer (module, protocol) {
 
       span.exit(exitKeyValuePairs)
 
-    })
+    }))
 
     span.enter()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1704,11 +1704,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
-    },
-    "event-pre-handler": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/event-pre-handler/-/event-pre-handler-1.0.1.tgz",
-      "integrity": "sha512-Po2p38PLl8R0ki+7TnKUNA1LsKVv8kLX1+MWo44mhTx3McX2qdMJNTUYsZklMqltuMgZZKJsWiKnShDpV0XdjA=="
     },
     "events": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {
@@ -44,7 +44,6 @@
     "cls-hooked": "^4.2.2",
     "continuation-local-storage": "^3.2.1",
     "debug-custom": "^1.0.5",
-    "event-pre-handler": "^1.0.1",
     "glob": "^7.0.3",
     "methods": "~1.1.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
- use emitter.prependListener()
- replaces event-pre-handler.js/patchEmitter()

I'm going to base trigger trace work on this branch because they both fiddle primarily with lib/probes/http.js.

