### PR TITLE
V x.x.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,3 +76,24 @@ Bug fixes
 - make TemplateLanguage KV consistent - never include leading dot.
 - bind finalizer in instrumentHttp.
 - fix zlib bind emitter message.
+
+### v6.8.0
+
+Features
+- fetch container information in Azure App Service environment.
+
+### v6.9.0
+
+Features
+- new `mongodb` probe for versions >= 3.3.0 as it now longer uses `mongodb-core`.
+- allow the `fs` probe to ignore specific errors.
+- `patching` log setting logs the version of patched modules.
+- disable `mongodb-core` versions < 3 for node versions > 11.15.0 due to v8 memory leak.
+
+Bug fixes
+- supply a default `TransactionName` when none is present.
+- log only one message for `getTraceSettings()` errors.
+- log only one message for each incorrect KV pair.
+- reset both count and time windows when a debounced log message is issued.
+- add missing `FileDescriptor` to exit events.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,19 @@ are many different ways to do so ranging from npm's `link` command, manually cop
 options embedded in the npm `postinstall` script, `install-appoptics-bindings.js`. The primary
 documentation for this advanced feature is the code.
 
+### Testing against all supported versions of the package
+
+When a probe has been updated all supported versions of a package must be tested. The package `testeachversion`
+facilitates this. `test/versions.js` defines the supported versions for each package we supply probes for. `testeachversion`
+uses this file by default. To test all supported versions of a given package use the command:
+
+`node_modules/.bin/testeachversion -p package-name`
+
+If you don't specify the `-p package-name` option, all supported versions of all packages will be tested. That
+takes a while. `testeachversion` writes two files, a details file and a summary file. More information and options
+is available via `testeachversion -h`.
+
+
 
 ## Docs
 

--- a/appoptics-apm.json
+++ b/appoptics-apm.json
@@ -4,7 +4,12 @@
     "domainPrefix": "",
     "probes": {
       "fs": {
-        "enabled": true
+        "enabled": true,
+        "ignoreErrors": {
+          "open": {
+            "ENOENT": true
+          }
+        }
       }
     }
 }

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -27,7 +27,7 @@ The configuration file can supply the following properties, showing their defaul
   insertTraceIdsIntoMorgan: false,
   createTraceIdsToken: undefined,
   probes: {
-    // probe-specific defaults. see dist/defaults.js for details
+    // probe-specific defaults. see lib/probe-defaults.js for details
   }
 }
 ```

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -52,9 +52,17 @@ The configuration file can supply the following properties, showing their defaul
 
 #### Configuration File Probe Settings ####
 
-Probes are the packages that `appoptics-apm` auto-instruments. Different types of probes have different configuration options. See `dist/defaults.js` (or `lib/defaults.js` if you've cloned the github repository) for details.
+Probes are the packages that `appoptics-apm` auto-instruments. Different types of probes have different configuration options. See `lib/defaults.js` for details.
 
-Probe settings in the `appoptics-apm` configuration file will override those in `defaults.js`, so the best approach to changing an option is to add it to `appoptics-apm.json`. For example, here is how to turn off sampling for `fs`:
+There is one particular setting for the `fs` probe that you might want to be aware of: `ignoreErrors`. The only errors that can be ignored are node
+System errors (see the node [docs](https://nodejs.org/api/errors.html#errors_common_system_errors)) provided by the asynchronous functions or thrown
+by the synchronous functions. Note that there is only one setting for each pair of asynchronous and synchronous functions, e.g. the `open` setting
+applies to both `fs.open()` and `fs.openSync()`.
+
+Ignoring the `ENOENT` error for the `fs.open()` and `fs.openSync()` functions is shown in the examples below. This setting won't take effect because of
+the `fs` probe setting `enabled: false` but is shown for the syntax.
+
+Probe settings in the `appoptics-apm` configuration file will override those in `defaults.js`, so the safest approach to changing an option is to add it to `appoptics-apm.json`. For example, here is how to turn off sampling for `fs`:
 
 ```
 {
@@ -62,7 +70,12 @@ Probe settings in the `appoptics-apm` configuration file will override those in 
   "serviceKey": "...",
   "probes": {
     "fs": {
-      "enabled": false
+      "enabled": false,
+      "ignoreErrors": {
+        "open": {
+          "ENOENT": true
+        }
+      }
     }
   }
 }
@@ -77,7 +90,12 @@ module.exports = {
   // isn't this much better?
   probes: {
     fs: {
-      enabled: false
+      enabled: false,
+      ignoreErrors: {
+        open: {
+          ENOENT: true,
+        }
+      }
     }
   }
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -11,6 +11,7 @@ let Span;
 
 let dbBind;
 let dbInfo;
+let dbSettingsError;
 
 const udp = process.env.APPOPTICS_REPORTER === 'udp';
 
@@ -26,6 +27,7 @@ module.exports = function (appoptics) {
   // create the debounced loggers
   dbBind = new log.Debounce('bind');
   dbInfo = new log.Debounce('info');
+  dbSettingsError = new log.Debounce('error');
 
   // keep weakmap references in a central place.
   ao.maps.responseIsPatched = responseIsPatched;
@@ -349,6 +351,7 @@ function readyToSample (ms, obj) {
   return status === 1
 }
 
+
 /**
  * @typedef {object} TraceSettings
  * @property {boolean} doSample - the sample decision
@@ -396,7 +399,7 @@ function getTraceSettings (xtrace, options = {}) {
   ao.lastSettings = osettings
 
   if (osettings.status > 0) {
-    ao.loggers.warn(`getTraceSettings() - ${osettings.message}(${osettings.error})`)
+    dbSettingsError.log(`getTraceSettings() - ${osettings.message}(${osettings.status})`)
     // if an error it's not clear which properties will be set. make sure values exist.
     osettings = Object.assign({
       doSample: false,

--- a/lib/event.js
+++ b/lib/event.js
@@ -185,9 +185,9 @@ Event.prototype.set = function (data) {
       // use the setter to decompose the error into appropriate keys
       this.error = data[k]
     } else {
-      const stack = ao.stack('Invalid type', 8)
       const type = Number.isNaN(data[k]) ? 'NaN' : typeof data[k]
-      log.error('Invalid type for KV %s: %s\n%s', k, type, stack)
+      const stack = ao.stack(`Invalid type for KV ${k}: ${type}`);
+      log.error(stack);
     }
   }
 }

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -2,6 +2,9 @@
 
 const path = require('path');
 
+// this is filled in later.
+const probeConfigChecks = {};
+
 function getUnifiedConfig () {
 
   const errors = [];        // for each error and array of arguments for log.error()
@@ -204,6 +207,17 @@ function getUnifiedConfig () {
   // that probe-defaults matches valid probes in lib/probes/.
   Object.keys(probeDefaults).forEach(mod => {
     results.probes[mod] = Object.assign({}, probeDefaults[mod], fileProbesConfig[mod]);
+    // if there is a check for this probe's config then use it.
+    if (probeConfigChecks[mod]) {
+      const probeResults = probeConfigChecks[mod](results.probes[mod]);
+      results.probes[mod] = probeResults.validConfig;
+      if (probeResults.errors) {
+        probeResults.errors.forEach(e => errors.push(e));
+      }
+      if (probeResults.warnings) {
+        probeResults.warnings.forEach(w => {warnings.push(w)});
+      }
+    }
     delete fileProbesConfig[mod];
   })
 
@@ -234,6 +248,40 @@ function getUnifiedConfig () {
   }
 
   return results;
+}
+
+//====================================
+// probe configuration check functions
+//====================================
+
+probeConfigChecks.fs = function (cfg) {
+  const errors = [];
+  const warnings = [];
+  const validConfig = Object.assign({}, cfg);
+  const validErrorObjects = {};
+
+  // could do more validation but the goal here is to make sure the checking function can use
+  // `in` on both levels of the ignoreErrors object. the checks it makes are:
+  //   `conf.ignoreErrors && method in conf.ignoreErrors`
+  // followed by:
+  //   `err.code in conf.ignoreErrors[method]`
+  if (cfg.ignoreErrors && typeof cfg.ignoreErrors !== 'object') {
+    errors.push(`invalid ignoreErrors setting: ${JSON.stringify(cfg.ignoreErrors)}`)
+    delete validConfig.ignoreErrors;
+  }
+  for (const e2i in validConfig.ignoreErrors) {
+    if (typeof validConfig.ignoreErrors[e2i] === 'object') {
+      validErrorObjects[e2i] = validConfig.ignoreErrors[e2i];
+    } else {
+      const etext = JSON.stringify({[e2i]: validConfig.ignoreErrors[e2i]});
+      errors.push(`invalid error code to ignore: ${etext}`);
+    }
+  }
+  if (cfg.ignoreErrors && validConfig.ignoreErrors) {
+    validConfig.ignoreErrors = validErrorObjects;
+  }
+
+  return {validConfig, errors, warnings};
 }
 
 //================================================================

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -96,7 +96,9 @@ function getUnifiedConfig () {
   } catch (e) {
     // it's not an error if the default filename isn't found.
     if ((e.code !== 'ENOENT' && e.code !== 'MODULE_NOT_FOUND') || configFile !== defaultConfigFile) {
-      const extra = e.message ? `: ${e.message}` : '';
+      // node 12 changed the error format to include the stack in the message. splitting the message on
+      // that string is ugly but effective.
+      const extra = e.message ? `: ${e.message.split('\nRequire stack')[0]}` : '';
       errors.push(`Cannot read config file ${configFile}${extra}`);
     }
   }

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -61,7 +61,7 @@ function getUnifiedConfig () {
     sampleRate: {location: 'c', type: 'i', deprecated: true},
     reporter: {location: 'b', type: ['ssl', 'udp', 'file']},
     endpoint: {location: 'b', type: 's', name: 'COLLECTOR'},
-    trustedPath: {location: 'b', type: 's'},
+    trustedPath: {location: 'b', type: 's', name: 'TRUSTEDPATH'},
 
     // not currently used by the node agent
     tokenBucketCapacity: {location: 'o', type: 'i'},

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -192,8 +192,9 @@ function getUnifiedConfig () {
     }
   })
 
-
+  //
   // now get the probe defaults
+  //
   let probeDefaults;
   try {
     probeDefaults = require('./probe-defaults');
@@ -205,8 +206,7 @@ function getUnifiedConfig () {
   // require implementing defaults for each probe. if there becomes an obvious
   // need to check them in the future that will be the time to implement.
   // only consider known probes
-  // TODO BAM should this be driven from defaults? if so, maybe release check needs to verify
-  // that probe-defaults matches valid probes in lib/probes/.
+  // TODO BAM should this be driven from defaults?
   Object.keys(probeDefaults).forEach(mod => {
     results.probes[mod] = Object.assign({}, probeDefaults[mod], fileProbesConfig[mod]);
     // if there is a check for this probe's config then use it.
@@ -222,6 +222,10 @@ function getUnifiedConfig () {
     }
     delete fileProbesConfig[mod];
   })
+
+  //
+  // now get transaction settings
+  //
 
   // handle excluded urls separately. the form is an array of
   // objects, each of the form:
@@ -271,6 +275,7 @@ probeConfigChecks.fs = function (cfg) {
     errors.push(`invalid ignoreErrors setting: ${JSON.stringify(cfg.ignoreErrors)}`)
     delete validConfig.ignoreErrors;
   }
+  // e2i - error to ignore
   for (const e2i in validConfig.ignoreErrors) {
     if (typeof validConfig.ignoreErrors[e2i] === 'object') {
       validErrorObjects[e2i] = validConfig.ignoreErrors[e2i];

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -27,7 +27,7 @@ function getUnifiedConfig () {
     // end-user focused, config file only
     enabled: {location: 'c', type: 'b', default: true},
     ignoreConflicts: {location: 'c', type: 'b'},
-    domainPrefix: {location: 'c', type: 's'},
+    domainPrefix: {location: 'c', type: 'b'},
     insertTraceIdsIntoLogs: {location: 'c', type: 'b'},
     insertTraceIdsIntoMorgan: {location: 'c', type: 'b'},
     createTraceIdsToken: {location: 'c', type: {morgan: 'morgan'}},
@@ -313,8 +313,12 @@ function convert (value, type) {
   if (Array.isArray(type)) {
     return type.indexOf(value) >= 0 ? value : undefined;
   }
-  if (typeof type === 'object' && value.toLowerCase() in type) {
-    return type[value.toLowerCase()];
+  if (typeof type === 'object') {
+    if (value in type) {
+      return type[value];
+    } else if (typeof value === 'string' && value.toLowerCase() in type) {
+      return type[value.toLowerCase()];
+    }
   }
   return undefined;
 }

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -40,18 +40,15 @@ function Debounce (level, options) {
 }
 
 Debounce.prototype.show = function () {
-  // have the number of incremental errors exceeded the delta limit?
-  if ((this.count - this.lastCount) > this.dCount) {
-    this.lastCount = this.count
-    return true
+  const now = Date.now();
+  // has the count of errors exceeded the delta limit or the time
+  // window been exceeded?
+  if ((this.count - this.lastCount) > this.dCount || (now - this.lastTime) > this.dTime) {
+    this.lastCount = this.count;
+    this.lastTime = now;
+    return true;
   }
-  // has it been dTime miliseconds since the last?
-  const now = Date.now()
-  if ((now - this.lastTime) > this.dTime) {
-    this.lastTime = now
-    return true
-  }
-  return false
+  return false;
 }
 
 Debounce.prototype.log = function () {

--- a/lib/probe-defaults.js
+++ b/lib/probe-defaults.js
@@ -209,14 +209,20 @@ module.exports = {
     collectBacktraces: true,
   },
 
+  // patches aws so it doesn't include the x-trace header in its integrity check.
+  // it's only an issue if an error occurs and the message is retransmitted.
+  // like the context-maintaining modules this cannot be disabled; the setting is
+  // ignored.
+  'aws-sdk': {enabled: true},
+
   //
   // context maintaining modules. they cannot be disabled and are listed
   // for completeness.
   //
-  'aws-sdk': {enabled: true},
   bcrypt: {enabled: true},
   bluebird: {enabled: true},
   'generic-pool': {enabled: true},
+  mongoose: {enabled: true},
   q: {enabled: true},
 
 

--- a/lib/probes/@hapi/hapi.js
+++ b/lib/probes/@hapi/hapi.js
@@ -322,9 +322,8 @@ function patchDecorator (plugin, version) {
 //
 // Apply hapi patches
 //
-module.exports = function (hapi, name) {
-  const pkg = requirePatch.relativeRequire(`${name}/package.json`);
-  const version = pkg.version;
+module.exports = function (hapi, options) {
+  const {name, version} = options;
 
   if (semver.gte(version, '17.0.0')) {
     // v17 has completely different implementation. handler needs to be patched
@@ -421,5 +420,5 @@ module.exports = function (hapi, name) {
     }
   }
 
-  return [hapi, pkg.version];
+  return [hapi, version];
 }

--- a/lib/probes/@hapi/vision.js
+++ b/lib/probes/@hapi/vision.js
@@ -3,7 +3,6 @@
 const ao = global[Symbol.for('AppOptics.Apm.Once')];
 const path = require('path');
 
-const requirePatch = require(path.resolve(ao.root, 'lib', 'require-patch'));
 const shimmer = require('ximmer')
 const semver = require('semver')
 const log = ao.loggers
@@ -12,8 +11,8 @@ const conf = ao.probes.vision
 //
 // Apply vision patches
 //
-module.exports = function (vision, name) {
-  const {version} = requirePatch.relativeRequire(`${name}/package.json`)
+module.exports = function (vision, options) {
+  const {version} = options;
 
   // only version 5 is handled
   if (semver.lt(version, '5.0.0')) {

--- a/lib/probes/amqplib/callback_api.js
+++ b/lib/probes/amqplib/callback_api.js
@@ -2,6 +2,7 @@
 
 const probe = require('../amqplib')
 
-module.exports = function (amqplib, name) {
-  return probe(amqplib, {name, amqplib: {callbacks: true}})
+module.exports = function (amqplib, options) {
+  options.amqplib = {callbacks: true};
+  return probe(amqplib, options);
 }

--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -132,8 +132,15 @@ function patchPathMethod (fs, method) {
                 Operation: method,
                 FilePath: args[0],
               },
-              function (createdSpan) {
-                span = createdSpan
+              finalize (createdSpan) {
+                span = createdSpan;
+                if (conf.ignoreErrors && method in conf.ignoreErrors) {
+                  span.setIgnoreErrorFn(function (err) {
+                    // if looking at operation and/or path in the future:
+                    // span.events.entry.kv.Operation === 'open' ditto.FilePath
+                    return err.code in conf.ignoreErrors[method];
+                  })
+                }
               }
             }
           },
@@ -170,7 +177,14 @@ function patchPathMethod (fs, method) {
         }
         if (method === 'open') {
           spanInfo.finalize = function (createdSpan) {
-            span = createdSpan
+            span = createdSpan;
+            if (conf.ignoreErrors && method in conf.ignoreErrors) {
+              span.setIgnoreErrorFn(function (err) {
+                // if looking at operation and/or path in the future:
+                // span.events.entry.kv.Operation === 'openSync' ditto.FilePath
+                return err.code in conf.ignoreErrors[method];
+              })
+            }
           }
         }
         let span

--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -145,7 +145,8 @@ function patchPathMethod (fs, method) {
             }
           },
           cb => fn.apply(this, args.concat(function (err, fd) {
-            if (span && method === 'open') {
+            // there might not be an fd if there was an error.
+            if (span && method === 'open' && !err) {
               span.events.exit.set({FileDescriptor: fd})
             }
             return cb.apply(this, arguments)
@@ -200,8 +201,10 @@ function patchPathMethod (fs, method) {
           conf
         )
       }
-      if (method === 'realpath') {
-        f.native = fn.native
+      // method realpath has a native function but maybe others will be added.
+      if (fn.native) {
+        log.patching(`fs.${method} - adding native method`);
+        f.native = fn.native;
       }
       return f
     })

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -11,6 +11,9 @@ const Event = ao.Event
 
 const log = ao.loggers
 
+// avoid issuing too many errors on bad transactions
+const dbSendError = new log.Debounce('error');
+
 const ule = Symbol('UnexpectedLastEvent');
 
 const defaultPort = {
@@ -519,24 +522,26 @@ function patchServer (module, protocol) {
         // it replies with the txname that was actually used if there was an error
         const txname = ao.reporter.sendHttpSpan(args);
 
-        // they should match (except for the domain prefix)
-        if (txname && args.txname && txname !== args.txname
-          && ao.cfg.domainPrefix
-          && txname.indexOf(args.txname) + args.txname.length !== txname.length) {
-          log.warn(
-            'sendHttpSpan() changed TransactionName from %s to %s',
-            args.txname,
-            txname
-          )
+        // TODO BAM the txname not null check can be removed once appoptics-bindings has been
+        // changed to return the integer error code instead of a null string.
+        if (typeof txname === 'string' && txname) {
+          // if there is a txname and it doesn't match
+          if (args.txname && txname !== args.txname) {
+            // here the names don't match so we might need to log a warning.
+            // if there isn't a domain prefix warn about the difference and if there
+            // is a domain prefix warn if the trailing txname doesn't match.
+            if (!ao.cfg.domainPrefix || !txname.endsWith(txname)) {
+              log.warn(`sendHttpSpan() changed TransactionName from ${args.txname} to ${txname}`);
+            }
+          }
+
+          // if it's a string the worst it can be is an empty string.
+          exitKeyValuePairs.TransactionName = txname;
+        } else {
+          exitKeyValuePairs.TransactionName = args.txname || 'unknown';
+          dbSendError.log(`sendHttpSpan() code ${txname}`);
         }
 
-        // what to do if an error sending? don't know transaction name but shouldn't
-        // matter, so don't use the return value.
-        if (txname) {
-          exitKeyValuePairs.TransactionName = txname
-        } else {
-          log.error('sendHttpSpan() returned empty TransactionName')
-        }
       }
 
       span.exit(exitKeyValuePairs)

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -21,14 +21,13 @@ const defaultPort = {
   http: 80
 }
 
-module.exports = function (module, protocol) {
-  protocol = protocol || 'http'
-  patchServer(module, protocol)
-  patchClient(module, protocol)
+module.exports = function (module, options, protocol = 'http') {
+  patchServer(module, options, protocol)
+  patchClient(module, options, protocol)
   return module
 }
 
-function patchClient (module, protocol) {
+function patchClient (module, options, protocol) {
   const name = protocol + '-client'
   const conf = ao.probes[name]
 
@@ -195,7 +194,7 @@ function patchClient (module, protocol) {
 //
 // patch the server - it creates a topLevel span
 //
-function patchServer (module, protocol) {
+function patchServer (module, options, protocol) {
   const conf = ao.probes[protocol]
 
   const fowardedHeaders = [

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -305,10 +305,6 @@ function patchServer (module, protocol) {
     //
     const settings = ao.getTraceSettings(xtrace, settingsOptions);
 
-    if (settings.status > 0) {
-      log.error(`error fetching settings: ${settings.message} (${settings.status})`);
-    }
-
     const args = arguments;
 
     if (ao.Event.last) {

--- a/lib/probes/https.js
+++ b/lib/probes/https.js
@@ -2,6 +2,6 @@
 
 const httpPatch = require('./http')
 
-module.exports = function (module) {
-  return httpPatch(module, 'https')
+module.exports = function (module, options) {
+  return httpPatch(module, options, 'https')
 }

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -4,59 +4,49 @@ const semver = require('semver');
 const shimmer = require('ximmer')
 
 const ao = require('..');
-const requirePatch = require('../require-patch');
 const conf = ao.probes['mongodb-core'];
-
-const version = requirePatch.relativeRequire('mongodb-core/package.json').version;
 
 const logMissing = ao.makeLogMissing('mongodb-core')
 
-module.exports = function (mongodb) {
+module.exports = function (mongodb, options) {
+  const {version} = options;
 
   // node 12 with mongodb-core prior to v3 exhibits a memory leak with cls-hooked.
   if (semver.gte(process.version, '11.0.0') && semver.lt(version, '3.0.0')) {
-    ao.loggers.patching(`disabling mongodb-core probe for node version ${process.version}`);
+    ao.loggers.patching(`disabling mongodb-core ${version} probe for node ${process.version}`);
     return mongodb;
   }
 
   // Patch Server
-  {
-    const proto = mongodb.Server && mongodb.Server.prototype
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('Server.prototype')
-    }
+  let proto = mongodb.Server && mongodb.Server.prototype;
+  if (proto) {
+    patchCommands(proto);
+  } else {
+    logMissing('Server.prototype');
   }
 
   // Patch ReplSet
-  {
-    const proto = mongodb.ReplSet && mongodb.ReplSet.prototype
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('ReplSet.prototype')
-    }
+  proto = mongodb.ReplSet && mongodb.ReplSet.prototype;
+  if (proto) {
+    patchCommands(proto);
+  } else {
+    logMissing('ReplSet.prototype');
   }
 
   // Patch Mongos
-  {
-    const proto = mongodb.Mongos && mongodb.Mongos.prototype
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('Mongos.prototype')
-    }
+  proto = mongodb.Mongos && mongodb.Mongos.prototype;
+  if (proto) {
+    patchCommands(proto);
+  } else {
+    logMissing('Mongos.prototype');
   }
 
   // Patch Cursor
-  {
-    const proto = mongodb.Cursor && mongodb.Cursor.prototype
-    if (proto) {
-      patchCursor(proto)
-    } else {
-      logMissing('Cursor.prototype')
-    }
+  proto = mongodb.Cursor && mongodb.Cursor.prototype
+  if (proto) {
+    patchCursor(proto)
+  } else {
+    logMissing('Cursor.prototype')
   }
 
   return [mongodb, version];
@@ -168,9 +158,14 @@ function getQuery (v) {return v.q || v.query}
 function getUpdate (v) {return v.u || v.update}
 
 // Command identifiers
-function notUndef (...args) {
+function ifDef (...args) {
   return function (o) {
-    return args.reduce((r, v) => r || v in o || v.toLowerCase() in o, false)
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] in o || args[i].toLowerCase() in o) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 
@@ -209,73 +204,73 @@ function makeBaseData (ctx, ns) {
 // BAM note: why does the order matter?
 const dataMakers = [
   // Databases
-  [notUndef('dropDatabase'), function (data) {
+  [ifDef('dropDatabase'), function (data) {
     data.QueryOp = 'drop'
   }],
 
   // Collections
-  [notUndef('create'), function (data, cmd) {
+  [ifDef('create'), function (data, cmd) {
     data.QueryOp = 'create_collection'
     data.New_Collection_Name = cmd.create
   }],
-  [notUndef('renameCollection'), function (data, cmd) {
+  [ifDef('renameCollection'), function (data, cmd) {
     data.QueryOp = 'rename'
     data.New_Collection_Name = cmd.to.slice(cmd.to.indexOf('.') + 1)
   }],
-  [notUndef('dropCollection', 'drop'), function (data) {
+  [ifDef('dropCollection', 'drop'), function (data) {
     data.QueryOp = 'drop_collection'
   }],
 
   // Finding
-  [notUndef('distinct'), function (data, cmd) {
+  [ifDef('distinct'), function (data, cmd) {
     data.QueryOp = 'distinct'
     data.Query = JSON.stringify(getQuery(cmd))
     data.Key = cmd.key
   }],
-  [notUndef('find'), function (data, cmd) {
+  [ifDef('find'), function (data, cmd) {
     data.QueryOp = 'find'
     data.Query = JSON.stringify(cmd.query)
   }],
-  [notUndef('findAndModify'), function (data, cmd) {
+  [ifDef('findAndModify'), function (data, cmd) {
     data.QueryOp = 'find_and_modify'
     data.Query = JSON.stringify(cmd.query)
     data.Update_Document = JSON.stringify(cmd.update)
   }],
-  [notUndef('count'), function (data, cmd) {
+  [ifDef('count'), function (data, cmd) {
     data.QueryOp = 'count'
     data.Query = JSON.stringify(getQuery(cmd))
   }],
 
   // Modifying
-  [notUndef('insert'), function (data, cmd) {
+  [ifDef('insert'), function (data, cmd) {
     data.QueryOp = 'insert'
     data.Insert_Document = JSON.stringify(cmd.documents)
   }],
-  [notUndef('update'), function (data, cmd) {
+  [ifDef('update'), function (data, cmd) {
     data.QueryOp = 'update'
     data.Query = JSON.stringify(cmd.updates.map(getQuery))
     data.Update_Document = JSON.stringify(cmd.updates.map(getUpdate))
   }],
-  [notUndef('delete'), function (data, cmd) {
+  [ifDef('delete'), function (data, cmd) {
     data.QueryOp = 'remove'
     data.Query = JSON.stringify(cmd.deletes.map(getQuery))
   }],
 
   // Indexes
-  [notUndef('createIndexes'), function (data, cmd) {
+  [ifDef('createIndexes'), function (data, cmd) {
     data.QueryOp = 'create_indexes'
     data.Indexes = JSON.stringify(cmd.indexes)
   }],
-  [notUndef('deleteIndexes', 'dropIndexes'), function (data, cmd) {
+  [ifDef('deleteIndexes', 'dropIndexes'), function (data, cmd) {
     data.QueryOp = 'drop_indexes'
     data.Index = JSON.stringify(cmd.index)
   }],
-  [notUndef('reIndex'), function (data) {
+  [ifDef('reIndex'), function (data) {
     data.QueryOp = 'reindex'
   }],
 
   // Aggregation
-  [notUndef('group'), function (data, cmd) {
+  [ifDef('group'), function (data, cmd) {
     data.QueryOp = 'group'
     data.Group_Condition = JSON.stringify(cmd.group.cond)
     data.Group_Initial = JSON.stringify(cmd.group.initial)
@@ -288,7 +283,7 @@ const dataMakers = [
     }
     data.Group_Key = JSON.stringify(cmd.group.key)
   }],
-  [notUndef('mapReduce'), function (data, cmd) {
+  [ifDef('mapReduce'), function (data, cmd) {
     data.QueryOp = 'map_reduce'
     data.Map_Function = cmd.map
     data.Reduce_Function = cmd.reduce
@@ -296,7 +291,7 @@ const dataMakers = [
       data.Finalize_Function = cmd.finalize
     }
   }],
-  [notUndef('aggregate'), function (data, cmd) {
+  [ifDef('aggregate'), function (data, cmd) {
     data.QueryOp = 'aggregate'
     data.Pipeline = JSON.stringify(cmd.pipeline)
   }]

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -12,7 +12,7 @@ module.exports = function (mongodb, options) {
   const {version} = options;
 
   // node 12 with mongodb-core prior to v3 exhibits a memory leak with cls-hooked.
-  if (semver.gte(process.version, '11.0.0') && semver.lt(version, '3.0.0')) {
+  if (semver.gte(process.version, '11.15.0') && semver.lt(version, '3.0.0')) {
     ao.loggers.patching(`disabling mongodb-core ${version} probe for node ${process.version}`);
     return mongodb;
   }

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -1,12 +1,24 @@
 'use strict'
 
+const semver = require('semver');
 const shimmer = require('ximmer')
-const ao = require('..')
-const conf = ao.probes['mongodb-core']
+
+const ao = require('..');
+const requirePatch = require('../require-patch');
+const conf = ao.probes['mongodb-core'];
+
+const pkg = requirePatch.relativeRequire('mongodb-core/package.json');
+const version = pkg.version;
 
 const logMissing = ao.makeLogMissing('mongodb-core')
 
 module.exports = function (mongodb) {
+
+  // node 12 with mongodb-core prior to v3 exhibits a memory leak with cls-hooked.
+  if (semver.gte(process.version, '11.0.0') && semver.lt(version, '3.0.0')) {
+    ao.loggers.patching(`disabling mongodb-core probe for node version ${process.version}`);
+    return mongodb;
+  }
 
   // Patch Server
   {

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -7,11 +7,6 @@ const ao = require('..');
 const requirePatch = require('../require-patch');
 const conf = ao.probes['mongodb-core'];
 
-const pkg = requirePatch.relativeRequire('mongodb-core/package.json');
-const version = pkg.version;
-
-const requirePatch = require('../require-patch');
-
 const version = requirePatch.relativeRequire('mongodb-core/package.json').version;
 
 const logMissing = ao.makeLogMissing('mongodb-core')

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -1,79 +1,77 @@
 'use strict'
 
-const shimmer = require('ximmer')
 const semver = require('semver');
+const shimmer = require('ximmer')
 
 const ao = require('..')
 const requirePatch = require('../require-patch');
 const conf = ao.probes.mongodb;
 
-const version = requirePatch.relativeRequire('mongodb/package.json').version;
-
 const logMissing = ao.makeLogMissing('mongodb')
 
-module.exports = function (mongodb) {
+module.exports = function (mongodb, options) {
+  const {version} = options;
 
   // v3.3.0 is the first version of mongodb that doesn't use mongodb-core.
   if (semver.lt(version, '3.3.0')) {
     return [mongodb, `${version} (no-op)`];
   }
 
+  //
+  // now patch the prototypes of each topology. because the prototype is being
+  // patched, not the module exports themselves, there is no need to replace the
+  // module's entry in require.cache. this just modifies the prototypes of the
+  // exports cached in require.cache.
+  //
+
   // Patch Server
-  {
-    let coreServer;
-    try {
-      coreServer = requirePatch.relativeRequire('mongodb/lib/core/topologies/server.js');
-    } catch (e) {
-      logMissing('topologies/server.js');
-    }
-    const proto = coreServer && coreServer.prototype || mongodb.Server && mongodb.Server.prototype;
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('Server.prototype')
-    }
+  let core;
+  try {
+    core = requirePatch.relReq('mongodb/lib/core/topologies/server.js');
+  } catch (e) {
+    logMissing('topologies/server.js');
   }
+  let proto = core && core.prototype || mongodb.Server && mongodb.Server.prototype;
+  if (proto) {
+    patchCommands(proto)
+  } else {
+    logMissing('Server.prototype')
+  }
+  core = undefined;
 
   // Patch ReplSet
-  {
-    let core;
-    try {
-      core = requirePatch.relativeRequire('mongodb/lib/core/topologies/replset.js');
-    } catch (e) {
-      logMissing('topologies/replset.js');
-    }
-    const proto = core && core.prototype || mongodb.ReplSet && mongodb.ReplSet.prototype;
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('ReplSet.prototype')
-    }
+  try {
+    core = requirePatch.relReq('mongodb/lib/core/topologies/replset.js');
+  } catch (e) {
+    logMissing('topologies/replset.js');
   }
+  proto = core && core.prototype || mongodb.ReplSet && mongodb.ReplSet.prototype;
+  if (proto) {
+    patchCommands(proto)
+  } else {
+    logMissing('ReplSet.prototype')
+  }
+  core = undefined;
 
   // Patch Mongos
-  {
-    let core;
-    try {
-      core = requirePatch.relativeRequire('mongodb/lib/core/topologies/mongos.js');
-    } catch (e) {
-      logMissing('topologies/mongos.js');
-    }
-    const proto = core && core.prototype || mongodb.Mongos && mongodb.Mongos.prototype
-    if (proto) {
-      patchCommands(proto)
-    } else {
-      logMissing('Mongos.prototype')
-    }
+  try {
+    core = requirePatch.relReq('mongodb/lib/core/topologies/mongos.js');
+  } catch (e) {
+    logMissing('topologies/mongos.js');
+  }
+  proto = core && core.prototype || mongodb.Mongos && mongodb.Mongos.prototype;
+  if (proto) {
+    patchCommands(proto)
+  } else {
+    logMissing('Mongos.prototype')
   }
 
   // Patch Cursor
-  {
-    const proto = mongodb.Cursor && mongodb.Cursor.prototype
-    if (proto) {
-      patchCursor(proto)
-    } else {
-      logMissing('Cursor.prototype')
-    }
+  proto = mongodb.Cursor && mongodb.Cursor.prototype;
+  if (proto) {
+    patchCursor(proto)
+  } else {
+    logMissing('Cursor.prototype')
   }
 
   return [mongodb, version];
@@ -193,7 +191,6 @@ function ifDef (...args) {
       }
     }
     return false;
-    //return args.reduce((r, v) => r || v in o || v.toLowerCase() in o, false)
   }
 }
 

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -1,32 +1,32 @@
 'use strict'
 
-const semver = require('semver');
 const shimmer = require('ximmer')
+const semver = require('semver');
 
-const ao = require('..');
+const ao = require('..')
 const requirePatch = require('../require-patch');
-const conf = ao.probes['mongodb-core'];
+const conf = ao.probes.mongodb;
 
-const pkg = requirePatch.relativeRequire('mongodb-core/package.json');
-const version = pkg.version;
+const version = requirePatch.relativeRequire('mongodb/package.json').version;
 
-const requirePatch = require('../require-patch');
-
-const version = requirePatch.relativeRequire('mongodb-core/package.json').version;
-
-const logMissing = ao.makeLogMissing('mongodb-core')
+const logMissing = ao.makeLogMissing('mongodb')
 
 module.exports = function (mongodb) {
 
-  // node 12 with mongodb-core prior to v3 exhibits a memory leak with cls-hooked.
-  if (semver.gte(process.version, '11.0.0') && semver.lt(version, '3.0.0')) {
-    ao.loggers.patching(`disabling mongodb-core probe for node version ${process.version}`);
-    return mongodb;
+  // v3.3.0 is the first version of mongodb that doesn't use mongodb-core.
+  if (semver.lt(version, '3.3.0')) {
+    return [mongodb, `${version} (no-op)`];
   }
 
   // Patch Server
   {
-    const proto = mongodb.Server && mongodb.Server.prototype
+    let coreServer;
+    try {
+      coreServer = requirePatch.relativeRequire('mongodb/lib/core/topologies/server.js');
+    } catch (e) {
+      logMissing('topologies/server.js');
+    }
+    const proto = coreServer && coreServer.prototype || mongodb.Server && mongodb.Server.prototype;
     if (proto) {
       patchCommands(proto)
     } else {
@@ -36,7 +36,13 @@ module.exports = function (mongodb) {
 
   // Patch ReplSet
   {
-    const proto = mongodb.ReplSet && mongodb.ReplSet.prototype
+    let core;
+    try {
+      core = requirePatch.relativeRequire('mongodb/lib/core/topologies/replset.js');
+    } catch (e) {
+      logMissing('topologies/replset.js');
+    }
+    const proto = core && core.prototype || mongodb.ReplSet && mongodb.ReplSet.prototype;
     if (proto) {
       patchCommands(proto)
     } else {
@@ -46,7 +52,13 @@ module.exports = function (mongodb) {
 
   // Patch Mongos
   {
-    const proto = mongodb.Mongos && mongodb.Mongos.prototype
+    let core;
+    try {
+      core = requirePatch.relativeRequire('mongodb/lib/core/topologies/mongos.js');
+    } catch (e) {
+      logMissing('topologies/mongos.js');
+    }
+    const proto = core && core.prototype || mongodb.Mongos && mongodb.Mongos.prototype
     if (proto) {
       patchCommands(proto)
     } else {
@@ -85,7 +97,7 @@ function makeWrapper (obj, name, addData) {
     return ao.instrument(
       () => {
         return {
-          name: 'mongodb-core',
+          name: 'mongodb',
           kvpairs,
         }
       },
@@ -109,7 +121,7 @@ function patchCommand (obj) {
     return ao.instrument(
       () => {
         return {
-          name: 'mongodb-core',
+          name: 'mongodb',
           kvpairs: makeData(this, ns, cmd)
         }
       },
@@ -147,7 +159,7 @@ function patchCursor (cursor) {
     return ao.instrument(
       () => {
         return {
-          name: 'mongodb-core',
+          name: 'mongodb',
           kvpairs: makeData(this.topology, this.ns, this.cmd)
         }
       },
@@ -173,12 +185,20 @@ function getQuery (v) {return v.q || v.query}
 function getUpdate (v) {return v.u || v.update}
 
 // Command identifiers
-function notUndef (...args) {
+function ifDef (...args) {
   return function (o) {
-    return args.reduce((r, v) => r || v in o || v.toLowerCase() in o, false)
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] in o || args[i].toLowerCase() in o) {
+        return true;
+      }
+    }
+    return false;
+    //return args.reduce((r, v) => r || v in o || v.toLowerCase() in o, false)
   }
 }
 
+// different versions of mongodb and mongodb-core have variations in naming
+// and object organization.
 function serverDetails ({s = {}}) {
   let o;
   if (s.serverDetails) {
@@ -197,16 +217,20 @@ function serverDetails ({s = {}}) {
 }
 
 function makeBaseData (ctx, ns) {
-  const dot = ns.indexOf('.')
-  const Database = ns.slice(0, dot)
-  const Collection = ns.slice(dot + 1)
-
+  // for some reason cursors don't use a namespace object.
+  if (typeof ns === 'string') {
+    // a collection name can contain a '.' so don't just split.
+    const dot = ns.indexOf('.');
+    const db = ns.slice(0, dot);
+    const collection = ns.slice(dot + 1);
+    ns = {db, collection};
+  }
   return {
     RemoteHost: serverDetails(ctx).name,
     Flavor: 'mongodb',
     Spec: 'query',
-    Collection,
-    Database,
+    Collection : ns.collection,
+    Database: ns.db,
   }
 }
 
@@ -214,73 +238,73 @@ function makeBaseData (ctx, ns) {
 // BAM note: why does the order matter?
 const dataMakers = [
   // Databases
-  [notUndef('dropDatabase'), function (data) {
+  [ifDef('dropDatabase'), function (data) {
     data.QueryOp = 'drop'
   }],
 
   // Collections
-  [notUndef('create'), function (data, cmd) {
+  [ifDef('create'), function (data, cmd) {
     data.QueryOp = 'create_collection'
     data.New_Collection_Name = cmd.create
   }],
-  [notUndef('renameCollection'), function (data, cmd) {
+  [ifDef('renameCollection'), function (data, cmd) {
     data.QueryOp = 'rename'
     data.New_Collection_Name = cmd.to.slice(cmd.to.indexOf('.') + 1)
   }],
-  [notUndef('dropCollection', 'drop'), function (data) {
+  [ifDef('dropCollection', 'drop'), function (data) {
     data.QueryOp = 'drop_collection'
   }],
 
   // Finding
-  [notUndef('distinct'), function (data, cmd) {
+  [ifDef('distinct'), function (data, cmd) {
     data.QueryOp = 'distinct'
     data.Query = JSON.stringify(getQuery(cmd))
     data.Key = cmd.key
   }],
-  [notUndef('find'), function (data, cmd) {
+  [ifDef('find'), function (data, cmd) {
     data.QueryOp = 'find'
     data.Query = JSON.stringify(cmd.query)
   }],
-  [notUndef('findAndModify'), function (data, cmd) {
+  [ifDef('findAndModify'), function (data, cmd) {
     data.QueryOp = 'find_and_modify'
     data.Query = JSON.stringify(cmd.query)
     data.Update_Document = JSON.stringify(cmd.update)
   }],
-  [notUndef('count'), function (data, cmd) {
+  [ifDef('count'), function (data, cmd) {
     data.QueryOp = 'count'
     data.Query = JSON.stringify(getQuery(cmd))
   }],
 
   // Modifying
-  [notUndef('insert'), function (data, cmd) {
+  [ifDef('insert'), function (data, cmd) {
     data.QueryOp = 'insert'
     data.Insert_Document = JSON.stringify(cmd.documents)
   }],
-  [notUndef('update'), function (data, cmd) {
+  [ifDef('update'), function (data, cmd) {
     data.QueryOp = 'update'
     data.Query = JSON.stringify(cmd.updates.map(getQuery))
     data.Update_Document = JSON.stringify(cmd.updates.map(getUpdate))
   }],
-  [notUndef('delete'), function (data, cmd) {
+  [ifDef('delete'), function (data, cmd) {
     data.QueryOp = 'remove'
     data.Query = JSON.stringify(cmd.deletes.map(getQuery))
   }],
 
   // Indexes
-  [notUndef('createIndexes'), function (data, cmd) {
+  [ifDef('createIndexes'), function (data, cmd) {
     data.QueryOp = 'create_indexes'
     data.Indexes = JSON.stringify(cmd.indexes)
   }],
-  [notUndef('deleteIndexes', 'dropIndexes'), function (data, cmd) {
+  [ifDef('deleteIndexes', 'dropIndexes'), function (data, cmd) {
     data.QueryOp = 'drop_indexes'
     data.Index = JSON.stringify(cmd.index)
   }],
-  [notUndef('reIndex'), function (data) {
+  [ifDef('reIndex'), function (data) {
     data.QueryOp = 'reindex'
   }],
 
   // Aggregation
-  [notUndef('group'), function (data, cmd) {
+  [ifDef('group'), function (data, cmd) {
     data.QueryOp = 'group'
     data.Group_Condition = JSON.stringify(cmd.group.cond)
     data.Group_Initial = JSON.stringify(cmd.group.initial)
@@ -293,7 +317,7 @@ const dataMakers = [
     }
     data.Group_Key = JSON.stringify(cmd.group.key)
   }],
-  [notUndef('mapReduce'), function (data, cmd) {
+  [ifDef('mapReduce'), function (data, cmd) {
     data.QueryOp = 'map_reduce'
     data.Map_Function = cmd.map
     data.Reduce_Function = cmd.reduce
@@ -301,7 +325,7 @@ const dataMakers = [
       data.Finalize_Function = cmd.finalize
     }
   }],
-  [notUndef('aggregate'), function (data, cmd) {
+  [ifDef('aggregate'), function (data, cmd) {
     data.QueryOp = 'aggregate'
     data.Pipeline = JSON.stringify(cmd.pipeline)
   }]
@@ -309,7 +333,6 @@ const dataMakers = [
 
 function makeData (ctx, ns, cmd) {
   const data = makeBaseData(ctx, ns)
-
   for (let i = 0; i < dataMakers.length; i++) {
     const [test, make] = dataMakers[i]
     if (test(cmd)) {

--- a/lib/require-patch.js
+++ b/lib/require-patch.js
@@ -17,6 +17,7 @@ exports = module.exports = {
     probes[name] = path;
     // supply a skeletal config if none is present.
     if (!ao.probes[name]) {
+      ao.loggers.debug(`require-patch supplying default config for probe ${name}`);
       ao.probes[name] = {enabled: true};
     }
   },
@@ -44,26 +45,44 @@ const nameToPatchFile = {
 }
 
 function patchedRequire (name) {
-  let mod = realRequire.call(this, name)
+  let mod = realRequire.call(this, name);
+
+  let pkg = {version: ''};
+  try {
+    pkg = this.require.call(this, `${name}/package.json`);
+  } catch (e) {
+    // nothing to do.
+  }
 
   // Only apply probes on first run
   if (mod && probes.hasOwnProperty(name) && !patched.get(mod)) {
     // Set relative require helper to point to the module being patched
-    exports.relativeRequire = this.require.bind(this);
+    exports.relReq = exports.relativeRequire = this.require.bind(this);
+    exports.inertRelReq = function (file) {
+      exports.disable();
+      exports.relativeRequire(file);
+      exports.enable();
+    };
+
+    const options = {name, version: pkg.version};
 
     // patch the module that was required above. 'name' is passed so
-    // that @hapi/hapi and hapi (as well as @hapi/vision and vision)
-    // can share the same probe code.
+    // multiple modules can share the same probe code, e.g., @hapi/hapi
+    // and hapi.
+    //
     // N.B. the amqplib/callback_api probe makes the second argument
     // an options object. if more information is needed by a probe
     // at some point, e.g., {name, newInfo: ...} then the second argument
     // here should become an options object and amqplib/callback_api will
     // need to be modified in addition to the @hapi probes.
     const path = Module._resolveFilename(name, this);
-    mod = realRequire(probes[name])(mod, name);
 
-    // allow patchers to return the patched version for display.
-    let v;
+    // require the probe with the real module as the first argument.
+    mod = realRequire(probes[name])(mod, options);
+
+    // allow patchers to return the version patched for logging. in order to
+    // return the version they should return [patched-module, version-info-string].
+    let v = pkg.version;
     if (Array.isArray(mod)) {
       v = mod[1];
       mod = mod[0];
@@ -77,7 +96,7 @@ function patchedRequire (name) {
       require.cache[path].exports = mod
     }
 
-    ao.loggers.patching(`patched ${name} ${v ? v : ''}`)
+    ao.loggers.patching(`patched ${name} ${v}`);
   }
 
   return mod

--- a/lib/require-patch.js
+++ b/lib/require-patch.js
@@ -9,6 +9,24 @@ const realRequire = module.constructor.prototype.require
 const patched = new WeakMap()
 const probes = {}
 
+
+// allow scoped packages to use same tests as unscoped versions. this
+// facilitates testing without duplicating for supported packages that
+// change to scoped.
+const nameToPatchFile = {
+  hapi: '@hapi/hapi',
+  vision: '@hapi/vision'
+};
+
+// abstracted probes are those known by another name, e.g., @hapi/hapi referred to
+// as `hapi` in the configuration. and `amqplib/callback_api` is just a wrapper around
+// the `amqplib` probe where the configuration is done.
+const abstractedProbes = [
+  '@hapi/hapi',
+  '@hapi/vision',
+  'amqplib/callback_api',
+];
+
 exports = module.exports = {
   //
   // Set locations of instrumentation wrappers to patch named modules
@@ -16,7 +34,7 @@ exports = module.exports = {
   register (name, path) {
     probes[name] = path;
     // supply a skeletal config if none is present.
-    if (!ao.probes[name]) {
+    if (!ao.probes[name] && abstractedProbes.indexOf(name) < 0) {
       ao.loggers.debug(`require-patch supplying default config for probe ${name}`);
       ao.probes[name] = {enabled: true};
     }
@@ -34,14 +52,6 @@ exports = module.exports = {
   disable () {
     module.constructor.prototype.require = realRequire
   }
-}
-
-// allow scoped packages to use same tests as unscoped versions. this
-// facilitates testing without duplicating for supported packages that
-// change to scoped.
-const nameToPatchFile = {
-  hapi: '@hapi/hapi',
-  vision: '@hapi/vision'
 }
 
 function patchedRequire (name) {

--- a/lib/span.js
+++ b/lib/span.js
@@ -48,6 +48,12 @@ function Span (name, settings, data) {
   this.topSpan = false
   this.doMetrics = false
 
+  // it is possible to ignore some errors. the only error that customers have
+  // requested to be able to ignore is ENOENT because their application looks for
+  // files at startup but it's not really an error for them to not be found.
+  // in order to ignore an error the probe must call Span.setErrorsToIgnoreFunction().
+  this.ignoreErrorFn = undefined;
+
   const edge = 'edge' in settings ? settings.edge : true
 
   const entry = new Event(name, 'entry', settings.metadata, edge)
@@ -408,7 +414,11 @@ Span.prototype.exitWithError = function (error, data) {
 Span.prototype.setExitError = function (error) {
   try {
     error = Span.toError(error)
-    if (error) this.events.exit.error = error
+    if (error) {
+      if (!this.ignoreErrorFn || !this.ignoreErrorFn(error)) {
+        this.events.exit.error = error;
+      }
+    }
   } catch (e) {
     log.error(`${this.name} span failed to set exit error`, e.stack)
   }
@@ -491,6 +501,28 @@ Span.prototype.error = function (error) {
   } catch (e) {
     log.error(`${this.name} span failed to send error event`, e.stack)
   }
+}
+
+/**
+ * Set a function that determines whether an error is reported or not. This
+ * is for internal use only.
+ *
+ * @method Span#setIgnoreErrorFn
+ * @param {Error} err the error to evaluate
+ * @returns {boolean} truthy to ignore the error
+ * @ignore
+ *
+ * @example
+ * span.setIgnoreErrorFn(function (err) {
+ *   // return true to ignore the error.
+ *   return err.code === 'ENOENT';
+ * })
+ */
+Span.prototype.setIgnoreErrorFn = function setIgnoreErrorFn (fn) {
+  if (this.ignoreErrorFn) {
+    log.warn(`resetting ignoreErrorFn for ${this.name}`);
+  }
+  this.ignoreErrorFn = fn;
 }
 
 //

--- a/lib/span.js
+++ b/lib/span.js
@@ -3,6 +3,7 @@
 const Event = require('./event')
 let ao;
 let log;
+let dbSendError;
 
 /**
  * Create an execution span.
@@ -503,9 +504,21 @@ Span.sendNonHttpSpan = function (txname, duration, error) {
     error: !!error
   }
 
-  const finalTxName = ao.reporter.sendNonHttpSpan(args)
+  const finalTxName = ao.reporter.sendNonHttpSpan(args);
 
-  return finalTxName
+  // if it's good and not a null string return it.
+  if (typeof finalTxName === 'string' && finalTxName) {
+    return finalTxName;
+  }
+
+  // if it wasn't a string then it should be a numeric code. worst
+  // case is that it is a null string.
+  dbSendError.log(`sendNonHttpSpan() code ${finalTxName}`);
+
+
+  // try to return a valid transaction name of some sort. it doesn't really
+  // matter because it wasn't sent no matter what it was.
+  return args.txname || 'unknown';
 }
 
 //
@@ -549,11 +562,12 @@ Span.toError = function (error) {
   }
 }
 
-//
-
+// because this module is invoked before the ao object is initialized
+// data required from ao must be deferred until init is called.
 Span.init = function (populatedAo) {
   ao = populatedAo;
   log = ao.loggers;
+  dbSendError = new ao.loggers.Debounce('error');
 }
 
 module.exports = Span;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,13 +3492,23 @@
       "optional": true
     },
     "mongodb": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
-      "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.3.tgz",
+      "integrity": "sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==",
       "dev": true,
       "requires": {
-        "mongodb-core": "3.1.11",
-        "safe-buffer": "^5.1.2"
+        "bson": "^1.1.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+          "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==",
+          "dev": true
+        }
       }
     },
     "mongodb-core": {
@@ -3555,6 +3565,16 @@
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
           "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==",
           "dev": true
+        },
+        "mongodb": {
+          "version": "3.1.13",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
+          "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
+          "dev": true,
+          "requires": {
+            "mongodb-core": "3.1.11",
+            "safe-buffer": "^5.1.2"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "memcached": "^2.2.2",
     "method-override": "^2.3.10",
     "mkdirp": "^0.5.1",
-    "mongodb": "^3.1.13",
+    "mongodb": "^3.3.3",
     "mongodb-core": "^3.1.11",
     "mongoose": "^5.4.19",
     "morgan": "^1.9.1",

--- a/prepack.js
+++ b/prepack.js
@@ -111,7 +111,7 @@ const onlyInProbesDir = difference(implementedProbes, commonProbes);
 // clean up known exceptions
 //
 
-// http-client and https-client are implemented in the http.js and https.js probes
+// http-client and https-client are implemented by the http.js and https.js probes
 onlyInDefault.delete('http-client');
 onlyInDefault.delete('https-client');
 

--- a/prepack.js
+++ b/prepack.js
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 'use strict';
 
+const m = process.version.match(/v(\d+)\.\d+\.\d+/);
+if (+m[1] < 10) {
+  // eslint-disable-next-line no-console
+  console.error(`appoptics-apm must be released using node >= 10; using ${process.version}`);
+  process.exit(1);
+}
+
 const fs = require('fs');
 
 const files = fs.readdirSync('.', 'utf8');

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -93,7 +93,7 @@ describe('event', function () {
     const event2 = new Event('test', 'exit', event.event)
 
     const logChecks = [
-      {level: 'error', message: 'Invalid type for KV %s: %s', values: ['Nan', 'NaN']},
+      {level: 'error', message: 'Error: Invalid type for KV Nan: NaN'},
       // there is a stack trace here but issuing the error is enough.
     ]
 

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -91,26 +91,26 @@ describe('logging', function () {
   it('should debounce repetitive logging by count', function () {
     const msg = 'test logging'
     const aolevel = 'error'
-    let debounced = new ao.loggers.Debounce('error')
+    let debounced = new ao.loggers.Debounce(aolevel);
     let count = 0
     let i
     debug.log = function (output) {
       const [level, text] = getLevelAndText(output)
       expect(level).equal('appoptics:' + aolevel)
-      expect(text).equal('[' + (i + 1) + ']' + msg)
-      count += 1
+      expect(text).equal(`[${i + 1}]${msg}`);
+      count += 1;
     }
     for (i = 0; i < 1000; i++) {
       debounced.log(msg)
     }
-    expect(count).equal(11)
+    expect(count).equal(10);
 
-    debounced = new ao.loggers.Debounce('error', {deltaCount: 500})
+    debounced = new ao.loggers.Debounce(aolevel, {deltaCount: 500});
     count = 0
     for (i = 0; i < 1000; i++) {
       debounced.log(msg)
     }
-    expect(count).equal(3)
+    expect(count).equal(2);
   })
 
   it('should debounce repetitive logging by time', function (done) {

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -2,6 +2,7 @@
 
 const helper = require('../helper')
 const {ao} = require('../1.test-common')
+const expect = require('chai').expect;
 
 const noop = helper.noop
 
@@ -58,12 +59,12 @@ describe('probes.fs', function () {
   //
   const checks = {
     entry: function (msg) {
-      msg.should.have.property('Layer', 'fs')
-      msg.should.have.property('Label', 'entry')
+      const explicit = `${msg.Layer}:${msg.Label}`;
+      expect(explicit).equal('fs:entry', 'Layer and Label must match');
     },
     exit: function (msg) {
-      msg.should.have.property('Layer', 'fs')
-      msg.should.have.property('Label', 'exit')
+      const explicit = `${msg.Layer}:${msg.Label}`;
+      expect(explicit).equal('fs:exit', 'Layer and Label must match');
     }
   }
 

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -6,6 +6,7 @@ const {ao} = require('../1.test-common.js')
 const noop = helper.noop
 const addon = ao.addon
 
+const expect = require('chai').expect;
 const semver = require('semver')
 const mongodb = require('mongodb-core')
 
@@ -13,6 +14,8 @@ const requirePatch = require('../../lib/require-patch')
 requirePatch.disable()
 const pkg = require('mongodb-core/package.json')
 requirePatch.enable()
+
+const moduleName = 'mongodb-core';
 
 // just because it's not really documented particularly well in mongo docs
 // the namespace argument (the first argument, a string, to most calls) is
@@ -185,18 +188,22 @@ function makeTests (db_host, host, isReplicaSet) {
       msg.should.have.property('Spec', 'query')
       msg.should.have.property('Flavor', 'mongodb')
       msg.should.have.property('RemoteHost')
-      msg.RemoteHost.should.match(/:\d*$/)
+      //msg.RemoteHost.should.match(/:\d*$/)
+      expect(msg.RemoteHost).oneOf(db_host.split(','));
     },
     common: function (msg) {
       msg.should.have.property('Database', `${dbn}`)
     },
     entry: function (msg) {
-      msg.should.have.property('Layer', 'mongodb-core')
-      msg.should.have.property('Label', 'entry')
+      const explicit = `${msg.Layer}:${msg.Label}`;
+      //console.log(`expecting ${moduleName}:entry got ${explicit}`);
+      expect(explicit).equal(`${moduleName}:entry`, 'message Layer and Label must be correct');
       check.base(msg)
     },
     exit: function (msg) {
-      msg.should.have.property('Layer', 'mongodb-core')
+      const explicit = `${msg.Layer}:${msg.Label}`;
+      expect(explicit).equal(`${moduleName}:exit`, 'message Layer and Label must be correct');
+      msg.should.have.property('Layer', moduleName)
       msg.should.have.property('Label', 'exit')
     }
   }
@@ -713,6 +720,7 @@ function makeTests (db_host, host, isReplicaSet) {
       }
 
       it('should map_reduce', function (done) {
+        // eslint-disable-next-line no-undef
         function map () {emit(this.a, 1)}
         function reduce (k, vals) {return 1}
 

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -188,7 +188,6 @@ function makeTests (db_host, host, isReplicaSet) {
       msg.should.have.property('Spec', 'query')
       msg.should.have.property('Flavor', 'mongodb')
       msg.should.have.property('RemoteHost')
-      //msg.RemoteHost.should.match(/:\d*$/)
       expect(msg.RemoteHost).oneOf(db_host.split(','));
     },
     common: function (msg) {
@@ -196,15 +195,12 @@ function makeTests (db_host, host, isReplicaSet) {
     },
     entry: function (msg) {
       const explicit = `${msg.Layer}:${msg.Label}`;
-      //console.log(`expecting ${moduleName}:entry got ${explicit}`);
       expect(explicit).equal(`${moduleName}:entry`, 'message Layer and Label must be correct');
       check.base(msg)
     },
     exit: function (msg) {
       const explicit = `${msg.Layer}:${msg.Label}`;
       expect(explicit).equal(`${moduleName}:exit`, 'message Layer and Label must be correct');
-      msg.should.have.property('Layer', moduleName)
-      msg.should.have.property('Label', 'exit')
     }
   }
 

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -14,6 +14,11 @@ requirePatch.disable()
 const pkg = require('mongodb-core/package.json')
 requirePatch.enable()
 
+// just because it's not really documented particularly well in mongo docs
+// the namespace argument (the first argument, a string, to most calls) is
+// `database-name.collection-name` and the `$cmd` collection is a special
+// collection against which
+
 // need to make decisions based on major version
 const majorVersion = semver.major(pkg.version)
 
@@ -149,6 +154,7 @@ function makeTests (db_host, host, isReplicaSet) {
     }
 
     server.on('error', function (err) {
+      // eslint-disable-next-line no-console
       console.log('error connecting', err)
       done()
     })

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -250,18 +250,12 @@ function makeTests (db_host, host, isReplicaSet) {
     },
     entry: function (msg) {
       const explicit = `${msg.Layer}:${msg.Label}`;
-      //console.log(`expecting ${moduleName}:entry got ${explicit}`);
-      //console.log(msg);
       expect(explicit).equal(`${moduleName}:entry`, 'message Layer and Label must be correct');
       check.base(msg)
     },
     exit: function (msg) {
       const explicit = `${msg.Layer}:${msg.Label}`;
-      //console.log(`expecting ${moduleName}:exit got ${explicit}`);
-      //console.log(msg);
       expect(explicit).equal(`${moduleName}:exit`, 'message Layer and Label must be correct');
-      msg.should.have.property('Layer', moduleName)
-      msg.should.have.property('Label', 'exit')
     }
   }
 

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -1,11 +1,8 @@
 'use strict'
 
-/* eslint-disable no-console */
-
 const helper = require('../helper')
 const {ao} = require('../1.test-common.js')
 
-const expect = require('chai').expect;
 
 const noop = helper.noop
 const addon = ao.addon
@@ -14,10 +11,9 @@ const semver = require('semver')
 const mongodb = require('mongodb')
 const MongoClient = mongodb.MongoClient
 
-const requirePatch = require('../../lib/require-patch')
-requirePatch.disable()
-const pkg = requirePatch.relativeRequire('mongodb/package.json');
-requirePatch.enable()
+const expect = require('chai').expect;
+
+const pkg = require('mongodb/package.json');
 
 // prior to version 3.3.0 mongodb used mongodb-core. from 3.3.0 on mongodb
 // has incorporated those functions into its own codebase.
@@ -30,7 +26,8 @@ let hosts = {
   'replica set': process.env.AO_TEST_MONGODB_SET
 }
 
-// version 3 of mongodb-core removed the 2.4 protocol driver.
+// version 3 of mongodb-core removed the 2.4 protocol driver. and mongodb 3.0.0
+// uses mongodb-core 3.0.0
 if (semver.gte(pkg.version, '3.0.0')) {
   delete hosts['2.4']
 }
@@ -48,8 +45,8 @@ if (process.env.CI === 'true' && process.env.TRAVIS === 'true') {
 // during matrix testing. It's not needed when testing only one instance
 // at a time locally. Save database name and collection name.
 
-const dbn = 'test' + (process.env.AO_IX ? '-' + process.env.AO_IX : '')
-const cn = `coll-${dbn}`
+const dbn = 'test' + (process.env.AO_IX ? '-' + process.env.AO_IX : '');
+const cn = `coll-${dbn}`;
 
 describe('probes.mongodb UDP', function () {
   let emitter
@@ -91,11 +88,14 @@ describe('probes/mongodb ' + pkg.version, function () {
   })
 })
 
+
+//
+// make the tests
+//
 function makeTests (db_host, host, isReplicaSet) {
   const ctx = {}
   let emitter
   let db
-  let realSampleTrace
 
   const options = {
     writeConcern: {w: 1},
@@ -106,7 +106,25 @@ function makeTests (db_host, host, isReplicaSet) {
   // Intercept appoptics messages for analysis
   //
   beforeEach(function (done) {
-    const current = this.currentTest
+    ao.probes.fs.enabled = false
+    ao.sampleRate = addon.MAX_SAMPLE_RATE
+    ao.traceMode = 'always'
+    ao.probes[moduleName].collectBacktraces = false
+    emitter = helper.appoptics(function () {
+      done();
+    });
+  });
+  afterEach(function (done) {
+    ao.probes.fs.enabled = true
+    emitter.close(function () {
+      done();
+    });
+  });
+
+
+  // skip specific tests to faciliate test debugging.
+  beforeEach(function () {
+    const current = this.currentTest;
     const doThese = {
       databases: true,
       collections: true,
@@ -116,27 +134,24 @@ function makeTests (db_host, host, isReplicaSet) {
       aggregations: true,
     }
     if (current.parent && !(current.parent.title in doThese)) {
-      this.skip()
     }
-    if (current.title !== 'should distinct' && current.title !== 'should count') {
-      //this.skip();
+    // skip specific titles
+    const skipTheseTitles = [];
+    if (skipTheseTitles.indexOf(current.title) >= 0) {
     }
-
-    ao.probes.fs.enabled = false
-    emitter = helper.appoptics(done)
-    ao.sampleRate = addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return {sample: true, source: 6, rate: ao.sampleRate}
+    // do only these specific titles
+    const doTheseTitles = [
+      'should drop',
+      'should distinct',
+      'should count',
+    ];
+    if (doTheseTitles.length && doTheseTitles.indexOf(current.title) >= 0) {
+      //ao.logger.addEnabled('span');
     }
-    ao.probes[moduleName].collectBacktraces = false
-  })
-  afterEach(function (done) {
-    ao.probes.fs.enabled = true
-    ao.addon.Context.sampleTrace = realSampleTrace
-    emitter.close(done)
-  })
+  });
+  afterEach(function () {
+    //ao.logger.removeEnabled('span');
+  });
 
   //
   // Open a fresh mongodb connection for each test
@@ -151,8 +166,6 @@ function makeTests (db_host, host, isReplicaSet) {
         port: Number(port)
       }
     })
-
-    //ao.logLevel = 'error,warn,debug,patching'
 
     ao.loggers.test.debug(`using dbn ${dbn}`)
 
@@ -172,6 +185,7 @@ function makeTests (db_host, host, isReplicaSet) {
       mongoClient.connect((err, _client) => {
         ao.loggers.test.debug('mongoClient() connect callback', err)
         if (err) {
+          // eslint-disable-next-line no-console
           console.log('error connecting', err)
           return done(err)
         }
@@ -194,11 +208,14 @@ function makeTests (db_host, host, isReplicaSet) {
       if (semver.gte(pkg.version, '3.0.0')) {
         server = new mongodb.Server(host.host, host.port)
         mongoClient = new MongoClient(server, mongoOptions)
+      } else {
+        throw new Error(`mongodb v${pkg.version} is not supported`);
       }
 
       mongoClient.connect((err, _client) => {
         ao.loggers.test.debug('mongoClient() connect callback', err)
         if (err) {
+          // eslint-disable-next-line no-console
           console.log('error connecting', err)
           return done(err)
         }
@@ -214,23 +231,6 @@ function makeTests (db_host, host, isReplicaSet) {
       })
     }
   })
-  before(function (done) {
-    /*
-    if (!db) {
-      done()
-      return
-    }
-    db.command(
-      `${dbn}.$cmd`,
-      {dropDatabase: 1},
-      function (err) {
-        ao.loggers.test.debug('before() dropDatabase callback', err)
-        done(err)
-      }
-    )
-    // */
-    done()
-  })
   after(function () {
     if (ctx.client) {
       ctx.client.close()
@@ -242,7 +242,6 @@ function makeTests (db_host, host, isReplicaSet) {
       msg.should.have.property('Spec', 'query')
       msg.should.have.property('Flavor', 'mongodb')
       msg.should.have.property('RemoteHost')
-      //msg.RemoteHost.should.match(/:\d*$/)
       expect(msg.RemoteHost).oneOf(db_host.split(','));
     },
     common: function (msg) {
@@ -264,7 +263,7 @@ function makeTests (db_host, host, isReplicaSet) {
   //
   const tests = {
     databases: function () {
-      it('should drop', function (done) {
+      it('should drop', function (tdone) {
         function entry (msg) {
           check.entry(msg)
           check.common(msg)
@@ -286,7 +285,7 @@ function makeTests (db_host, host, isReplicaSet) {
 
         helper.test(emitter, function (done) {
           db.command({dropDatabase: 1}, done)
-        }, steps, done)
+        }, steps, tdone)
       })
     },
 
@@ -319,7 +318,7 @@ function makeTests (db_host, host, isReplicaSet) {
           db.command({create: cn},
             function (e, data) {
               if (e) {
-                ao.loggers.test.debug(`error creating "coll-${dbn}`, e)
+                ao.loggers.error(`error creating "${cn}"`, e)
                 done(e)
                 return
               }
@@ -354,13 +353,13 @@ function makeTests (db_host, host, isReplicaSet) {
         helper.test(emitter, function (done) {
           adminDb.command(
             {
-              renameCollection: `${dbn}.coll-${dbn}`,
+              renameCollection: `${dbn}.${cn}`,
               to: `${dbn}.coll2-${dbn}`,
               dropTarget: true
             },
             function (e, data) {
               if (e) {
-                ao.loggers.debug(`error renaming "coll-${dbn} to ${dbn}.coll2-${dbn}`, e)
+                ao.loggers.debug(`error renaming "${cn}" to "${dbn}.coll2-${dbn}"`, e)
                 done(e)
                 return
               }
@@ -590,14 +589,7 @@ function makeTests (db_host, host, isReplicaSet) {
           check.exit(msg)
         }
 
-        const steps = [entry]
-        /*
-        if (isReplicaSet) {
-          steps.push(entry)
-          steps.push(exit)
-        }
-        // */
-        steps.push(exit)
+        const steps = [entry, exit];
 
         helper.test(emitter, function (done) {
           ctx.collection.countDocuments(

--- a/test/span.test.js
+++ b/test/span.test.js
@@ -354,10 +354,10 @@ describe('span', function () {
     helper.doChecks(emitter, checks, done)
 
     const logChecks = [
-      {level: 'error', message: 'Invalid type for KV'},
-      {level: 'error', message: 'Invalid type for KV'},
-      {level: 'error', message: 'Invalid type for KV'},
-      {level: 'error', message: 'Invalid type for KV'},
+      {level: 'error', message: 'Error: Invalid type for KV'},
+      {level: 'error', message: 'Error: Invalid type for KV'},
+      {level: 'error', message: 'Error: Invalid type for KV'},
+      {level: 'error', message: 'Error: Invalid type for KV'},
     ]
 
     let getCount  // eslint-disable-line

--- a/test/swoken/swoken.test.js
+++ b/test/swoken/swoken.test.js
@@ -2,9 +2,9 @@
 
 // the following three must be in sync, i.e., all refer to staging or production
 // as well as REPORTER specifying that the COLLECTOR should be used.
-process.env.APPOPTICS_COLLECTOR = 'collector-stg.appoptics.com';
+process.env.APPOPTICS_COLLECTOR = 'collector.appoptics.com';
 process.env.APPOPTICS_REPORTER = 'ssl';
-const swoken = process.env.AO_SWOKEN_STG;
+const swoken = process.env.AO_SWOKEN_PROD;
 
 const name = 'swoken-Modification-test';
 

--- a/test/swoken/swoken.test.js
+++ b/test/swoken/swoken.test.js
@@ -18,14 +18,13 @@ describe('verify that a swoken is handled correctly', function () {
   it('the service name should be lower case', function () {
     assert(ao.serviceKey === `${swoken}:${name.toLowerCase()}`);
   });
-  it('the config should not be changed', function () {
-    assert(ao.cfg.serviceKey === undefined);
-  });
+
   it('shouldn\'t change the environment variable', function () {
     assert(process.env.APPOPTICS_SERVICE_KEY === `${swoken}:${name}`);
-  })
+  });
+
   it('should validate with the collector using the swoken', function () {
     const ready = ao.readyToSample(5000);
     assert(ready);
-  })
+  });
 })

--- a/test/token/token.test.js
+++ b/test/token/token.test.js
@@ -2,9 +2,9 @@
 
 // the following three must be in sync, i.e., all refer to staging or production
 // as well as REPORTER specifying that the COLLECTOR should be used.
-process.env.APPOPTICS_COLLECTOR = 'collector-stg.appoptics.com';
+process.env.APPOPTICS_COLLECTOR = 'collector.appoptics.com';
 process.env.APPOPTICS_REPORTER = 'ssl';
-const token = process.env.AO_TOKEN_STG;
+const token = process.env.AO_TOKEN_PROD;
 
 const name = 'token-Modification-test';
 

--- a/test/token/token.test.js
+++ b/test/token/token.test.js
@@ -18,14 +18,13 @@ describe('verify that a legacy token is handled correctly', function () {
   it('the service name should be lower case', function () {
     assert(ao.serviceKey === `${token}:${name.toLowerCase()}`);
   });
-  it('the config should not be changed', function () {
-    assert(ao.cfg.serviceKey === undefined);
-  });
+
   it('shouldn\'t change the environment variable', function () {
     assert(process.env.APPOPTICS_SERVICE_KEY === `${token}:${name}`);
-  })
+  });
+
   it('should validate with the collector using the token', function () {
     const ready = ao.readyToSample(5000);
     assert(ready);
-  })
+  });
 })

--- a/test/unified-config.test.js
+++ b/test/unified-config.test.js
@@ -176,7 +176,7 @@ describe('config', function () {
       hostnameAlias: 'bruce',
       serviceKey: 'f'.repeat(64),
       ignoreConflicts: true,
-      domainPrefix: 'fubar',
+      domainPrefix: false,
     }
     writeConfigJSON(config);
 
@@ -224,6 +224,50 @@ describe('config', function () {
       'invalid configuration file value ec2MetadataTimeout: hello',
     ];
     doChecks(cfg, {warnings});
+  })
+
+  it('should handle benchmark config file', function () {
+    const literal = [
+      'let serviceKey;',
+      '',
+      'module.exports = {',
+      '  enabled: true,',
+      '  traceMode: 1,',
+      '  hostnameAlias: \'\',',
+      '  domainPrefix: false,',
+      '  serviceKey,',
+      '  insertTraceIdsIntoLogs: undefined,',
+      '  insertTraceIdsIntoMorgan: undefined,',
+      '  createTraceIdsToken: false,',
+      '  probes: {',
+      '    fs: {',
+      '      enabled: true',
+      '    }',
+      '  }',
+      '};',
+    ];
+    const expected = {
+      enabled: true,
+      traceMode: 1,
+      hostnameAlias: '',
+      domainPrefix: false,
+      serviceKey: 'undefined',
+      insertTraceIdsIntoLogs: false,
+      insertTraceIdsIntoMorgan: false,
+    };
+
+    writeConfigJs(literal.join('\n'));
+
+    // specify the filename with extension to work around node bug/feature/issue.
+    const file = process.env.APPOPTICS_APM_CONFIG_NODE = 'appoptics-apm.js';
+
+    const cfg = guc();
+
+    const warnings = [
+      'invalid configuration file value createTraceIdsToken: false',
+      'traceMode is deprecated; it will be invalid in the future',
+    ];
+    doChecks(cfg, {file: `${process.cwd()}/${file}`, global: expected, warnings});
   })
 
   it('should handle a non-default config file correctly', function () {
@@ -306,7 +350,7 @@ describe('config', function () {
       hostnameAlias: 'bruce',
       serviceKey: 'f'.repeat(64),
       ignoreConflicts: true,
-      domainPrefix: 'fubar',
+      domainPrefix: false,
     }
     writeConfigJSON(config);
     process.env.APPOPTICS_SERVICE_KEY = 'ab'.repeat(32);

--- a/test/unified-config.test.js
+++ b/test/unified-config.test.js
@@ -360,6 +360,38 @@ describe('config', function () {
     doChecks(cfg, {unusedProbes: [config.probes]});
   })
 
+  it('should handle an fs probe\'s ignoreErrors property', function () {
+    const config = {probes: {fs: {enabled: true, ignoreErrors: {open: {ENOENT: true}}}}};
+    writeConfigJSON(config);
+
+    const cfg = guc();
+
+    doChecks(cfg, {probes: config.probes});
+  })
+
+  it('should verify an fs probe\'s ignoreErrors value is an object', function () {
+    const config = {probes: {fs: {enabled: true, ignoreErrors: 'i am a shrimp'}}};
+    writeConfigJSON(config);
+
+    const cfg = guc();
+
+    const errors = [`invalid ignoreErrors setting: ${JSON.stringify('i am a shrimp')}`];
+    delete config.probes.fs.ignoreErrors;
+    doChecks(cfg, {probes: config.probes, errors});
+  })
+
+  it('should verify that an fs probe\'s ignoreErrors object contains objects', function () {
+    const config = {probes: {fs: {ignoreErrors: {open: {ENOENT: true}, readdir: 'and so am i'}}}};
+    writeConfigJSON(config);
+
+    const cfg = guc();
+
+    const errors = [`invalid error code to ignore: ${JSON.stringify({readdir: 'and so am i'})}`];
+    delete config.probes.fs.ignoreErrors.readdir;
+    doChecks(cfg, {probes: config.probes, errors});
+
+  })
+
   //
   // transaction settings
   //

--- a/test/unified-config.test.js
+++ b/test/unified-config.test.js
@@ -366,10 +366,16 @@ describe('config', function () {
   it('should correctly handle env vars with explicit names', function () {
     process.env.APPOPTICS_DEBUG_LEVEL = 4;
     process.env.APPOPTICS_COLLECTOR = 'collector-stg.appoptics.com';
+    process.env.APPOPTICS_TRUSTEDPATH = './certs/special.cert';
 
     const cfg = guc();
 
-    const config = {logLevel: 4, endpoint: process.env.APPOPTICS_COLLECTOR};
+    const expectedLogLevel = +process.env.APPOPTICS_DEBUG_LEVEL;
+    const config = {
+      logLevel: expectedLogLevel,
+      endpoint: process.env.APPOPTICS_COLLECTOR,
+      trustedPath: process.env.APPOPTICS_TRUSTEDPATH,
+    };
     doChecks(cfg, {global: config});
   })
 

--- a/test/versions.js
+++ b/test/versions.js
@@ -1,5 +1,10 @@
 'use strict'
 
+//
+// this file defines the versions that will be test when using
+// test-each-version.
+//
+
 const {VersionSpec} = require('testeachversion')
 const semver = require('semver');
 
@@ -81,6 +86,8 @@ test('koa-router', {
 test('level', node('gte', '12.0.0') ? '>= 5.0.0' : '>= 1.3.0');
 
 test('memcached', '>= 2.2.0')
+// prior to version 3.3.0 mongodb used mongodb-core
+test('mongodb', '>= 3.3.0');
 test('mongodb-core', '>= 2.0.0')
 test('mongoose', '>= 4.6.4')
 test('morgan', '>= 1.6.0')

--- a/test/versions.js
+++ b/test/versions.js
@@ -1,8 +1,8 @@
 'use strict'
 
 //
-// this file defines the versions that will be test when using
-// test-each-version.
+// this file defines the versions that will be tested when using
+// testeachversion.
 //
 
 const {VersionSpec} = require('testeachversion')

--- a/test/versions.js
+++ b/test/versions.js
@@ -86,10 +86,12 @@ test('koa-router', {
 test('level', node('gte', '12.0.0') ? '>= 5.0.0' : '>= 1.3.0');
 
 test('memcached', '>= 2.2.0')
-// prior to version 3.3.0 mongodb used mongodb-core
+// prior to version 3.3.0 mongodb used mongodb-core.
 test('mongodb', '>= 3.3.0');
 test('mongodb-core', '>= 2.0.0')
-test('mongoose', '>= 4.6.4')
+// our agent disables mongodb-core versions less than 3 on node > 11.15.0 due to memory leak.
+// mongoose 5 is the first that uses mongodb-core 3.
+test('mongoose', node('gte', '11.15.0') ? '>= 5.0.0' : '>= 4.6.4')
 test('morgan', '>= 1.6.0')
 test('mysql', '>= 2.1.0')
 


### PR DESCRIPTION
- supply a default when there is no TransactionName. [AO-14454]
- prepare for a numeric code return on errors [AO-14437]
- don't enable mongodb-core probe version < 3 if node > 10 [AO-14456, AO-14253]
- don't log two errors for each bad KV pair
- fix duplicate/incorrect logging of getTraceSettings() errors [AO-14457]
- reset count and time-window when issuing a debounced log message [AO-14438]
- create mongodb probe since v3.3.0 no longer uses mongodb-core [AO-14417]
- allow the fs probe to ignore specific errors (ENOENT, etc.) [AO-12757]
- fix bug where FileDescriptor would not be added to an exit event
- require-patch now logs the version for patched modules.

[AO-14454]: https://swicloud.atlassian.net/browse/AO-14454
[AO-14437]: https://swicloud.atlassian.net/browse/AO-14437
[AO-14457]: https://swicloud.atlassian.net/browse/AO-14457
[AO-14438]: https://swicloud.atlassian.net/browse/AO-14438
[AO-14417]: https://swicloud.atlassian.net/browse/AO-14417
[AO-12757]: https://swicloud.atlassian.net/browse/AO-12757