### PR TITLE
lib/span.js - handle error code return [AO-14337]

### DIFF
--- a/lib/span.js
+++ b/lib/span.js
@@ -3,6 +3,7 @@
 const Event = require('./event')
 let ao;
 let log;
+let dbSendError;
 
 /**
  * Create an execution span.
@@ -503,9 +504,21 @@ Span.sendNonHttpSpan = function (txname, duration, error) {
     error: !!error
   }
 
-  const finalTxName = ao.reporter.sendNonHttpSpan(args)
+  const finalTxName = ao.reporter.sendNonHttpSpan(args);
 
-  return finalTxName
+  // if it's good and not a null string return it.
+  if (typeof finalTxName === 'string' && finalTxName) {
+    return finalTxName;
+  }
+
+  // if it wasn't a string then it should be a numeric code. worst
+  // case is that it is a null string.
+  dbSendError.log(`sendNonHttpSpan() code ${finalTxName}`);
+
+
+  // try to return a valid transaction name of some sort. it doesn't really
+  // matter because it wasn't sent no matter what it was.
+  return args.txname || 'unknown';
 }
 
 //
@@ -549,11 +562,12 @@ Span.toError = function (error) {
   }
 }
 
-//
-
+// because this module is invoked before the ao object is initialized
+// data required from ao must be deferred until init is called.
 Span.init = function (populatedAo) {
   ao = populatedAo;
   log = ao.loggers;
+  dbSendError = new ao.loggers.Debounce('error');
 }
 
 module.exports = Span;


### PR DESCRIPTION
- aob.reporter.sendNonHttpSpan() can now return a numeric code
- log an error (debounced) if it occurs.