### PR TITLE
allow the fs probe to ignore specific errors [AO-12757]

### DIFF
--- a/appoptics-apm.json
+++ b/appoptics-apm.json
@@ -4,7 +4,12 @@
     "domainPrefix": "",
     "probes": {
       "fs": {
-        "enabled": true
+        "enabled": true,
+        "ignoreErrors": {
+          "open": {
+            "ENOENT": true
+          }
+        }
       }
     }
 }

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -55,10 +55,12 @@ The configuration file can supply the following properties, showing their defaul
 Probes are the packages that `appoptics-apm` auto-instruments. Different types of probes have different configuration options. See `lib/defaults.js` for details.
 
 There is one particular setting for the `fs` probe that you might want to be aware of: `ignoreErrors`. The only errors that can be ignored are node
-System errors (see the node [docs](https://nodejs.org/api/errors.html#errors_common_system_errors)) returned by the asynchronous functions or thrown
-by the synchronous functions. Note that there is only one setting for the `open` and it ignores errors for both `fs.open()` and `fs.openSync()`.
+System errors (see the node [docs](https://nodejs.org/api/errors.html#errors_common_system_errors)) provided by the asynchronous functions or thrown
+by the synchronous functions. Note that there is only one setting for each pair of asynchronous and synchronous functions, e.g. the `open` setting
+applies to both `fs.open()` and `fs.openSync()`.
 
-Ignoring the `ENOENT` error for the `fs.open()` and `fs.openSync()` functions is shown in the examples below.
+Ignoring the `ENOENT` error for the `fs.open()` and `fs.openSync()` functions is shown in the examples below. This setting won't take effect because of
+the `fs` probe setting `enabled: false` but is shown for the syntax.
 
 Probe settings in the `appoptics-apm` configuration file will override those in `defaults.js`, so the safest approach to changing an option is to add it to `appoptics-apm.json`. For example, here is how to turn off sampling for `fs`:
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -52,9 +52,15 @@ The configuration file can supply the following properties, showing their defaul
 
 #### Configuration File Probe Settings ####
 
-Probes are the packages that `appoptics-apm` auto-instruments. Different types of probes have different configuration options. See `dist/defaults.js` (or `lib/defaults.js` if you've cloned the github repository) for details.
+Probes are the packages that `appoptics-apm` auto-instruments. Different types of probes have different configuration options. See `lib/defaults.js` for details.
 
-Probe settings in the `appoptics-apm` configuration file will override those in `defaults.js`, so the best approach to changing an option is to add it to `appoptics-apm.json`. For example, here is how to turn off sampling for `fs`:
+There is one particular setting for the `fs` probe that you might want to be aware of: `ignoreErrors`. The only errors that can be ignored are node
+System errors (see the node [docs](https://nodejs.org/api/errors.html#errors_common_system_errors)) returned by the asynchronous functions or thrown
+by the synchronous functions. Note that there is only one setting for the `open` and it ignores errors for both `fs.open()` and `fs.openSync()`.
+
+Ignoring the `ENOENT` error for the `fs.open()` and `fs.openSync()` functions is shown in the examples below.
+
+Probe settings in the `appoptics-apm` configuration file will override those in `defaults.js`, so the safest approach to changing an option is to add it to `appoptics-apm.json`. For example, here is how to turn off sampling for `fs`:
 
 ```
 {
@@ -62,7 +68,12 @@ Probe settings in the `appoptics-apm` configuration file will override those in 
   "serviceKey": "...",
   "probes": {
     "fs": {
-      "enabled": false
+      "enabled": false,
+      "ignoreErrors": {
+        "open": {
+          "ENOENT": true
+        }
+      }
     }
   }
 }
@@ -77,7 +88,12 @@ module.exports = {
   // isn't this much better?
   probes: {
     fs: {
-      enabled: false
+      enabled: false,
+      ignoreErrors: {
+        open: {
+          ENOENT: true,
+        }
+      }
     }
   }
 }

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -260,8 +260,11 @@ probeConfigChecks.fs = function (cfg) {
   const validConfig = Object.assign({}, cfg);
   const validErrorObjects = {};
 
-  // could do more validation but the checking function uses `e.code in conf.ignoreErrors` to
-  // make the ignore decision. so just make sure it's a object so `in` can be used.
+  // could do more validation but the goal here is to make sure the checking function can use
+  // `in` on both levels of the ignoreErrors object. the checks it makes are:
+  //   `conf.ignoreErrors && method in conf.ignoreErrors`
+  // followed by:
+  //   `err.code in conf.ignoreErrors[method]`
   if (cfg.ignoreErrors && typeof cfg.ignoreErrors !== 'object') {
     errors.push(`invalid ignoreErrors setting: ${JSON.stringify(cfg.ignoreErrors)}`)
     delete validConfig.ignoreErrors;

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -258,12 +258,24 @@ probeConfigChecks.fs = function (cfg) {
   const errors = [];
   const warnings = [];
   const validConfig = Object.assign({}, cfg);
+  const validErrorObjects = {};
 
   // could do more validation but the checking function uses `e.code in conf.ignoreErrors` to
   // make the ignore decision. so just make sure it's a object so `in` can be used.
   if (cfg.ignoreErrors && typeof cfg.ignoreErrors !== 'object') {
     errors.push(`invalid ignoreErrors setting: ${JSON.stringify(cfg.ignoreErrors)}`)
     delete validConfig.ignoreErrors;
+  }
+  for (const e2i in validConfig.ignoreErrors) {
+    if (typeof validConfig.ignoreErrors[e2i] === 'object') {
+      validErrorObjects[e2i] = validConfig.ignoreErrors[e2i];
+    } else {
+      const etext = JSON.stringify({[e2i]: validConfig.ignoreErrors[e2i]});
+      errors.push(`invalid error code to ignore: ${etext}`);
+    }
+  }
+  if (cfg.ignoreErrors && validConfig.ignoreErrors) {
+    validConfig.ignoreErrors = validErrorObjects;
   }
 
   return {validConfig, errors, warnings};

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -2,6 +2,9 @@
 
 const path = require('path');
 
+// this is filled in later.
+const probeConfigChecks = {};
+
 function getUnifiedConfig () {
 
   const errors = [];        // for each error and array of arguments for log.error()
@@ -204,6 +207,17 @@ function getUnifiedConfig () {
   // that probe-defaults matches valid probes in lib/probes/.
   Object.keys(probeDefaults).forEach(mod => {
     results.probes[mod] = Object.assign({}, probeDefaults[mod], fileProbesConfig[mod]);
+    // if there is a check for this probe's config then use it.
+    if (probeConfigChecks[mod]) {
+      const probeResults = probeConfigChecks[mod](results.probes[mod]);
+      results.probes[mod] = probeResults.validConfig;
+      if (probeResults.errors) {
+        probeResults.errors.forEach(e => errors.push(e));
+      }
+      if (probeResults.warnings) {
+        probeResults.warnings.forEach(w => {warnings.push(w)});
+      }
+    }
     delete fileProbesConfig[mod];
   })
 
@@ -234,6 +248,25 @@ function getUnifiedConfig () {
   }
 
   return results;
+}
+
+//====================================
+// probe configuration check functions
+//====================================
+
+probeConfigChecks.fs = function (cfg) {
+  const errors = [];
+  const warnings = [];
+  const validConfig = Object.assign({}, cfg);
+
+  // could do more validation but the checking function uses `e.code in conf.ignoreErrors` to
+  // make the ignore decision. so just make sure it's a object so `in` can be used.
+  if (cfg.ignoreErrors && typeof cfg.ignoreErrors !== 'object') {
+    errors.push(`invalid ignoreErrors setting: ${JSON.stringify(cfg.ignoreErrors)}`)
+    delete validConfig.ignoreErrors;
+  }
+
+  return {validConfig, errors, warnings};
 }
 
 //================================================================

--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -134,6 +134,13 @@ function patchPathMethod (fs, method) {
               },
               finalize (createdSpan) {
                 span = createdSpan;
+                if (method === 'open' && conf.ignoreErrors) {
+                  span.setIgnoreErrorFn(function (err) {
+                    // if looking at operation and/or path in the future:
+                    // span.events.entry.kv.Operation === 'openSync' ditto.FilePath
+                    return err.code in conf.ignoreErrors;
+                  })
+                }
               }
             }
           },
@@ -171,6 +178,11 @@ function patchPathMethod (fs, method) {
         if (method === 'open') {
           spanInfo.finalize = function (createdSpan) {
             span = createdSpan;
+            if (conf.ignoreErrors) {
+              span.setIgnoreErrorFn(function (err) {
+                return err.code in conf.ignoreErrors;
+              })
+            }
           }
         }
         let span

--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -134,11 +134,11 @@ function patchPathMethod (fs, method) {
               },
               finalize (createdSpan) {
                 span = createdSpan;
-                if (method === 'open' && conf.ignoreErrors) {
+                if (conf.ignoreErrors && method in conf.ignoreErrors) {
                   span.setIgnoreErrorFn(function (err) {
                     // if looking at operation and/or path in the future:
-                    // span.events.entry.kv.Operation === 'openSync' ditto.FilePath
-                    return err.code in conf.ignoreErrors;
+                    // span.events.entry.kv.Operation === 'open' ditto.FilePath
+                    return err.code in conf.ignoreErrors[method];
                   })
                 }
               }
@@ -178,9 +178,11 @@ function patchPathMethod (fs, method) {
         if (method === 'open') {
           spanInfo.finalize = function (createdSpan) {
             span = createdSpan;
-            if (conf.ignoreErrors) {
+            if (conf.ignoreErrors && method in conf.ignoreErrors) {
               span.setIgnoreErrorFn(function (err) {
-                return err.code in conf.ignoreErrors;
+                // if looking at operation and/or path in the future:
+                // span.events.entry.kv.Operation === 'openSync' ditto.FilePath
+                return err.code in conf.ignoreErrors[method];
               })
             }
           }

--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -132,8 +132,8 @@ function patchPathMethod (fs, method) {
                 Operation: method,
                 FilePath: args[0],
               },
-              function (createdSpan) {
-                span = createdSpan
+              finalize (createdSpan) {
+                span = createdSpan;
               }
             }
           },
@@ -170,7 +170,7 @@ function patchPathMethod (fs, method) {
         }
         if (method === 'open') {
           spanInfo.finalize = function (createdSpan) {
-            span = createdSpan
+            span = createdSpan;
           }
         }
         let span

--- a/lib/span.js
+++ b/lib/span.js
@@ -47,6 +47,12 @@ function Span (name, settings, data) {
   this.topSpan = false
   this.doMetrics = false
 
+  // it is possible to ignore some errors. the only error that customers have
+  // requested to be able to ignore is ENOENT because their application looks for
+  // files at startup but it's not really an error for them to not be found.
+  // in order to ignore an error the probe must call Span.setErrorsToIgnoreFunction().
+  this.ignoreErrorFn = undefined;
+
   const edge = 'edge' in settings ? settings.edge : true
 
   const entry = new Event(name, 'entry', settings.metadata, edge)
@@ -407,7 +413,11 @@ Span.prototype.exitWithError = function (error, data) {
 Span.prototype.setExitError = function (error) {
   try {
     error = Span.toError(error)
-    if (error) this.events.exit.error = error
+    if (error) {
+      if (!this.ignoreErrorFn || !this.ignoreErrorFn(error)) {
+        this.events.exit.error = error;
+      }
+    }
   } catch (e) {
     log.error(`${this.name} span failed to set exit error`, e.stack)
   }
@@ -490,6 +500,28 @@ Span.prototype.error = function (error) {
   } catch (e) {
     log.error(`${this.name} span failed to send error event`, e.stack)
   }
+}
+
+/**
+ * Set a function that determines whether an error is reported or not. This
+ * is for internal use only.
+ *
+ * @method Span#setIgnoreErrorFn
+ * @param {Error} err the error to evaluate
+ * @returns {boolean} truthy to ignore the error
+ * @ignore
+ *
+ * @example
+ * span.setIgnoreErrorFn(function (err) {
+ *   // return true to ignore the error.
+ *   return err.code === 'ENOENT';
+ * })
+ */
+Span.prototype.setIgnoreErrorFn = function setIgnoreErrorFn (fn) {
+  if (this.ignoreErrorFn) {
+    log.warn(`resetting ignoreErrorFn for ${this.name}`);
+  }
+  this.ignoreErrorFn = fn;
 }
 
 //

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -406,14 +406,11 @@ describe('probes.fs', function () {
         const steps = [
           function (msg) {
             checks.entry(msg)
-            msg.should.have.property('Operation', call.name)
-            switch (call.type) {
-              case 'path':
-                msg.should.have.property('FilePath', args[0])
-                break
-              case 'fd':
-                msg.should.have.property('FileDescriptor', args[0])
-                break
+            msg.should.have.property('Operation', call.name);
+            if (call.type === 'path') {
+              msg.should.have.property('FilePath', args[0]);
+            } else if (call.type === 'fd') {
+              msg.should.have.property('FileDescriptor', args[0]);
             }
           }
         ]
@@ -436,7 +433,10 @@ describe('probes.fs', function () {
 
         // Push the exit check
         steps.push(function (msg) {
-          checks.exit(msg)
+          checks.exit(msg);
+          if (call.name === 'open') {
+            msg.should.have.property('FileDescriptor');
+          }
         })
 
         // Before starting test, run any required tasks

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -562,7 +562,7 @@ describe('probes.fs', function () {
 
   it('should suppress openSync errors when requested', function (done) {
     const previousIgnoreErrors = ao.probes.fs.ignoreErrors;
-    ao.probes.fs.ignoreErrors = {ENOENT: true};
+    ao.probes.fs.ignoreErrors = {open: {ENOENT: true}};
     function reset (err) {
       ao.probes.fs.ignoreErrors = previousIgnoreErrors;
       done(err);
@@ -616,7 +616,7 @@ describe('probes.fs', function () {
 
   it('should suppress open errors when requested', function (done) {
     const previousIgnoreErrors = ao.probes.fs.ignoreErrors;
-    ao.probes.fs.ignoreErrors = {ENOENT: true};
+    ao.probes.fs.ignoreErrors = {open: {ENOENT: true}};
     function reset (err) {
       ao.probes.fs.ignoreErrors = previousIgnoreErrors;
       done(err);

--- a/test/unified-config.test.js
+++ b/test/unified-config.test.js
@@ -360,6 +360,26 @@ describe('config', function () {
     doChecks(cfg, {unusedProbes: [config.probes]});
   })
 
+  it('should handle an fs probe\'s ignoreErrors property', function () {
+    const config = {probes: {fs: {enabled: true, ignoreErrors: {ENOENT: true}}}};
+    writeConfigJSON(config);
+
+    const cfg = guc();
+
+    doChecks(cfg, {probes: config.probes});
+  })
+
+  it('should verify an fs probe\'s ignoreErrors value is an object', function () {
+    const config = {probes: {fs: {enabled: true, ignoreErrors: 'i am a shrimp'}}};
+    writeConfigJSON(config);
+
+    const cfg = guc();
+
+    const errors = [`invalid ignoreErrors setting: ${JSON.stringify('i am a shrimp')}`];
+    delete config.probes.fs.ignoreErrors;
+    doChecks(cfg, {probes: config.probes, errors});
+  })
+
   //
   // transaction settings
   //

--- a/test/unified-config.test.js
+++ b/test/unified-config.test.js
@@ -361,7 +361,7 @@ describe('config', function () {
   })
 
   it('should handle an fs probe\'s ignoreErrors property', function () {
-    const config = {probes: {fs: {enabled: true, ignoreErrors: {ENOENT: true}}}};
+    const config = {probes: {fs: {enabled: true, ignoreErrors: {open: {ENOENT: true}}}}};
     writeConfigJSON(config);
 
     const cfg = guc();
@@ -378,6 +378,18 @@ describe('config', function () {
     const errors = [`invalid ignoreErrors setting: ${JSON.stringify('i am a shrimp')}`];
     delete config.probes.fs.ignoreErrors;
     doChecks(cfg, {probes: config.probes, errors});
+  })
+
+  it('should verify that an fs probe\'s ignoreErrors object contains objects', function () {
+    const config = {probes: {fs: {ignoreErrors: {open: {ENOENT: true}, readdir: 'and so am i'}}}};
+    writeConfigJSON(config);
+
+    const cfg = guc();
+
+    const errors = [`invalid error code to ignore: ${JSON.stringify({readdir: 'and so am i'})}`];
+    delete config.probes.fs.ignoreErrors.readdir;
+    doChecks(cfg, {probes: config.probes, errors});
+
   })
 
   //


### PR DESCRIPTION
- allow "ignoreErrors" property in the "fs" config.
- provide checking to verify ignoreErrors will allow the `in` operator to be used.
- implement general ignore error logic in `lib/span`
- use span logic in fs probe.
- fixes unreported bug where FileDescriptor would not be added to span exit event.