### PR TITLE
fix duplicate logging when ao.getTraceSettings() encounters an error [AO-14457]

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -11,6 +11,7 @@ let Span;
 
 let dbBind;
 let dbInfo;
+let dbSettingsError;
 
 const udp = process.env.APPOPTICS_REPORTER === 'udp';
 
@@ -26,6 +27,7 @@ module.exports = function (appoptics) {
   // create the debounced loggers
   dbBind = new log.Debounce('bind');
   dbInfo = new log.Debounce('info');
+  dbSettingsError = new log.Debounce('error');
 
   // keep weakmap references in a central place.
   ao.maps.responseIsPatched = responseIsPatched;
@@ -349,6 +351,7 @@ function readyToSample (ms, obj) {
   return status === 1
 }
 
+
 /**
  * @typedef {object} TraceSettings
  * @property {boolean} doSample - the sample decision
@@ -396,7 +399,7 @@ function getTraceSettings (xtrace, options = {}) {
   ao.lastSettings = osettings
 
   if (osettings.status > 0) {
-    ao.loggers.warn(`getTraceSettings() - ${osettings.message}(${osettings.status})`)
+    dbSettingsError.log(`getTraceSettings() - ${osettings.message}(${osettings.status})`)
     // if an error it's not clear which properties will be set. make sure values exist.
     osettings = Object.assign({
       doSample: false,

--- a/lib/api.js
+++ b/lib/api.js
@@ -396,7 +396,7 @@ function getTraceSettings (xtrace, options = {}) {
   ao.lastSettings = osettings
 
   if (osettings.status > 0) {
-    ao.loggers.warn(`getTraceSettings() - ${osettings.message}(${osettings.error})`)
+    ao.loggers.warn(`getTraceSettings() - ${osettings.message}(${osettings.status})`)
     // if an error it's not clear which properties will be set. make sure values exist.
     osettings = Object.assign({
       doSample: false,

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -305,10 +305,6 @@ function patchServer (module, protocol) {
     //
     const settings = ao.getTraceSettings(xtrace, settingsOptions);
 
-    if (settings.status > 0) {
-      log.error(`error fetching settings: ${settings.message} (${settings.status})`);
-    }
-
     const args = arguments;
 
     if (ao.Event.last) {


### PR DESCRIPTION
1. remove logging from lib/probes/http.js for getTraceSettings()
1. fix use of incorrect status code in lib/api/getTraceSettings().
2. debounce getTraceSettings() logging in api
