### PR TITLE
lib/probes/mongodb-core - node version check

### DIFF
--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -1,12 +1,24 @@
 'use strict'
 
+const semver = require('semver');
 const shimmer = require('ximmer')
-const ao = require('..')
-const conf = ao.probes['mongodb-core']
+
+const ao = require('..');
+const requirePatch = require('../require-patch');
+const conf = ao.probes['mongodb-core'];
+
+const pkg = requirePatch.relativeRequire('mongodb-core/package.json');
+const version = pkg.version;
 
 const logMissing = ao.makeLogMissing('mongodb-core')
 
 module.exports = function (mongodb) {
+
+  // node 12 with mongodb-core prior to v3 exhibits a memory leak with cls-hooked.
+  if (semver.gte(process.version, '11.0.0') && semver.lt(version, '3.0.0')) {
+    ao.loggers.patching(`disabling mongodb-core probe for node version ${process.version}`);
+    return mongodb;
+  }
 
   // Patch Server
   {

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -14,6 +14,11 @@ requirePatch.disable()
 const pkg = require('mongodb-core/package.json')
 requirePatch.enable()
 
+// just because it's not really documented particularly well in mongo docs
+// the namespace argument (the first argument, a string, to most calls) is
+// `database-name.collection-name` and the `$cmd` collection is a special
+// collection against which
+
 // need to make decisions based on major version
 const majorVersion = semver.major(pkg.version)
 
@@ -149,6 +154,7 @@ function makeTests (db_host, host, isReplicaSet) {
     }
 
     server.on('error', function (err) {
+      // eslint-disable-next-line no-console
       console.log('error connecting', err)
       done()
     })


### PR DESCRIPTION
- don't instrument node > 10 if version < 3.0.0 [AO-14456]
- explain 'db.collection' syntax in commands (in test/probes/mongodb-core.test.js)

[AO-14456]: https://swicloud.atlassian.net/browse/AO-14456