### PR TITLE
lib/probe/http - prevent undefined TransactionName

### DIFF
--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -11,6 +11,9 @@ const Event = ao.Event
 
 const log = ao.loggers
 
+// avoid issuing too many errors on bad transactions
+const dbSendError = new log.Debounce('error');
+
 const ule = Symbol('UnexpectedLastEvent');
 
 const defaultPort = {
@@ -523,24 +526,26 @@ function patchServer (module, protocol) {
         // it replies with the txname that was actually used if there was an error
         const txname = ao.reporter.sendHttpSpan(args);
 
-        // they should match (except for the domain prefix)
-        if (txname && args.txname && txname !== args.txname
-          && ao.cfg.domainPrefix
-          && txname.indexOf(args.txname) + args.txname.length !== txname.length) {
-          log.warn(
-            'sendHttpSpan() changed TransactionName from %s to %s',
-            args.txname,
-            txname
-          )
+        if (typeof txname === 'string') {
+          // if there is a txname and it doesn't match
+          // TODO BAM the txname check can be removed once appoptics-bindings has been
+          // changed to return the integer error code instead of a null string.
+          if (txname && args.txname && txname !== args.txname) {
+            // here the names don't match so we might need to log a warning.
+            // if there isn't a domain prefix warn about the difference and if there
+            // is a domain prefix warn if the trailing txname doesn't match.
+            if (!ao.cfg.domainPrefix || !txname.endsWith(txname)) {
+              log.warn(`sendHttpSpan() changed TransactionName from ${args.txname} to ${txname}`);
+            }
+          }
+
+          // if it's a string the worst it can be is an empty string.
+          exitKeyValuePairs.TransactionName = txname;
+        } else {
+          exitKeyValuePairs.TransactionName = args.txname || 'unknown';
+          dbSendError.log(`sendHttpSpan() code ${txname}`);
         }
 
-        // what to do if an error sending? don't know transaction name but shouldn't
-        // matter, so don't use the return value.
-        if (txname) {
-          exitKeyValuePairs.TransactionName = txname
-        } else {
-          log.error('sendHttpSpan() returned empty TransactionName')
-        }
       }
 
       span.exit(exitKeyValuePairs)

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -526,11 +526,11 @@ function patchServer (module, protocol) {
         // it replies with the txname that was actually used if there was an error
         const txname = ao.reporter.sendHttpSpan(args);
 
-        if (typeof txname === 'string') {
+        // TODO BAM the txname not null check can be removed once appoptics-bindings has been
+        // changed to return the integer error code instead of a null string.
+        if (typeof txname === 'string' && txname) {
           // if there is a txname and it doesn't match
-          // TODO BAM the txname check can be removed once appoptics-bindings has been
-          // changed to return the integer error code instead of a null string.
-          if (txname && args.txname && txname !== args.txname) {
+          if (args.txname && txname !== args.txname) {
             // here the names don't match so we might need to log a warning.
             // if there isn't a domain prefix warn about the difference and if there
             // is a domain prefix warn if the trailing txname doesn't match.


### PR DESCRIPTION
- supply a default when there is no TransactionName. [AO-14454]
- prepare for a numeric code return on errors [AO-14437]
- debounce the error logging.

The second item requires an appropriate release of appoptics-bindings.

[AO-14454]: https://swicloud.atlassian.net/browse/AO-14454

[AO-14437]: https://swicloud.atlassian.net/browse/AO-14437