### PR TITLE
loggers - reset both count and time on logging [AO-14438]

### DIFF
--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -40,18 +40,15 @@ function Debounce (level, options) {
 }
 
 Debounce.prototype.show = function () {
-  // have the number of incremental errors exceeded the delta limit?
-  if ((this.count - this.lastCount) > this.dCount) {
-    this.lastCount = this.count
-    return true
+  const now = Date.now();
+  // has the count of errors exceeded the delta limit or the time
+  // window been exceeded?
+  if ((this.count - this.lastCount) > this.dCount || (now - this.lastTime) > this.dTime) {
+    this.lastCount = this.count;
+    this.lastTime = now;
+    return true;
   }
-  // has it been dTime miliseconds since the last?
-  const now = Date.now()
-  if ((now - this.lastTime) > this.dTime) {
-    this.lastTime = now
-    return true
-  }
-  return false
+  return false;
 }
 
 Debounce.prototype.log = function () {

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -91,26 +91,26 @@ describe('logging', function () {
   it('should debounce repetitive logging by count', function () {
     const msg = 'test logging'
     const aolevel = 'error'
-    let debounced = new ao.loggers.Debounce('error')
+    let debounced = new ao.loggers.Debounce(aolevel);
     let count = 0
     let i
     debug.log = function (output) {
       const [level, text] = getLevelAndText(output)
       expect(level).equal('appoptics:' + aolevel)
-      expect(text).equal('[' + (i + 1) + ']' + msg)
-      count += 1
+      expect(text).equal(`[${i + 1}]${msg}`);
+      count += 1;
     }
     for (i = 0; i < 1000; i++) {
       debounced.log(msg)
     }
-    expect(count).equal(11)
+    expect(count).equal(10);
 
-    debounced = new ao.loggers.Debounce('error', {deltaCount: 500})
+    debounced = new ao.loggers.Debounce(aolevel, {deltaCount: 500});
     count = 0
     for (i = 0; i < 1000; i++) {
       debounced.log(msg)
     }
-    expect(count).equal(3)
+    expect(count).equal(2);
   })
 
   it('should debounce repetitive logging by time', function (done) {


### PR DESCRIPTION
- when a log entry is generated reset both the count and time-window start.
- fix tests that previously were broken because of the previous item.