### PR TITLE
mongodb probe fixes [AO-14417]

### DIFF
--- a/lib/probes/@hapi/hapi.js
+++ b/lib/probes/@hapi/hapi.js
@@ -322,9 +322,8 @@ function patchDecorator (plugin, version) {
 //
 // Apply hapi patches
 //
-module.exports = function (hapi, name) {
-  const pkg = requirePatch.relativeRequire(`${name}/package.json`);
-  const version = pkg.version;
+module.exports = function (hapi, options) {
+  const {name, version} = options;
 
   if (semver.gte(version, '17.0.0')) {
     // v17 has completely different implementation. handler needs to be patched
@@ -421,5 +420,5 @@ module.exports = function (hapi, name) {
     }
   }
 
-  return [hapi, pkg.version];
+  return [hapi, version];
 }

--- a/lib/probes/@hapi/vision.js
+++ b/lib/probes/@hapi/vision.js
@@ -3,7 +3,6 @@
 const ao = global[Symbol.for('AppOptics.Apm.Once')];
 const path = require('path');
 
-const requirePatch = require(path.resolve(ao.root, 'lib', 'require-patch'));
 const shimmer = require('ximmer')
 const semver = require('semver')
 const log = ao.loggers
@@ -12,8 +11,8 @@ const conf = ao.probes.vision
 //
 // Apply vision patches
 //
-module.exports = function (vision, name) {
-  const {version} = requirePatch.relativeRequire(`${name}/package.json`)
+module.exports = function (vision, options) {
+  const {version} = options;
 
   // only version 5 is handled
   if (semver.lt(version, '5.0.0')) {

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -21,14 +21,13 @@ const defaultPort = {
   http: 80
 }
 
-module.exports = function (module, protocol) {
-  protocol = protocol || 'http'
-  patchServer(module, protocol)
-  patchClient(module, protocol)
+module.exports = function (module, options, protocol = 'http') {
+  patchServer(module, options, protocol)
+  patchClient(module, options, protocol)
   return module
 }
 
-function patchClient (module, protocol) {
+function patchClient (module, options, protocol) {
   const name = protocol + '-client'
   const conf = ao.probes[name]
 
@@ -195,7 +194,7 @@ function patchClient (module, protocol) {
 //
 // patch the server - it creates a topLevel span
 //
-function patchServer (module, protocol) {
+function patchServer (module, options, protocol) {
   const conf = ao.probes[protocol]
 
   const fowardedHeaders = [

--- a/lib/probes/https.js
+++ b/lib/probes/https.js
@@ -2,6 +2,6 @@
 
 const httpPatch = require('./http')
 
-module.exports = function (module) {
-  return httpPatch(module, 'https')
+module.exports = function (module, options) {
+  return httpPatch(module, options, 'https')
 }

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -4,14 +4,12 @@ const semver = require('semver');
 const shimmer = require('ximmer')
 
 const ao = require('..');
-const requirePatch = require('../require-patch');
 const conf = ao.probes['mongodb-core'];
-
-const version = requirePatch.relativeRequire('mongodb-core/package.json').version;
 
 const logMissing = ao.makeLogMissing('mongodb-core')
 
-module.exports = function (mongodb) {
+module.exports = function (mongodb, options) {
+  const {version} = options;
 
   // node 12 with mongodb-core prior to v3 exhibits a memory leak with cls-hooked.
   if (semver.gte(process.version, '11.0.0') && semver.lt(version, '3.0.0')) {
@@ -168,7 +166,7 @@ function getQuery (v) {return v.q || v.query}
 function getUpdate (v) {return v.u || v.update}
 
 // Command identifiers
-function notUndef (...args) {
+function ifDef (...args) {
   return function (o) {
     return args.reduce((r, v) => r || v in o || v.toLowerCase() in o, false)
   }
@@ -209,73 +207,73 @@ function makeBaseData (ctx, ns) {
 // BAM note: why does the order matter?
 const dataMakers = [
   // Databases
-  [notUndef('dropDatabase'), function (data) {
+  [ifDef('dropDatabase'), function (data) {
     data.QueryOp = 'drop'
   }],
 
   // Collections
-  [notUndef('create'), function (data, cmd) {
+  [ifDef('create'), function (data, cmd) {
     data.QueryOp = 'create_collection'
     data.New_Collection_Name = cmd.create
   }],
-  [notUndef('renameCollection'), function (data, cmd) {
+  [ifDef('renameCollection'), function (data, cmd) {
     data.QueryOp = 'rename'
     data.New_Collection_Name = cmd.to.slice(cmd.to.indexOf('.') + 1)
   }],
-  [notUndef('dropCollection', 'drop'), function (data) {
+  [ifDef('dropCollection', 'drop'), function (data) {
     data.QueryOp = 'drop_collection'
   }],
 
   // Finding
-  [notUndef('distinct'), function (data, cmd) {
+  [ifDef('distinct'), function (data, cmd) {
     data.QueryOp = 'distinct'
     data.Query = JSON.stringify(getQuery(cmd))
     data.Key = cmd.key
   }],
-  [notUndef('find'), function (data, cmd) {
+  [ifDef('find'), function (data, cmd) {
     data.QueryOp = 'find'
     data.Query = JSON.stringify(cmd.query)
   }],
-  [notUndef('findAndModify'), function (data, cmd) {
+  [ifDef('findAndModify'), function (data, cmd) {
     data.QueryOp = 'find_and_modify'
     data.Query = JSON.stringify(cmd.query)
     data.Update_Document = JSON.stringify(cmd.update)
   }],
-  [notUndef('count'), function (data, cmd) {
+  [ifDef('count'), function (data, cmd) {
     data.QueryOp = 'count'
     data.Query = JSON.stringify(getQuery(cmd))
   }],
 
   // Modifying
-  [notUndef('insert'), function (data, cmd) {
+  [ifDef('insert'), function (data, cmd) {
     data.QueryOp = 'insert'
     data.Insert_Document = JSON.stringify(cmd.documents)
   }],
-  [notUndef('update'), function (data, cmd) {
+  [ifDef('update'), function (data, cmd) {
     data.QueryOp = 'update'
     data.Query = JSON.stringify(cmd.updates.map(getQuery))
     data.Update_Document = JSON.stringify(cmd.updates.map(getUpdate))
   }],
-  [notUndef('delete'), function (data, cmd) {
+  [ifDef('delete'), function (data, cmd) {
     data.QueryOp = 'remove'
     data.Query = JSON.stringify(cmd.deletes.map(getQuery))
   }],
 
   // Indexes
-  [notUndef('createIndexes'), function (data, cmd) {
+  [ifDef('createIndexes'), function (data, cmd) {
     data.QueryOp = 'create_indexes'
     data.Indexes = JSON.stringify(cmd.indexes)
   }],
-  [notUndef('deleteIndexes', 'dropIndexes'), function (data, cmd) {
+  [ifDef('deleteIndexes', 'dropIndexes'), function (data, cmd) {
     data.QueryOp = 'drop_indexes'
     data.Index = JSON.stringify(cmd.index)
   }],
-  [notUndef('reIndex'), function (data) {
+  [ifDef('reIndex'), function (data) {
     data.QueryOp = 'reindex'
   }],
 
   // Aggregation
-  [notUndef('group'), function (data, cmd) {
+  [ifDef('group'), function (data, cmd) {
     data.QueryOp = 'group'
     data.Group_Condition = JSON.stringify(cmd.group.cond)
     data.Group_Initial = JSON.stringify(cmd.group.initial)
@@ -288,7 +286,7 @@ const dataMakers = [
     }
     data.Group_Key = JSON.stringify(cmd.group.key)
   }],
-  [notUndef('mapReduce'), function (data, cmd) {
+  [ifDef('mapReduce'), function (data, cmd) {
     data.QueryOp = 'map_reduce'
     data.Map_Function = cmd.map
     data.Reduce_Function = cmd.reduce
@@ -296,7 +294,7 @@ const dataMakers = [
       data.Finalize_Function = cmd.finalize
     }
   }],
-  [notUndef('aggregate'), function (data, cmd) {
+  [ifDef('aggregate'), function (data, cmd) {
     data.QueryOp = 'aggregate'
     data.Pipeline = JSON.stringify(cmd.pipeline)
   }]

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -13,48 +13,40 @@ module.exports = function (mongodb, options) {
 
   // node 12 with mongodb-core prior to v3 exhibits a memory leak with cls-hooked.
   if (semver.gte(process.version, '11.0.0') && semver.lt(version, '3.0.0')) {
-    ao.loggers.patching(`disabling mongodb-core probe for node version ${process.version}`);
+    ao.loggers.patching(`disabling mongodb-core ${version} probe for node ${process.version}`);
     return mongodb;
   }
 
   // Patch Server
-  {
-    const proto = mongodb.Server && mongodb.Server.prototype
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('Server.prototype')
-    }
+  let proto = mongodb.Server && mongodb.Server.prototype;
+  if (proto) {
+    patchCommands(proto);
+  } else {
+    logMissing('Server.prototype');
   }
 
   // Patch ReplSet
-  {
-    const proto = mongodb.ReplSet && mongodb.ReplSet.prototype
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('ReplSet.prototype')
-    }
+  proto = mongodb.ReplSet && mongodb.ReplSet.prototype;
+  if (proto) {
+    patchCommands(proto);
+  } else {
+    logMissing('ReplSet.prototype');
   }
 
   // Patch Mongos
-  {
-    const proto = mongodb.Mongos && mongodb.Mongos.prototype
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('Mongos.prototype')
-    }
+  proto = mongodb.Mongos && mongodb.Mongos.prototype;
+  if (proto) {
+    patchCommands(proto);
+  } else {
+    logMissing('Mongos.prototype');
   }
 
   // Patch Cursor
-  {
-    const proto = mongodb.Cursor && mongodb.Cursor.prototype
-    if (proto) {
-      patchCursor(proto)
-    } else {
-      logMissing('Cursor.prototype')
-    }
+  proto = mongodb.Cursor && mongodb.Cursor.prototype
+  if (proto) {
+    patchCursor(proto)
+  } else {
+    logMissing('Cursor.prototype')
   }
 
   return [mongodb, version];
@@ -168,7 +160,12 @@ function getUpdate (v) {return v.u || v.update}
 // Command identifiers
 function ifDef (...args) {
   return function (o) {
-    return args.reduce((r, v) => r || v in o || v.toLowerCase() in o, false)
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] in o || args[i].toLowerCase() in o) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -7,11 +7,6 @@ const ao = require('..');
 const requirePatch = require('../require-patch');
 const conf = ao.probes['mongodb-core'];
 
-const pkg = requirePatch.relativeRequire('mongodb-core/package.json');
-const version = pkg.version;
-
-const requirePatch = require('../require-patch');
-
 const version = requirePatch.relativeRequire('mongodb-core/package.json').version;
 
 const logMissing = ao.makeLogMissing('mongodb-core')

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -17,10 +17,17 @@ module.exports = function (mongodb, options) {
     return [mongodb, `${version} (no-op)`];
   }
 
+  //
+  // now patch the prototypes of each topology. because the prototype is being
+  // patched, not the module exports themselves, there is no need to replace the
+  // module's entry in require.cache. this just modifies the prototypes of the
+  // exports cached in require.cache.
+  //
+
   // Patch Server
   let core;
   try {
-    core = requirePatch.inertRelReq('mongodb/lib/core/topologies/server.js');
+    core = requirePatch.relReq('mongodb/lib/core/topologies/server.js');
   } catch (e) {
     logMissing('topologies/server.js');
   }
@@ -34,7 +41,7 @@ module.exports = function (mongodb, options) {
 
   // Patch ReplSet
   try {
-    core = requirePatch.inertRelReq('mongodb/lib/core/topologies/replset.js');
+    core = requirePatch.relReq('mongodb/lib/core/topologies/replset.js');
   } catch (e) {
     logMissing('topologies/replset.js');
   }
@@ -48,7 +55,7 @@ module.exports = function (mongodb, options) {
 
   // Patch Mongos
   try {
-    core = requirePatch.inertRelReq('mongodb/lib/core/topologies/mongos.js');
+    core = requirePatch.relReq('mongodb/lib/core/topologies/mongos.js');
   } catch (e) {
     logMissing('topologies/mongos.js');
   }
@@ -111,7 +118,6 @@ function patchCommand (obj) {
     }
     return ao.instrument(
       () => {
-        console.log('command executed');
         return {
           name: 'mongodb',
           kvpairs: makeData(this, ns, cmd)

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -1,17 +1,16 @@
 'use strict'
 
-const shimmer = require('ximmer')
 const semver = require('semver');
+const shimmer = require('ximmer')
 
 const ao = require('..')
 const requirePatch = require('../require-patch');
 const conf = ao.probes.mongodb;
 
-const version = requirePatch.relativeRequire('mongodb/package.json').version;
-
 const logMissing = ao.makeLogMissing('mongodb')
 
-module.exports = function (mongodb) {
+module.exports = function (mongodb, options) {
+  const {version} = options;
 
   // v3.3.0 is the first version of mongodb that doesn't use mongodb-core.
   if (semver.lt(version, '3.3.0')) {
@@ -19,61 +18,53 @@ module.exports = function (mongodb) {
   }
 
   // Patch Server
-  {
-    let coreServer;
-    try {
-      coreServer = requirePatch.relativeRequire('mongodb/lib/core/topologies/server.js');
-    } catch (e) {
-      logMissing('topologies/server.js');
-    }
-    const proto = coreServer && coreServer.prototype || mongodb.Server && mongodb.Server.prototype;
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('Server.prototype')
-    }
+  let core;
+  try {
+    core = requirePatch.inertRelReq('mongodb/lib/core/topologies/server.js');
+  } catch (e) {
+    logMissing('topologies/server.js');
   }
+  let proto = core && core.prototype || mongodb.Server && mongodb.Server.prototype;
+  if (proto) {
+    patchCommands(proto)
+  } else {
+    logMissing('Server.prototype')
+  }
+  core = undefined;
 
   // Patch ReplSet
-  {
-    let core;
-    try {
-      core = requirePatch.relativeRequire('mongodb/lib/core/topologies/replset.js');
-    } catch (e) {
-      logMissing('topologies/replset.js');
-    }
-    const proto = core && core.prototype || mongodb.ReplSet && mongodb.ReplSet.prototype;
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('ReplSet.prototype')
-    }
+  try {
+    core = requirePatch.inertRelReq('mongodb/lib/core/topologies/replset.js');
+  } catch (e) {
+    logMissing('topologies/replset.js');
   }
+  proto = core && core.prototype || mongodb.ReplSet && mongodb.ReplSet.prototype;
+  if (proto) {
+    patchCommands(proto)
+  } else {
+    logMissing('ReplSet.prototype')
+  }
+  core = undefined;
 
   // Patch Mongos
-  {
-    let core;
-    try {
-      core = requirePatch.relativeRequire('mongodb/lib/core/topologies/mongos.js');
-    } catch (e) {
-      logMissing('topologies/mongos.js');
-    }
-    const proto = core && core.prototype || mongodb.Mongos && mongodb.Mongos.prototype
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('Mongos.prototype')
-    }
+  try {
+    core = requirePatch.inertRelReq('mongodb/lib/core/topologies/mongos.js');
+  } catch (e) {
+    logMissing('topologies/mongos.js');
+  }
+  proto = core && core.prototype || mongodb.Mongos && mongodb.Mongos.prototype;
+  if (proto) {
+    patchCommands(proto)
+  } else {
+    logMissing('Mongos.prototype')
   }
 
   // Patch Cursor
-  {
-    const proto = mongodb.Cursor && mongodb.Cursor.prototype
-    if (proto) {
-      patchCursor(proto)
-    } else {
-      logMissing('Cursor.prototype')
-    }
+  proto = mongodb.Cursor && mongodb.Cursor.prototype;
+  if (proto) {
+    patchCursor(proto)
+  } else {
+    logMissing('Cursor.prototype')
   }
 
   return [mongodb, version];
@@ -120,6 +111,7 @@ function patchCommand (obj) {
     }
     return ao.instrument(
       () => {
+        console.log('command executed');
         return {
           name: 'mongodb',
           kvpairs: makeData(this, ns, cmd)

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -191,7 +191,6 @@ function ifDef (...args) {
       }
     }
     return false;
-    //return args.reduce((r, v) => r || v in o || v.toLowerCase() in o, false)
   }
 }
 

--- a/lib/require-patch.js
+++ b/lib/require-patch.js
@@ -17,6 +17,7 @@ exports = module.exports = {
     probes[name] = path;
     // supply a skeletal config if none is present.
     if (!ao.probes[name]) {
+      ao.loggers.debug(`require-patch supplying default config for probe ${name}`);
       ao.probes[name] = {enabled: true};
     }
   },
@@ -56,7 +57,7 @@ function patchedRequire (name) {
   // Only apply probes on first run
   if (mod && probes.hasOwnProperty(name) && !patched.get(mod)) {
     // Set relative require helper to point to the module being patched
-    exports.relativeRequire = this.require.bind(this);
+    exports.relReq = exports.relativeRequire = this.require.bind(this);
     exports.inertRelReq = function (file) {
       exports.disable();
       exports.relativeRequire(file);

--- a/lib/require-patch.js
+++ b/lib/require-patch.js
@@ -44,26 +44,44 @@ const nameToPatchFile = {
 }
 
 function patchedRequire (name) {
-  let mod = realRequire.call(this, name)
+  let mod = realRequire.call(this, name);
+
+  let pkg = {version: ''};
+  try {
+    pkg = this.require.call(this, `${name}/package.json`);
+  } catch (e) {
+    // nothing to do.
+  }
 
   // Only apply probes on first run
   if (mod && probes.hasOwnProperty(name) && !patched.get(mod)) {
     // Set relative require helper to point to the module being patched
     exports.relativeRequire = this.require.bind(this);
+    exports.inertRelReq = function (file) {
+      exports.disable();
+      exports.relativeRequire(file);
+      exports.enable();
+    };
+
+    const options = {name, version: pkg.version};
 
     // patch the module that was required above. 'name' is passed so
-    // that @hapi/hapi and hapi (as well as @hapi/vision and vision)
-    // can share the same probe code.
+    // multiple modules can share the same probe code, e.g., @hapi/hapi
+    // and hapi.
+    //
     // N.B. the amqplib/callback_api probe makes the second argument
     // an options object. if more information is needed by a probe
     // at some point, e.g., {name, newInfo: ...} then the second argument
     // here should become an options object and amqplib/callback_api will
     // need to be modified in addition to the @hapi probes.
     const path = Module._resolveFilename(name, this);
-    mod = realRequire(probes[name])(mod, name);
 
-    // allow patchers to return the patched version for display.
-    let v;
+    // require the probe with the real module as the first argument.
+    mod = realRequire(probes[name])(mod, options);
+
+    // allow patchers to return the version patched for logging. in order to
+    // return the version they should return [patched-module, version-info-string].
+    let v = pkg.version;
     if (Array.isArray(mod)) {
       v = mod[1];
       mod = mod[0];
@@ -77,7 +95,7 @@ function patchedRequire (name) {
       require.cache[path].exports = mod
     }
 
-    ao.loggers.patching(`patched ${name} ${v ? v : ''}`)
+    ao.loggers.patching(`patched ${name} ${v}`);
   }
 
   return mod

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -188,7 +188,6 @@ function makeTests (db_host, host, isReplicaSet) {
       msg.should.have.property('Spec', 'query')
       msg.should.have.property('Flavor', 'mongodb')
       msg.should.have.property('RemoteHost')
-      //msg.RemoteHost.should.match(/:\d*$/)
       expect(msg.RemoteHost).oneOf(db_host.split(','));
     },
     common: function (msg) {
@@ -196,15 +195,12 @@ function makeTests (db_host, host, isReplicaSet) {
     },
     entry: function (msg) {
       const explicit = `${msg.Layer}:${msg.Label}`;
-      //console.log(`expecting ${moduleName}:entry got ${explicit}`);
       expect(explicit).equal(`${moduleName}:entry`, 'message Layer and Label must be correct');
       check.base(msg)
     },
     exit: function (msg) {
       const explicit = `${msg.Layer}:${msg.Label}`;
       expect(explicit).equal(`${moduleName}:exit`, 'message Layer and Label must be correct');
-      msg.should.have.property('Layer', moduleName)
-      msg.should.have.property('Label', 'exit')
     }
   }
 

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -45,8 +45,8 @@ if (process.env.CI === 'true' && process.env.TRAVIS === 'true') {
 // during matrix testing. It's not needed when testing only one instance
 // at a time locally. Save database name and collection name.
 
-const dbn = 'test' + (process.env.AO_IX ? '-' + process.env.AO_IX : '')
-const cn = `coll-${dbn}`
+const dbn = 'test' + (process.env.AO_IX ? '-' + process.env.AO_IX : '');
+const cn = `coll-${dbn}`;
 
 describe('probes.mongodb UDP', function () {
   let emitter
@@ -96,7 +96,6 @@ function makeTests (db_host, host, isReplicaSet) {
   const ctx = {}
   let emitter
   let db
-  //let realSampleTrace
 
   const options = {
     writeConcern: {w: 1},
@@ -232,23 +231,6 @@ function makeTests (db_host, host, isReplicaSet) {
       })
     }
   })
-  before(function (done) {
-    /*
-    if (!db) {
-      done()
-      return
-    }
-    db.command(
-      `${dbn}.$cmd`,
-      {dropDatabase: 1},
-      function (err) {
-        ao.loggers.test.debug('before() dropDatabase callback', err)
-        done(err)
-      }
-    )
-    // */
-    done()
-  })
   after(function () {
     if (ctx.client) {
       ctx.client.close()
@@ -336,7 +318,7 @@ function makeTests (db_host, host, isReplicaSet) {
           db.command({create: cn},
             function (e, data) {
               if (e) {
-                ao.loggers.test.debug(`error creating "coll-${dbn}`, e)
+                ao.loggers.error(`error creating "${cn}"`, e)
                 done(e)
                 return
               }
@@ -371,13 +353,13 @@ function makeTests (db_host, host, isReplicaSet) {
         helper.test(emitter, function (done) {
           adminDb.command(
             {
-              renameCollection: `${dbn}.coll-${dbn}`,
+              renameCollection: `${dbn}.${cn}`,
               to: `${dbn}.coll2-${dbn}`,
               dropTarget: true
             },
             function (e, data) {
               if (e) {
-                ao.loggers.debug(`error renaming "coll-${dbn} to ${dbn}.coll2-${dbn}`, e)
+                ao.loggers.debug(`error renaming "${cn}" to "${dbn}.coll2-${dbn}"`, e)
                 done(e)
                 return
               }
@@ -607,14 +589,7 @@ function makeTests (db_host, host, isReplicaSet) {
           check.exit(msg)
         }
 
-        const steps = [entry]
-        /*
-        if (isReplicaSet) {
-          steps.push(entry)
-          steps.push(exit)
-        }
-        // */
-        steps.push(exit)
+        const steps = [entry, exit];
 
         helper.test(emitter, function (done) {
           ctx.collection.countDocuments(

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -294,7 +294,7 @@ function makeTests (db_host, host, isReplicaSet) {
 
         const steps = [entry]
 
-        if (isReplicaSet && moduleName === 'mongodb-core') {
+        if (isReplicaSet) {
           steps.push(entry)
           steps.push(exit)
         }
@@ -551,7 +551,6 @@ function makeTests (db_host, host, isReplicaSet) {
         steps.push(exit)
 
         helper.test(emitter, function (done) {
-          debugger
           ctx.collection.distinct(
             key,
             query,

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -250,18 +250,12 @@ function makeTests (db_host, host, isReplicaSet) {
     },
     entry: function (msg) {
       const explicit = `${msg.Layer}:${msg.Label}`;
-      //console.log(`expecting ${moduleName}:entry got ${explicit}`);
-      //console.log(msg);
       expect(explicit).equal(`${moduleName}:entry`, 'message Layer and Label must be correct');
       check.base(msg)
     },
     exit: function (msg) {
       const explicit = `${msg.Layer}:${msg.Label}`;
-      //console.log(`expecting ${moduleName}:exit got ${explicit}`);
-      //console.log(msg);
       expect(explicit).equal(`${moduleName}:exit`, 'message Layer and Label must be correct');
-      msg.should.have.property('Layer', moduleName)
-      msg.should.have.property('Label', 'exit')
     }
   }
 

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -1,11 +1,8 @@
 'use strict'
 
-/* eslint-disable no-console */
-
 const helper = require('../helper')
 const {ao} = require('../1.test-common.js')
 
-const expect = require('chai').expect;
 
 const noop = helper.noop
 const addon = ao.addon
@@ -14,10 +11,9 @@ const semver = require('semver')
 const mongodb = require('mongodb')
 const MongoClient = mongodb.MongoClient
 
-const requirePatch = require('../../lib/require-patch')
-requirePatch.disable()
-const pkg = requirePatch.relativeRequire('mongodb/package.json');
-requirePatch.enable()
+const expect = require('chai').expect;
+
+const pkg = require('mongodb/package.json');
 
 // prior to version 3.3.0 mongodb used mongodb-core. from 3.3.0 on mongodb
 // has incorporated those functions into its own codebase.
@@ -30,7 +26,8 @@ let hosts = {
   'replica set': process.env.AO_TEST_MONGODB_SET
 }
 
-// version 3 of mongodb-core removed the 2.4 protocol driver.
+// version 3 of mongodb-core removed the 2.4 protocol driver. and mongodb 3.0.0
+// uses mongodb-core 3.0.0
 if (semver.gte(pkg.version, '3.0.0')) {
   delete hosts['2.4']
 }
@@ -91,11 +88,15 @@ describe('probes/mongodb ' + pkg.version, function () {
   })
 })
 
+
+//
+// make the tests
+//
 function makeTests (db_host, host, isReplicaSet) {
   const ctx = {}
   let emitter
   let db
-  let realSampleTrace
+  //let realSampleTrace
 
   const options = {
     writeConcern: {w: 1},
@@ -106,7 +107,25 @@ function makeTests (db_host, host, isReplicaSet) {
   // Intercept appoptics messages for analysis
   //
   beforeEach(function (done) {
-    const current = this.currentTest
+    ao.probes.fs.enabled = false
+    ao.sampleRate = addon.MAX_SAMPLE_RATE
+    ao.traceMode = 'always'
+    ao.probes[moduleName].collectBacktraces = false
+    emitter = helper.appoptics(function () {
+      done();
+    });
+  });
+  afterEach(function (done) {
+    ao.probes.fs.enabled = true
+    emitter.close(function () {
+      done();
+    });
+  });
+
+
+  // skip specific tests to faciliate test debugging.
+  beforeEach(function () {
+    const current = this.currentTest;
     const doThese = {
       databases: true,
       collections: true,
@@ -116,27 +135,24 @@ function makeTests (db_host, host, isReplicaSet) {
       aggregations: true,
     }
     if (current.parent && !(current.parent.title in doThese)) {
-      this.skip()
     }
-    if (current.title !== 'should distinct' && current.title !== 'should count') {
-      //this.skip();
+    // skip specific titles
+    const skipTheseTitles = [];
+    if (skipTheseTitles.indexOf(current.title) >= 0) {
     }
-
-    ao.probes.fs.enabled = false
-    emitter = helper.appoptics(done)
-    ao.sampleRate = addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return {sample: true, source: 6, rate: ao.sampleRate}
+    // do only these specific titles
+    const doTheseTitles = [
+      'should drop',
+      'should distinct',
+      'should count',
+    ];
+    if (doTheseTitles.length && doTheseTitles.indexOf(current.title) >= 0) {
+      //ao.logger.addEnabled('span');
     }
-    ao.probes[moduleName].collectBacktraces = false
-  })
-  afterEach(function (done) {
-    ao.probes.fs.enabled = true
-    ao.addon.Context.sampleTrace = realSampleTrace
-    emitter.close(done)
-  })
+  });
+  afterEach(function () {
+    //ao.logger.removeEnabled('span');
+  });
 
   //
   // Open a fresh mongodb connection for each test
@@ -151,8 +167,6 @@ function makeTests (db_host, host, isReplicaSet) {
         port: Number(port)
       }
     })
-
-    //ao.logLevel = 'error,warn,debug,patching'
 
     ao.loggers.test.debug(`using dbn ${dbn}`)
 
@@ -172,6 +186,7 @@ function makeTests (db_host, host, isReplicaSet) {
       mongoClient.connect((err, _client) => {
         ao.loggers.test.debug('mongoClient() connect callback', err)
         if (err) {
+          // eslint-disable-next-line no-console
           console.log('error connecting', err)
           return done(err)
         }
@@ -194,11 +209,14 @@ function makeTests (db_host, host, isReplicaSet) {
       if (semver.gte(pkg.version, '3.0.0')) {
         server = new mongodb.Server(host.host, host.port)
         mongoClient = new MongoClient(server, mongoOptions)
+      } else {
+        throw new Error(`mongodb v${pkg.version} is not supported`);
       }
 
       mongoClient.connect((err, _client) => {
         ao.loggers.test.debug('mongoClient() connect callback', err)
         if (err) {
+          // eslint-disable-next-line no-console
           console.log('error connecting', err)
           return done(err)
         }
@@ -242,7 +260,6 @@ function makeTests (db_host, host, isReplicaSet) {
       msg.should.have.property('Spec', 'query')
       msg.should.have.property('Flavor', 'mongodb')
       msg.should.have.property('RemoteHost')
-      //msg.RemoteHost.should.match(/:\d*$/)
       expect(msg.RemoteHost).oneOf(db_host.split(','));
     },
     common: function (msg) {
@@ -264,7 +281,7 @@ function makeTests (db_host, host, isReplicaSet) {
   //
   const tests = {
     databases: function () {
-      it('should drop', function (done) {
+      it('should drop', function (tdone) {
         function entry (msg) {
           check.entry(msg)
           check.common(msg)
@@ -277,7 +294,7 @@ function makeTests (db_host, host, isReplicaSet) {
 
         const steps = [entry]
 
-        if (isReplicaSet) {
+        if (isReplicaSet && moduleName === 'mongodb-core') {
           steps.push(entry)
           steps.push(exit)
         }
@@ -286,7 +303,7 @@ function makeTests (db_host, host, isReplicaSet) {
 
         helper.test(emitter, function (done) {
           db.command({dropDatabase: 1}, done)
-        }, steps, done)
+        }, steps, tdone)
       })
     },
 
@@ -534,6 +551,7 @@ function makeTests (db_host, host, isReplicaSet) {
         steps.push(exit)
 
         helper.test(emitter, function (done) {
+          debugger
           ctx.collection.distinct(
             key,
             query,

--- a/test/versions.js
+++ b/test/versions.js
@@ -1,8 +1,8 @@
 'use strict'
 
 //
-// this file defines the versions that will be test when using
-// test-each-version.
+// this file defines the versions that will be tested when using
+// testeachversion.
 //
 
 const {VersionSpec} = require('testeachversion')


### PR DESCRIPTION
- move version fetching to require-patch.js and pass version to probes
- align mongodb and mongodb-core probes and test code more closely
- remove sampleTrace() references in mongodb/mongodb-core testing
- backtrack on test-skipping logic because it fails to execute afterEach()