### PR TITLE
Populate proper values in transaction settings

### DIFF
--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -346,7 +346,7 @@ function parsetransactionSettings (settings) {
 
   settings.forEach(setting => {
     // presume success of one form or another
-    const goodEntry = {type: 'url', pattern: undefined, doSample: false, doMetrics: false}
+    const goodEntry = {type: 'url', regex: undefined, string: undefined, doSample: false, doMetrics: false}
 
     if (setting.type !== 'url') {
       errors.push({spec: setting, error: `invalid type: "${setting.type}"`})
@@ -372,13 +372,13 @@ function parsetransactionSettings (settings) {
     // because the config file can be JSON or a module. JSON cannot have a
     // RegExp value but a module can.
     if (setting.regex instanceof RegExp) {
-      goodEntry.pattern = setting.regex
+      goodEntry.regex = setting.regex
       goodSettings.push(goodEntry)
     } else if (typeof setting.regex === 'string') {
       let re
       try {
         re = new RegExp(setting.regex)
-        goodEntry.pattern = re
+        goodEntry.regex = re
       } catch (e) {
         errors.push({spec: setting, error: e.message})
       }
@@ -386,7 +386,7 @@ function parsetransactionSettings (settings) {
         goodSettings.push(goodEntry)
       }
     } else if (setting.string && typeof setting.string === 'string') {
-      goodEntry.pattern = setting.string
+      goodEntry.string = setting.string
       goodSettings.push(goodEntry)
     } else {
       errors.push({spec: setting, error: 'invalid specialUrl'})

--- a/test/unified-config.test.js
+++ b/test/unified-config.test.js
@@ -98,10 +98,14 @@ function toInternalTransactionSettings (settings) {
     translated.push({
       doMetrics: s.tracing !== 'disabled',
       doSample: s.tracing !== 'disabled',
-      pattern: s.string || (s.regex instanceof RegExp ? s.regex : new RegExp(s.regex)),
+      string: s.string,
+      regex: s.regex,
       type: s.type,
-    })
-  })
+    });
+    if (typeof s.regex === 'string') {
+      translated[translated.length - 1].regex = new RegExp(s.regex);
+    }
+  });
 
   return translated;
 }


### PR DESCRIPTION
Configuration parser was populating fields that were never used and filtering logic was expecting fields that were never populated.