### PR TITLE
lib - use llhttp version if present [AO-14657]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -465,17 +465,18 @@ if (enabled) {
   //
   nextTick(function () {
     ao.requestStore.run(function () {
+      const v = process.versions;
       const data = {
         '__Init': 1,
         'Layer': 'nodejs',
         'Label': 'single',
-        'Node.Version': process.versions.node,
-        'Node.V8.Version': process.versions.v8,
-        'Node.LibUV.Version': process.versions.uv,
-        'Node.OpenSSL.Version': process.versions.openssl,
-        'Node.Ares.Version': process.versions.ares,
-        'Node.ZLib.Version': process.versions.zlib,
-        'Node.HTTPParser.Version': process.versions.http_parser,
+        'Node.Version': v.node,
+        'Node.V8.Version': v.v8,
+        'Node.LibUV.Version': v.uv,
+        'Node.OpenSSL.Version': v.openssl,
+        'Node.Ares.Version': v.ares,
+        'Node.ZLib.Version': v.zlib,
+        'Node.HTTPParser.Version': v.llhttp || v.http_parser,
         'Node.Oboe.Version': bindings.Config.getVersionString(),
       }
 


### PR DESCRIPTION
- node 12 removed http_parser