### PR TITLE
mongodb probe [AO-14417]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,19 @@ are many different ways to do so ranging from npm's `link` command, manually cop
 options embedded in the npm `postinstall` script, `install-appoptics-bindings.js`. The primary
 documentation for this advanced feature is the code.
 
+### Testing against all supported versions of the package
+
+When a probe has been updated all supported versions of a package must be tested. The package `testeachversion`
+facilitates this. `test/versions.js` defines the supported versions for each package we supply probes for. `testeachversion`
+uses this file by default. To test all supported versions of a given package use the command:
+
+`node_modules/.bin/testeachversion -p package-name`
+
+If you don't specify the `-p package-name` option, all supported versions of all packages will be tested. That
+takes a while. `testeachversion` writes two files, a details file and a summary file. More information and options
+is available via `testeachversion -h`.
+
+
 
 ## Docs
 

--- a/lib/probe-defaults.js
+++ b/lib/probe-defaults.js
@@ -209,14 +209,20 @@ module.exports = {
     collectBacktraces: true,
   },
 
+  // patches aws so it doesn't include the x-trace header in its integrity check.
+  // it's only an issue if an error occurs and the message is retransmitted.
+  // like the context-maintaining modules this cannot be disabled; the setting is
+  // ignored.
+  'aws-sdk': {enabled: true},
+
   //
   // context maintaining modules. they cannot be disabled and are listed
   // for completeness.
   //
-  'aws-sdk': {enabled: true},
   bcrypt: {enabled: true},
   bluebird: {enabled: true},
   'generic-pool': {enabled: true},
+  mongoose: {enabled: true},
   q: {enabled: true},
 
 

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -4,6 +4,10 @@ const shimmer = require('ximmer')
 const ao = require('..')
 const conf = ao.probes['mongodb-core']
 
+const requirePatch = require('../require-patch');
+
+const version = requirePatch.relativeRequire('mongodb-core/package.json').version;
+
 const logMissing = ao.makeLogMissing('mongodb-core')
 
 module.exports = function (mongodb) {
@@ -48,7 +52,7 @@ module.exports = function (mongodb) {
     }
   }
 
-  return mongodb
+  return [mongodb, version];
 }
 
 function makeWrapper (obj, name, addData) {
@@ -164,13 +168,20 @@ function notUndef (...args) {
 }
 
 function serverDetails ({s = {}}) {
+  let o;
   if (s.serverDetails) {
-    return s.serverDetails
+    o = s.serverDetails;
+  } else if (s.replicaSetState && s.replicaSetState.primary) {
+    o = s.replicaSetState.primary;
+    // eslint-disable-next-line max-len
+  } else if (s.coreTopology && s.coreTopology.s && s.coreTopology.s.replicaSetState && s.coreTopology.s.replicaSetState.primary) {
+    o = s.coreTopology.s.replicaSetState.primary;
   } else if (s.replState && s.replState.primary) {
-    return s.replState.primary.s.serverDetails
+    o = s.replState.primary.s.serverDetails;
   } else {
-    return {name: s.options.host + ':' + (s.options.port || 27017)}
+    o = {name: s.options.host + ':' + (s.options.port || 27017)};
   }
+  return o;
 }
 
 function makeBaseData (ctx, ns) {

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -1,0 +1,328 @@
+'use strict'
+
+const shimmer = require('ximmer')
+const semver = require('semver');
+
+const ao = require('..')
+const requirePatch = require('../require-patch');
+const conf = ao.probes.mongodb;
+
+const version = requirePatch.relativeRequire('mongodb/package.json').version;
+
+const logMissing = ao.makeLogMissing('mongodb')
+
+module.exports = function (mongodb) {
+
+  // v3.3.0 is the first version of mongodb that doesn't use mongodb-core.
+  if (semver.lt(version, '3.3.0')) {
+    return [mongodb, `disabled ${version}`];
+  }
+
+  let coreServer;
+  try {
+    coreServer = requirePatch.relativeRequire('mongodb/lib/core/topologies/server.js');
+  } catch (e) {
+    logMissing('topologies/server.js');
+  }
+
+  // Patch Server
+  {
+    const proto = coreServer && coreServer.prototype || mongodb.Server && mongodb.Server.prototype
+    if (proto) {
+      patchCommands(proto)
+    } else {
+      logMissing('Server.prototype')
+    }
+  }
+
+  // Patch ReplSet
+  {
+    const proto = mongodb.ReplSet && mongodb.ReplSet.prototype
+    if (proto) {
+      patchCommands(proto)
+    } else {
+      logMissing('ReplSet.prototype')
+    }
+  }
+
+  // Patch Mongos
+  {
+    const proto = mongodb.Mongos && mongodb.Mongos.prototype
+    if (proto) {
+      patchCommands(proto)
+    } else {
+      logMissing('Mongos.prototype')
+    }
+  }
+
+  // Patch Cursor
+  {
+    const proto = mongodb.Cursor && mongodb.Cursor.prototype
+    if (proto) {
+      patchCursor(proto)
+    } else {
+      logMissing('Cursor.prototype')
+    }
+  }
+
+  return [mongodb, version];
+}
+
+function makeWrapper (obj, name, addData) {
+  if (typeof obj[name] !== 'function') {
+    logMissing(`${name}()`)
+    return
+  }
+  shimmer.wrap(obj, name, handler => function (ns, cmd, opts, cb) {
+    if (typeof opts === 'function') {
+      cb = opts
+      opts = {}
+    }
+
+    const kvpairs = makeBaseData(this, ns)
+    kvpairs.QueryOp = name
+    addData(kvpairs, cmd)
+
+    return ao.instrument(
+      () => {
+        return {
+          name: 'mongodb',
+          kvpairs,
+        }
+      },
+      done => handler.call(this, ns, cmd, opts, done),
+      conf,
+      cb
+    )
+  })
+}
+
+function patchCommand (obj) {
+  if (typeof obj.command !== 'function') {
+    logMissing(`${obj.command}()`)
+    return
+  }
+  shimmer.wrap(obj, 'command', handler => function (ns, cmd, opts, cb) {
+    if (typeof opts === 'function') {
+      cb = opts
+      opts = {}
+    }
+    return ao.instrument(
+      () => {
+        return {
+          name: 'mongodb',
+          kvpairs: makeData(this, ns, cmd)
+        }
+      },
+      done => handler.call(this, ns, cmd, opts, done),
+      conf,
+      cb
+    )
+  })
+}
+
+function patchCommands (obj) {
+  makeWrapper(obj, 'insert', (data, cmd) => {
+    data.Insert_Document = JSON.stringify(cmd)
+  })
+  makeWrapper(obj, 'update', (data, cmd) => {
+    data.Query = JSON.stringify(cmd.map(getQuery))
+    data.Update_Document = JSON.stringify(cmd.map(getUpdate))
+  })
+  makeWrapper(obj, 'remove', (data, cmd) => {
+    data.Query = JSON.stringify(cmd.map(getQuery))
+  })
+
+  patchCommand(obj)
+}
+
+function patchCursor (cursor) {
+  if (typeof cursor.next !== 'function') {
+    logMissing('cursor.next()')
+    return
+  }
+  shimmer.wrap(cursor, 'next', handler => function (cb) {
+    const self = this
+    let span
+
+    return ao.instrument(
+      () => {
+        return {
+          name: 'mongodb',
+          kvpairs: makeData(this.topology, this.ns, this.cmd)
+        }
+      },
+      done => handler.call(this, function () {
+        if (span) span.events.exit.set({
+          CursorId: self.cursorState.cursorId.toString(),
+          CursorOp: 'next'
+        })
+        return done.apply(this, arguments)
+      }),
+      conf,
+      cb
+    )
+  })
+}
+
+//
+// Helpers
+//
+
+// List deconstructors
+function getQuery (v) {return v.q || v.query}
+function getUpdate (v) {return v.u || v.update}
+
+// Command identifiers
+function ifDef (...args) {
+  return function (o) {
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] in o || args[i].toLowerCase() in o) {
+        return true;
+      }
+    }
+    return false;
+    //return args.reduce((r, v) => r || v in o || v.toLowerCase() in o, false)
+  }
+}
+
+function serverDetails ({s = {}}) {
+  if (s.serverDetails) {
+    return s.serverDetails
+  } else if (s.replState && s.replState.primary) {
+    return s.replState.primary.s.serverDetails
+  } else {
+    return {name: s.options.host + ':' + (s.options.port || 27017)}
+  }
+}
+
+function makeBaseData (ctx, ns) {
+  // for some reason cursors don't use a namespace object.
+  if (typeof ns === 'string') {
+    // a collection name can contain a '.' so don't just split.
+    const dot = ns.indexOf('.');
+    const db = ns.slice(0, dot);
+    const collection = ns.slice(dot + 1);
+    ns = {db, collection};
+  }
+  return {
+    RemoteHost: serverDetails(ctx).name,
+    Flavor: 'mongodb',
+    Spec: 'query',
+    Collection : ns.collection,
+    Database: ns.db,
+  }
+}
+
+// NOTE: The order of these matters.
+// BAM note: why does the order matter?
+const dataMakers = [
+  // Databases
+  [ifDef('dropDatabase'), function (data) {
+    data.QueryOp = 'drop'
+  }],
+
+  // Collections
+  [ifDef('create'), function (data, cmd) {
+    data.QueryOp = 'create_collection'
+    data.New_Collection_Name = cmd.create
+  }],
+  [ifDef('renameCollection'), function (data, cmd) {
+    data.QueryOp = 'rename'
+    data.New_Collection_Name = cmd.to.slice(cmd.to.indexOf('.') + 1)
+  }],
+  [ifDef('dropCollection', 'drop'), function (data) {
+    data.QueryOp = 'drop_collection'
+  }],
+
+  // Finding
+  [ifDef('distinct'), function (data, cmd) {
+    data.QueryOp = 'distinct'
+    data.Query = JSON.stringify(getQuery(cmd))
+    data.Key = cmd.key
+  }],
+  [ifDef('find'), function (data, cmd) {
+    data.QueryOp = 'find'
+    data.Query = JSON.stringify(cmd.query)
+  }],
+  [ifDef('findAndModify'), function (data, cmd) {
+    data.QueryOp = 'find_and_modify'
+    data.Query = JSON.stringify(cmd.query)
+    data.Update_Document = JSON.stringify(cmd.update)
+  }],
+  [ifDef('count'), function (data, cmd) {
+    data.QueryOp = 'count'
+    data.Query = JSON.stringify(getQuery(cmd))
+  }],
+
+  // Modifying
+  [ifDef('insert'), function (data, cmd) {
+    data.QueryOp = 'insert'
+    data.Insert_Document = JSON.stringify(cmd.documents)
+  }],
+  [ifDef('update'), function (data, cmd) {
+    data.QueryOp = 'update'
+    data.Query = JSON.stringify(cmd.updates.map(getQuery))
+    data.Update_Document = JSON.stringify(cmd.updates.map(getUpdate))
+  }],
+  [ifDef('delete'), function (data, cmd) {
+    data.QueryOp = 'remove'
+    data.Query = JSON.stringify(cmd.deletes.map(getQuery))
+  }],
+
+  // Indexes
+  [ifDef('createIndexes'), function (data, cmd) {
+    data.QueryOp = 'create_indexes'
+    data.Indexes = JSON.stringify(cmd.indexes)
+  }],
+  [ifDef('deleteIndexes', 'dropIndexes'), function (data, cmd) {
+    data.QueryOp = 'drop_indexes'
+    data.Index = JSON.stringify(cmd.index)
+  }],
+  [ifDef('reIndex'), function (data) {
+    data.QueryOp = 'reindex'
+  }],
+
+  // Aggregation
+  [ifDef('group'), function (data, cmd) {
+    data.QueryOp = 'group'
+    data.Group_Condition = JSON.stringify(cmd.group.cond)
+    data.Group_Initial = JSON.stringify(cmd.group.initial)
+    if (typeof cmd.group.$reduce === 'function') {
+      data.Group_Reduce = cmd.group.$reduce.toString()
+    } else if (typeof cmd.group.$reduce === 'object') {
+      data.Group_Reduce = cmd.group.$reduce.code.toString()
+    } else {
+      data.Group_Reduce = cmd.group.$reduce.toString()
+    }
+    data.Group_Key = JSON.stringify(cmd.group.key)
+  }],
+  [ifDef('mapReduce'), function (data, cmd) {
+    data.QueryOp = 'map_reduce'
+    data.Map_Function = cmd.map
+    data.Reduce_Function = cmd.reduce
+    if (cmd.finalize) {
+      data.Finalize_Function = cmd.finalize
+    }
+  }],
+  [ifDef('aggregate'), function (data, cmd) {
+    data.QueryOp = 'aggregate'
+    data.Pipeline = JSON.stringify(cmd.pipeline)
+  }]
+]
+
+function makeData (ctx, ns, cmd) {
+  const data = makeBaseData(ctx, ns)
+  for (let i = 0; i < dataMakers.length; i++) {
+    const [test, make] = dataMakers[i]
+    if (test(cmd)) {
+      make(data, cmd)
+      return data
+    }
+  }
+
+  data.QueryOp = 'command'
+  data.Command = JSON.stringify(cmd)
+
+  return data
+}

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -15,19 +15,18 @@ module.exports = function (mongodb) {
 
   // v3.3.0 is the first version of mongodb that doesn't use mongodb-core.
   if (semver.lt(version, '3.3.0')) {
-    return [mongodb, `no-op ${version}`];
-  }
-
-  let coreServer;
-  try {
-    coreServer = requirePatch.relativeRequire('mongodb/lib/core/topologies/server.js');
-  } catch (e) {
-    logMissing('topologies/server.js');
+    return [mongodb, `${version} (no-op)`];
   }
 
   // Patch Server
   {
-    const proto = coreServer && coreServer.prototype || mongodb.Server && mongodb.Server.prototype
+    let coreServer;
+    try {
+      coreServer = requirePatch.relativeRequire('mongodb/lib/core/topologies/server.js');
+    } catch (e) {
+      logMissing('topologies/server.js');
+    }
+    const proto = coreServer && coreServer.prototype || mongodb.Server && mongodb.Server.prototype;
     if (proto) {
       patchCommands(proto)
     } else {
@@ -37,7 +36,13 @@ module.exports = function (mongodb) {
 
   // Patch ReplSet
   {
-    const proto = mongodb.ReplSet && mongodb.ReplSet.prototype
+    let core;
+    try {
+      core = requirePatch.relativeRequire('mongodb/lib/core/topologies/replset.js');
+    } catch (e) {
+      logMissing('topologies/replset.js');
+    }
+    const proto = core && core.prototype || mongodb.ReplSet && mongodb.ReplSet.prototype;
     if (proto) {
       patchCommands(proto)
     } else {
@@ -47,7 +52,13 @@ module.exports = function (mongodb) {
 
   // Patch Mongos
   {
-    const proto = mongodb.Mongos && mongodb.Mongos.prototype
+    let core;
+    try {
+      core = requirePatch.relativeRequire('mongodb/lib/core/topologies/mongos.js');
+    } catch (e) {
+      logMissing('topologies/mongos.js');
+    }
+    const proto = core && core.prototype || mongodb.Mongos && mongodb.Mongos.prototype
     if (proto) {
       patchCommands(proto)
     } else {
@@ -186,14 +197,23 @@ function ifDef (...args) {
   }
 }
 
+// different versions of mongodb and mongodb-core have variations in naming
+// and object organization.
 function serverDetails ({s = {}}) {
+  let o;
   if (s.serverDetails) {
-    return s.serverDetails
+    o = s.serverDetails;
+  } else if (s.replicaSetState && s.replicaSetState.primary) {
+    o = s.replicaSetState.primary;
+    // eslint-disable-next-line max-len
+  } else if (s.coreTopology && s.coreTopology.s && s.coreTopology.s.replicaSetState && s.coreTopology.s.replicaSetState.primary) {
+    o = s.coreTopology.s.replicaSetState.primary;
   } else if (s.replState && s.replState.primary) {
-    return s.replState.primary.s.serverDetails
+    o = s.replState.primary.s.serverDetails;
   } else {
-    return {name: s.options.host + ':' + (s.options.port || 27017)}
+    o = {name: s.options.host + ':' + (s.options.port || 27017)};
   }
+  return o;
 }
 
 function makeBaseData (ctx, ns) {

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -15,7 +15,7 @@ module.exports = function (mongodb) {
 
   // v3.3.0 is the first version of mongodb that doesn't use mongodb-core.
   if (semver.lt(version, '3.3.0')) {
-    return [mongodb, `disabled ${version}`];
+    return [mongodb, `no-op ${version}`];
   }
 
   let coreServer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,13 +3492,23 @@
       "optional": true
     },
     "mongodb": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
-      "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.3.tgz",
+      "integrity": "sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==",
       "dev": true,
       "requires": {
-        "mongodb-core": "3.1.11",
-        "safe-buffer": "^5.1.2"
+        "bson": "^1.1.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+          "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==",
+          "dev": true
+        }
       }
     },
     "mongodb-core": {
@@ -3555,6 +3565,16 @@
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
           "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==",
           "dev": true
+        },
+        "mongodb": {
+          "version": "3.1.13",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
+          "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
+          "dev": true,
+          "requires": {
+            "mongodb-core": "3.1.11",
+            "safe-buffer": "^5.1.2"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "memcached": "^2.2.2",
     "method-override": "^2.3.10",
     "mkdirp": "^0.5.1",
-    "mongodb": "^3.1.13",
+    "mongodb": "^3.3.3",
     "mongodb-core": "^3.1.11",
     "mongoose": "^5.4.19",
     "morgan": "^1.9.1",

--- a/prepack.js
+++ b/prepack.js
@@ -111,7 +111,7 @@ const onlyInProbesDir = difference(implementedProbes, commonProbes);
 // clean up known exceptions
 //
 
-// http-client and https-client are implemented in the http.js and https.js probes
+// http-client and https-client are implemented by the http.js and https.js probes
 onlyInDefault.delete('http-client');
 onlyInDefault.delete('https-client');
 

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -6,6 +6,7 @@ const {ao} = require('../1.test-common.js')
 const noop = helper.noop
 const addon = ao.addon
 
+const expect = require('chai').expect;
 const semver = require('semver')
 const mongodb = require('mongodb-core')
 
@@ -13,6 +14,8 @@ const requirePatch = require('../../lib/require-patch')
 requirePatch.disable()
 const pkg = require('mongodb-core/package.json')
 requirePatch.enable()
+
+const moduleName = 'mongodb-core';
 
 // need to make decisions based on major version
 const majorVersion = semver.major(pkg.version)
@@ -180,18 +183,22 @@ function makeTests (db_host, host, isReplicaSet) {
       msg.should.have.property('Spec', 'query')
       msg.should.have.property('Flavor', 'mongodb')
       msg.should.have.property('RemoteHost')
-      msg.RemoteHost.should.match(/:\d*$/)
+      //msg.RemoteHost.should.match(/:\d*$/)
+      expect(msg.RemoteHost).oneOf(db_host.split(','));
     },
     common: function (msg) {
       msg.should.have.property('Database', `${dbn}`)
     },
     entry: function (msg) {
-      msg.should.have.property('Layer', 'mongodb-core')
-      msg.should.have.property('Label', 'entry')
+      const explicit = `${msg.Layer}:${msg.Label}`;
+      //console.log(`expecting ${moduleName}:entry got ${explicit}`);
+      expect(explicit).equal(`${moduleName}:entry`, 'message Layer and Label must be correct');
       check.base(msg)
     },
     exit: function (msg) {
-      msg.should.have.property('Layer', 'mongodb-core')
+      const explicit = `${msg.Layer}:${msg.Label}`;
+      expect(explicit).equal(`${moduleName}:exit`, 'message Layer and Label must be correct');
+      msg.should.have.property('Layer', moduleName)
       msg.should.have.property('Label', 'exit')
     }
   }

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -149,6 +149,7 @@ function makeTests (db_host, host, isReplicaSet) {
     }
 
     server.on('error', function (err) {
+      // eslint-disable-next-line no-console
       console.log('error connecting', err)
       done()
     })
@@ -707,6 +708,7 @@ function makeTests (db_host, host, isReplicaSet) {
       }
 
       it('should map_reduce', function (done) {
+        // eslint-disable-next-line no-undef
         function map () {emit(this.a, 1)}
         function reduce (k, vals) {return 1}
 

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -270,7 +270,6 @@ function makeTests (db_host, host, isReplicaSet) {
   //
   const tests = {
     databases: function () {
-      // calls topologies/Server.command()
       it('should drop', function (done) {
         function entry (msg) {
           check.entry(msg)
@@ -301,7 +300,6 @@ function makeTests (db_host, host, isReplicaSet) {
     // collections tests
     //
     collections: function () {
-      // calls topologies/Server.command()
       it('should create', function (done) {
         function entry (msg) {
           check.entry(msg)
@@ -337,7 +335,6 @@ function makeTests (db_host, host, isReplicaSet) {
         }, steps, done)
       })
 
-      // calls topologies/Server.command()
       it('should rename', function (done) {
         function entry (msg) {
           check.entry(msg)
@@ -379,7 +376,6 @@ function makeTests (db_host, host, isReplicaSet) {
         }, steps, done)
       })
 
-      // calls topologies/Server.command()
       it('should drop', function (done) {
         function entry (msg) {
           check.entry(msg)
@@ -420,7 +416,6 @@ function makeTests (db_host, host, isReplicaSet) {
     // query tests
     //
     queries: function () {
-      // DOES NOT CALL
       it('should insertMany', function (done) {
         function entry (msg) {
           check.entry(msg)
@@ -448,7 +443,6 @@ function makeTests (db_host, host, isReplicaSet) {
         }, steps, done)
       })
 
-      // DOES NOT CALL
       it('should updateOne', function (done) {
         const query = {a: 1}
         const update = {
@@ -520,8 +514,6 @@ function makeTests (db_host, host, isReplicaSet) {
         }, steps, done)
       })
 
-      // not mongodb.Server()
-      // calls topologies/Server.command()
       it('should distinct', function (done) {
         const query = {a: 1}
         const key = 'b'
@@ -556,8 +548,6 @@ function makeTests (db_host, host, isReplicaSet) {
         }, steps, done)
       })
 
-      // not mongodb.Server()
-      // calls topologies/Server.command() - deprecation warning use countDocuments
       it('should count', function (done) {
         const query = {a: 1}
 
@@ -587,9 +577,6 @@ function makeTests (db_host, host, isReplicaSet) {
         }, steps, done)
       })
 
-      // not mongodb.Server()
-      // calls topologies/Server.command()
-      // {aggregate: 'coll-test', pipeline: [{'$match': [Object]}, {'$group': [Object]}], cursor: {}}
       it('should countDocuments', function (done) {
         const query = {a: 1}
         const pipeline = '[{"$match":{"a":1}},{"$group":{"_id":1,"n":{"$sum":1}}}]';
@@ -626,8 +613,6 @@ function makeTests (db_host, host, isReplicaSet) {
         }, steps, done)
       })
 
-      // deprecated: user deleteOne, deleteMany, bulkWrite
-      // DOES NOT CALL
       it('should remove', function (done) {
         const query = {a: 1}
 
@@ -666,8 +651,6 @@ function makeTests (db_host, host, isReplicaSet) {
         return
       }
 
-      // does call topolgies/Server.command()
-      // { createIndexes: 'coll-test', indexes: [{key: [Object], name: 'mimi'}]}
       it('should create_indexes', function (done) {
         const index = {
           key: {a: 1, b: 2},
@@ -701,7 +684,6 @@ function makeTests (db_host, host, isReplicaSet) {
         }, steps, done)
       })
 
-      // does call topolgies/Server.command()
       it('should reindex', function (done) {
         function entry (msg) {
           check.entry(msg)
@@ -726,7 +708,6 @@ function makeTests (db_host, host, isReplicaSet) {
         }, steps, done)
       })
 
-      // does call topolgies/Server.command()
       it('should drop_indexes', function (done) {
         function entry (msg) {
           check.entry(msg)
@@ -753,7 +734,6 @@ function makeTests (db_host, host, isReplicaSet) {
     },
 
     cursors: function () {
-      // DOES NOT CALL
       it('should find', function (done) {
         helper.test(emitter, function (done) {
           const cursor = ctx.collection.find(
@@ -774,7 +754,6 @@ function makeTests (db_host, host, isReplicaSet) {
 
     aggregations: function () {
 
-      // does call topolgies/Server.command()
       it('should group', function (done) {
         const group = {
           ns: `${dbn}.data-${dbn}`,
@@ -823,7 +802,6 @@ function makeTests (db_host, host, isReplicaSet) {
         return
       }
 
-      // does call topolgies/Server.command()
       it('should map_reduce', function (done) {
         // eslint-disable-next-line
         function map () {emit(this.a, 1)}

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -118,6 +118,9 @@ function makeTests (db_host, host, isReplicaSet) {
     if (current.parent && !(current.parent.title in doThese)) {
       this.skip()
     }
+    if (current.title !== 'should distinct' && current.title !== 'should count') {
+      //this.skip();
+    }
 
     ao.probes.fs.enabled = false
     emitter = helper.appoptics(done)
@@ -239,19 +242,24 @@ function makeTests (db_host, host, isReplicaSet) {
       msg.should.have.property('Spec', 'query')
       msg.should.have.property('Flavor', 'mongodb')
       msg.should.have.property('RemoteHost')
-      msg.RemoteHost.should.match(/:\d*$/)
+      //msg.RemoteHost.should.match(/:\d*$/)
+      expect(msg.RemoteHost).oneOf(db_host.split(','));
     },
     common: function (msg) {
       msg.should.have.property('Database', `${dbn}`)
     },
     entry: function (msg) {
       const explicit = `${msg.Layer}:${msg.Label}`;
+      //console.log(`expecting ${moduleName}:entry got ${explicit}`);
+      //console.log(msg);
       expect(explicit).equal(`${moduleName}:entry`, 'message Layer and Label must be correct');
-      msg.should.have.property('Layer', moduleName)
-      msg.should.have.property('Label', 'entry')
       check.base(msg)
     },
     exit: function (msg) {
+      const explicit = `${msg.Layer}:${msg.Label}`;
+      //console.log(`expecting ${moduleName}:exit got ${explicit}`);
+      //console.log(msg);
+      expect(explicit).equal(`${moduleName}:exit`, 'message Layer and Label must be correct');
       msg.should.have.property('Layer', moduleName)
       msg.should.have.property('Label', 'exit')
     }
@@ -532,7 +540,7 @@ function makeTests (db_host, host, isReplicaSet) {
 
         const steps = [ entry ]
 
-        if (isReplicaSet) {
+        if (isReplicaSet && moduleName === 'mongodb-core') {
           steps.push(entry)
           steps.push(exit)
         }
@@ -565,7 +573,7 @@ function makeTests (db_host, host, isReplicaSet) {
         }
 
         const steps = [ entry ]
-        if (isReplicaSet) {
+        if (isReplicaSet && moduleName === 'mongodb-core') {
           steps.push(entry)
           steps.push(exit)
         }

--- a/test/versions.js
+++ b/test/versions.js
@@ -1,5 +1,10 @@
 'use strict'
 
+//
+// this file defines the versions that will be test when using
+// test-each-version.
+//
+
 const {VersionSpec} = require('testeachversion')
 const semver = require('semver');
 
@@ -81,6 +86,8 @@ test('koa-router', {
 test('level', node('gte', '12.0.0') ? '>= 5.0.0' : '>= 1.3.0');
 
 test('memcached', '>= 2.2.0')
+// prior to version 3.3.0 mongodb used mongodb-core
+test('mongodb', '>= 3.3.0');
 test('mongodb-core', '>= 2.0.0')
 test('mongoose', '>= 4.6.4')
 test('morgan', '>= 1.6.0')


### PR DESCRIPTION
- add support for mongodb v3.3.0+ which no longer uses mongodb-core.
- add tests for mongodb v3.0.0+ with new command api.
- add to versions.js for matrix testing.
- updates to mongodb/mongodb-core tests to verify RemoteHost (was silently failing).
