### PR TITLE
6.7.1 candidate

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -576,7 +576,7 @@ function instrumentHttp (build, run, options, res) {
 
   if (span) {
     span.enter()
-    ao.addResponseFinalizer(res, () => {
+    ao.addResponseFinalizer(res, ao.bind(() => {
       span.exit()
       try {
         if (ctx) {
@@ -587,7 +587,7 @@ function instrumentHttp (build, run, options, res) {
       } catch (e) {
         ao.loggers.error('instrumentHttp failed to exit span %l', span)
       }
-    })
+    }));
   }
 
   try {

--- a/lib/probes/@hapi/hapi.js
+++ b/lib/probes/@hapi/hapi.js
@@ -90,6 +90,9 @@ function wrapPrepare (request) {
       const TemplateFile = response.source.template;
 
       let TemplateLanguage = path.extname(TemplateFile);
+      if (TemplateLanguage[0] === '.') {
+        TemplateLanguage = TemplateLanguage.slice(1);
+      }
       if (!TemplateLanguage) {
         if (response.source.manager) {
           TemplateLanguage = response.source.manager._defaultExtension;
@@ -158,11 +161,17 @@ function wrapRender (render, version) {
 
     return ao.instrument(
       () => {
+        let extension = path.extname(filename);
+        if (extension) {
+          extension = extension.slice(1);
+        } else {
+          extension = this._defaultExtension;
+        }
         return {
           name: 'hapi-render',
           kvpairs: {
             TemplateFile: filename,
-            TemplateLanguage: path.extname(filename) || this._defaultExtension,
+            TemplateLanguage: extension,
           }
         }
       },

--- a/lib/probes/zlib.js
+++ b/lib/probes/zlib.js
@@ -77,8 +77,8 @@ function wrapConstructor (proto, name) {
   }
   shimmer.wrap(proto, name, Real => {
     function WrappedZlib (options) {
+      const last = Span.last;
       try {
-        const last = Span.last
         if (last && conf.enabled && !spans.get(this)) {
           const span = last.descend('zlib', makeKvPairs(name, options))
           spans.set(this, span)
@@ -89,7 +89,8 @@ function wrapConstructor (proto, name) {
         ao.loggers.error('zlib failed to enter span', e)
       }
 
-      Real.call(ao.bindEmitter(this), options)
+      const em = last ? ao.bindEmitter(this) : this;
+      Real.call(em, options)
     }
     inherits(WrappedZlib, Real)
     wrapClassEmit(WrappedZlib.prototype)
@@ -127,7 +128,7 @@ function wrapClass (proto, name) {
   wrapCreator(proto, name)
 }
 
-function wrapMethods (proto, name) {
+function wrapMethod (proto, name) {
   if (typeof proto[name] === 'function') {
     shimmer.wrap(proto, name, fn => function (...args) {
       const cb = args.pop()
@@ -162,6 +163,6 @@ function wrapMethods (proto, name) {
 
 module.exports = function (zlib) {
   classes.forEach(name => wrapClass(zlib, name))
-  methods.forEach(method => wrapMethods(zlib, method))
+  methods.forEach(method => wrapMethod(zlib, method))
   return zlib
 }

--- a/test/probes/hapi/hapi-16-and-below.js
+++ b/test/probes/hapi/hapi-16-and-below.js
@@ -33,7 +33,7 @@ if (semver.satisfies(nodeVersion, '> 0.8')) {
 
 describe('probes.hapi ' + pkg.version + ' vision ' + visionPkg.version, function () {
   let emitter
-  let port = 3000
+  let port = 3500;
 
   //
   // Intercept appoptics messages for analysis

--- a/test/probes/vision/vision-4-and-below.js
+++ b/test/probes/vision/vision-4-and-below.js
@@ -33,7 +33,7 @@ if (semver.satisfies(nodeVersion, '> 0.8')) {
 
 describe('probes.vision ' + pkg.version + ' hapi ' + hapiPkg.version, function () {
   let emitter
-  let port = 3000
+  let port = 3500;
 
   //
   // Intercept appoptics messages for analysis

--- a/test/probes/vision/vision-5-and-above.js
+++ b/test/probes/vision/vision-5-and-above.js
@@ -44,7 +44,7 @@ if (semver.gte(pkg.version, '5.0.0')) {
 
 describe(`probes.${visionName} ${pkg.version} ${hapiText}`, function () {
   let emitter
-  let port = 3000
+  let port = 3500;
 
   //
   // Intercept appoptics messages for analysis


### PR DESCRIPTION
AO-14149

- update `guides/configuration.md`.
- bind context for response finalizer in `instrumentHttp`.
- `lib/probes/@hapi/hapi.js` - consistently report template language without dot.
- `lib/probes/zlib.js` - only bind emitter when context exists.
- `test/` various - use port 3500 to avoid conflicts with commonly used 3000.
- `test/probes/hapi/hapi-17-and-above.js` - add `zlib` testing and fix when invalid `vision` plugin.

