### PR TITLE
add option to force a new trace to begin

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -868,6 +868,7 @@ function makeWrappedRunner (run, callback) {
  * @param {object}  [opts] - options
  * @param {boolean} [opts.enabled=true] - enable tracing
  * @param {boolean} [opts.collectBacktraces=false] - collect backtraces
+ * @param {boolean} [opts.forceNewTrace] - ignore any existing context and force a new trace
  * @param {string|function} [opts.customTxName] - name or function
  * @returns {value} the value returned by the run function or undefined if it can't be run
  *
@@ -936,9 +937,12 @@ function startOrContinueTrace (xtrace, build, run, opts, cb) {
     return run(ao.bind(cb))
   }
 
-  // If already tracing, continue the existing trace ignoring
-  // any xtrace passed as the first argument.
-  const last = Span.last
+  // If already tracing, continue the existing trace ignoring any xtrace
+  // passed as the first argument, unless forcing a new trace.
+  let last;
+  if (!opts.forceNewTrace) {
+    last = Span.last
+  }
   if (last) {
     return runInstrument(last, build, run, opts, cb)
   }

--- a/lib/api.js
+++ b/lib/api.js
@@ -1011,6 +1011,7 @@ function startOrContinueTrace (xtrace, build, run, opts, cb) {
  * @param {object}  [opts] - options
  * @param {boolean} [opts.enabled=true] - enable tracing
  * @param {boolean} [opts.collectBacktraces=false] - collect backtraces
+ * @param {boolean} [opts.forceNewTrace] - ignore any existing context and force a new trace
  * @param {string|function} [opts.customTxName] - name or function
  * @returns {Promise} the value returned by the run function or undefined if it can't be run
  *


### PR DESCRIPTION
`startOrContinueTrace()`'s config option can now contain `forceNewTrace: true` in order to ignore any existing trace and unconditionally start a new trace.