### PR TITLE
VM metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,3 +97,25 @@ Bug fixes
 - reset both count and time windows when a debounced log message is issued.
 - add missing `FileDescriptor` to exit events.
 
+### v7.0.0
+
+Features
+- add forceNewTrace option to `startOrContinueTrace()`
+- support brotli compressin in `zlib`
+- support restify v7+
+- use `ace-context`; remove `continuation-local-storage`
+
+Bug fixes
+- force new context on inbound HTTP requests.
+- fix http `RemoteURL` KV when search/query is present
+- exit http/s client spans correctly on socket errors
+- exit http/s client spans on upgrade events
+- don't add undefined `Database` KV
+- use new http_parser values if present
+
+### v7.1.0
+
+Features
+- runtime metrics
+- new function `sendMetrics()`; deprecate `sendMetric()`
+- requires `appoptics-bindings@9`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Table of Contents
 ## Dev environment
 
 The dev environment for [appoptics-apm](https://github.com/appoptics/appoptics-apm-node) requires
-node (version 6+, 10+ preferred), docker, and a bash shell. It's generally easiest to work at a bash
+node (version 8+, 10+ preferred), docker, and a bash shell. It's generally easiest to work at a bash
 command prompt for editing and running tests from that prompt that interact with exposed ports from
 the docker containers created by the `docker-compose.yml` file.
 
@@ -44,39 +44,25 @@ appoptics-bindings, a dependency. Refer to `test/docker/mac-os-test-env` for det
 
 In order to run the full test suite various databases are required so that instrumentation for the database
 drivers can be tested. The test environment is created by first executing the bash command
-`source env.sh bash` and then executing `docker-compose up -d`. This two steps will set environment
+`source env.sh bash` and then executing `docker-compose up -d`. These two steps will set environment
 variables and bring up docker containers that provide services (mostly databases) needed by the test suite.
 
 With that in place, the full suite of tests can be run using `npm test`. Each test resides in a file name
 ending in `.test.js` so it is possible to run subsets of the tests by directly invoking mocha, e.g.,
-`mocha test/custom.test.js`, `mocha test/*.test.js`, or `mocha test/probes/*.test.js`
-
-There is also a `main` container created that can be used as a clean-room environment for testing. So if we
-have put the `appoptics-apm-node` code in the `ao` directory (because it is short and concise) docker will
-create the container `ao_main_1` as a default name. To use that, presuming the `docker-compose up -d`
-command has already been executed:
-
-1. `docker exec -it ao_main_1 /bin/bash` - get a command prompt in the container
-2. `cd appoptics` - change to the appoptics directory
-3. `npm install` - to install the package and dependencies
-4. `source env.sh docker-java` - to setup the java-collector (beta note: the "docker" arg needs to be
-updated)
-5. `source env.sh add-bin` - to add the node_module executables to the path
-5. run tests using `npm test` or using mocha directory as shown above.
-
+`mocha test/custom.test.js`, `mocha test/*.test.js`, or `mocha test/probes/*.test.js`. Note that `npm test`
+invokes a shell script because `mocha` loads all the tests once and some tests must be run independently.
+The `test.sh` file shows what all the tests are.
 
 For testing, a mock reporter that listens on UDP port 7832 is used (hardcoded in `test/helper.js`). The
 mock reporter intercepts UDP messages and checks them for correctness. When you source `env.sh` it will set
-environment variables appropriately. It does require that `AO_TOKEN_STG` exists in your environment. That
-is the service key that is used for access.  If using the java-collector or scribe-collector the key can be
-fake, like `f08da708-7f1c-4935-ae2e-122caf1ebe31`. If accessing a production or staging environment it must
+environment variables appropriately. It does require that `AO_TOKEN_STG` or `AO_TOKEN_PROD` is defined in
+your environment. That is the service key that is used for access.  If using the java-collector the key can
+be fake, like `f08da708-7f1c-4935-ae2e-122caf1ebe31`. If accessing a production or staging environment it must
 be a valid key.
 
 
 It is possible to use non-production versions of the `appoptics-bindings` package when developing. There
-are many different ways to do so ranging from npm's `link` command, manually copying files, and many
-options embedded in the npm `postinstall` script, `install-appoptics-bindings.js`. The primary
-documentation for this advanced feature is the code.
+are different ways to do accomplish this ranging from npm's `link` command to manually copying files.
 
 ### Testing against all supported versions of the package
 
@@ -88,8 +74,8 @@ uses this file by default. To test all supported versions of a given package use
 
 If you don't specify the `-p package-name` option, all supported versions of all packages will be tested. That
 takes a while. `testeachversion` writes two files, a details file and a summary file. More information and options
-is available via `testeachversion -h`.
-
+is available via `testeachversion -h`. Another file packaged with `testeachversion` is `humanize-logs` (`humanize`
+in the `.bin` directory). It reads the summary file and outputs a more readable format.
 
 
 ## Docs
@@ -162,5 +148,5 @@ useful for debugging using something like `mocha --inspect-brk test/probes/http.
 ### Pull Requests
 
 When your changes pass testing, including any new tests required to verify your changes
-and documentation if appropriate, issue a PR. We'll try to take a prompt look at get back
+and documentation if appropriate, issue a PR. We'll try to take a prompt look and get back
 to you quickly.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ is a great way to start.
 ## Dependencies
 
 - Linux
-- Node.js v6+ [Maintenance and Active LTS](https://github.com/nodejs/Release)
+- Node.js v8+ [Maintenance and Active LTS](https://github.com/nodejs/Release)
 
 The agent compiles a C++ addon during install, so you’ll need to have the following on the system prior to installing the agent:
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -22,6 +22,7 @@ The configuration file can supply the following properties, showing their defaul
   domainPrefix: false,
   ignoreConflicts: false,
   traceMode: 'enabled',
+  runtimeMetrics: true,
   transactionSettings: undefined,
   insertTraceIdsIntoLogs: false,
   insertTraceIdsIntoMorgan: false,
@@ -42,6 +43,7 @@ The configuration file can supply the following properties, showing their defaul
 |domainPrefix|`false`|Prefix transaction names with the domain name.|
 |ignoreConflicts|`false`|Appoptics will disable itself when conflicting APM products are loaded unless this is set to `true`.|
 |traceMode|`'enabled'`|Mode `'enabled'` will cause Appoptics to sample as many requests as possible. Mode 'disabled' will disable sampling and metrics.|
+|runtimeMetrics|`true`|Collect runtime metrics characterizing the performance of node and v8|
 |transactionSettings|`undefined`|An array of transactions to exclude. Each array element is an object of the form `{type: 'url', string: 'pattern', tracing: trace-setting}` or `{type: 'url', regex: /regex/, tracing: trace-setting}`. When the specified type (currently only `'url'` is implemented) matches the string or regex then tracing for that url is set to trace-setting, overriding the global traceMode. N.B. if inserting a regex into a JSON configuration file you must enter the string that is expected by the `RegExp` constructor because JSON has no representation of a `RegExp` object. `trace-setting` is either `'enabled'` or `'disabled'`.|
 |ec2MetadataTimeout|`1000`|Milliseconds to wait for the ec2/openstack metadata service to respond|
 |insertTraceIdsIntoLogs|`false`|Insert trace IDs into supported logging packages' output. Options are `true`, `'traced'`, `'sampledOnly'`, and `'always'`. The default, `false`, does not insert trace ids. `true` and `'traced'` insert the ID when AppOptics is tracing. `'sampledOnly'` inserts the ID when the trace is sampled. `'always'` inserts an empty trace ID value (all-zeroes) even when not tracing.|
@@ -121,6 +123,7 @@ These environment variables may be set:
 |APPOPTICS_TRUSTEDPATH|built-in|Path to the certificate used to verify the collector endpoint. Used only for testing.|
 |APPOPTICS_DEBUG_LEVEL|`'2'`|Logging level for low-level library. Higher numbers get more logging. Possible values: 1 to 6|
 |APPOPTICS_TRIGGER_TRACE_ENABLED|`'true'`|Enable the trigger-trace feature. Options are `'true'`, `'false'`|
+|APPOPTICS_RUNTIME_METRICS|`'true'`|Enable runtime metrics. Options are `'true'`, `'false'`|
 
 Deprecated environment variables. They will be removed in the future:
 

--- a/lib/addon-sim.js
+++ b/lib/addon-sim.js
@@ -67,6 +67,9 @@ const addon = {
     sendStatus () {return 0},
     // -1 is success
     sendMetric () {return -1},
+    sendMetrics () {
+      return {errors: []}
+    },
     // it returns the transaction name, so...
     sendHttpSpan (obj) {return obj.txname ? obj.txname : ''},
     // we're as ready to sample as we'll ever be

--- a/lib/api-sim.js
+++ b/lib/api-sim.js
@@ -70,6 +70,7 @@ module.exports = function (appoptics) {
     reportError,
     reportInfo,
     sendMetric,
+    sendMetrics,
     getFormattedTraceId,
     insertLogObject,
   }
@@ -661,6 +662,10 @@ function reportInfo (data) {
  */
 function sendMetric (name, options) {
   return aob.Reporter.sendMetric(name, options);
+}
+
+function sendMetrics (metrics) {
+  return aob.Reporter.sendMetrics(metrics);
 }
 
 //

--- a/lib/api-sim.js
+++ b/lib/api-sim.js
@@ -35,11 +35,19 @@ module.exports = function (appoptics) {
     return span
   }
 
+  class Metrics {
+    constructor () {}
+    start () {}
+    stop () {}
+    resetInterval () {}
+  }
+
   // return the API
   return {
     // core classes
     Event,
     Span,
+    Metrics,
 
     // basic functions
     readyToSample,

--- a/lib/api.js
+++ b/lib/api.js
@@ -64,6 +64,7 @@ module.exports = function (appoptics) {
     reportError,
     reportInfo,
     sendMetric,
+    sendMetrics,
     getFormattedTraceId,
     insertLogObject,
   }
@@ -1130,10 +1131,12 @@ function reportInfo (data) {
 // returns -1 for success else error code. the only error now is 0.
 //
 /**
+ * @deprecated use sendMetrics()
  * Send a custom metric. There are two types of metrics:
- * 1) count-based - the number of times something has occurred (no value is associated with this type)
- * 2) value-based - a specific value (or sum of values).
- * If options.value is present the metric being reported is value-based.
+ * 1) count-based - the number of times something has occurred (no value
+ *     is associated with this type)
+ * 2) value-based - a specific value (or sum of values if count > 1). If
+ *     options.value is present the metric being reported is value-based.
  *
  * @method ao.sendMetric
  * @param {string} name - the name of the metric
@@ -1146,7 +1149,7 @@ function reportInfo (data) {
  * @param {object} [options.tags] - an object containing {tag: value} pairs
  *
  * @throws {TypeError} - if an invalid argument is supplied
- * @returns {number} - -1 for success else an error code.
+ * @returns {number} - (-1) for success else an error code.
  *
  * @example
  *
@@ -1166,7 +1169,112 @@ function reportInfo (data) {
  *
  */
 function sendMetric (name, options) {
-  return aob.Reporter.sendMetric(name, options);
+  const metric = Object.assign({name}, options);
+  const result = aob.Reporter.sendMetrics([metric]);
+  return result.errors && result.errors.length === 0 ? -1 : 0;
+}
+
+
+/**
+ * @typedef {object} metric
+ * @property {string} name - name of the metric
+ * @property {integer} [count=1] - count of the metric
+ * @property {number} [value] - if summary, value or sum of values
+ * @property {boolean} [addHostTag=false] - add a hostname tag
+ * @property {object} [tags] - key-value pairs that can be used for filtering
+ *
+ * @property {boolean} [testing=false] - return array of correct metrics in addition
+ *     to an array of metrics with errors.
+ * @property {boolean} [noop=false] - do not actually send the metrics to the collector
+ */
+
+/**
+ * @typedef {object} SendMetricsReturn
+ * @property {array} errors - an array of metrics for which an error occurred
+ * @property {array} [correct] - if globalOption.testing specified the correctly
+ *                               processed metrics are returned in this array.
+ */
+
+/**
+ * Send custom metrics. There are two types of metrics:
+ * 1) count-based - the number of times something has occurred (no
+ *                  value is associated with this type)
+ * 2) value-based - a specific value (or sum of values if count > 1).
+ *
+ *
+ * @method ao.sendMetrics
+ * @param {(metric|metric[])} metrics - a metric or an array of metrics
+ * @param {object} [gopts] - supply defaults to be applied to each metric.
+ * @param {boolean} [gopts.addHostTag=false] - add a hostname tag
+ * @param {object} [gopts.tags] - tags to add to each metric. the tags are
+ *     added as "metric.tags = Object.assign({}, gopts.tags, metric.tags)"
+ *
+ * @returns {SendMetricsReturn}
+ *
+ * @example
+ *
+ * // send a single metric
+ * ao.sendMetrics({name: 'my.counts.basic'});
+ * ao.sendMetrics({name: 'my.values.some', value: 42.42});
+ *
+ * // send multiple metrics (most efficient)
+ * ao.sendMetrics([
+ *   // default count is 1
+ *   {name: 'my.counts.defaulted'},
+ *   {name: 'my.counts.multiple', count: 3},
+ *   {name: 'my.values.xyzzy', value: 10},
+ *   // report two values for which the sum is 25.
+ *   {name: 'my.values.xyzzy', count: 2, value: 25}
+ * ]);
+ *
+ * // add tags that can be used for filtering on the host
+ * ao.sendMetrics([
+ *   {name: 'my.metric.end-of-file', tags: {class: 'error', subsystem: 'fs'}}
+ * ]);
+ *
+ * // add a hostname tag automatically.
+ * ao.sendMetrics([
+ *   {name: 'my.metric.end-of-file', tags: {class: 'error'}, addHostTag: true}
+ * ]);
+ *
+ * // add a hostname tag and an application tag to each metric.
+ * ao.sendMetrics(
+ *   [
+ *     {name: 'my.metric', tags: {class: 'status'}},
+ *     {name: 'my.time', value: 33.3, tags: {class: 'performance'}}
+*    ],
+ *   {addHostTag: true, tags: {application: 'x'}}
+ * );
+ *
+ * // default class to 'status' for metrics that don't supply a class
+ * // tag.
+ * ao.sendMetrics(
+ *   [
+ *     {name: 'my.metric'},
+ *     {name: 'my.time', value: 33.3, tags: {class: 'performance'}}
+ *   ],
+ *   {tags: {class: 'status'}}
+ * );
+ */
+function sendMetrics (metrics, gopts = {}) {
+  const addHostTag = gopts.addHostTag;
+  const globalTags = gopts.tags;
+
+  if (!Array.isArray(metrics)) {
+    metrics = [metrics];
+  }
+
+  // merge global options into individual metrics
+  const merged = [];
+  for (let i = 0; i < metrics.length; i++) {
+    const m = metrics[i];
+
+    const metric = Object.assign({addHostTag}, m);
+    metric.tags = Object.assign({}, globalTags, m.tags);
+    merged.push(metric);
+  }
+
+  return aob.reporter.sendMetrics(merged);
 }
 
 //

--- a/lib/api.js
+++ b/lib/api.js
@@ -33,15 +33,17 @@ module.exports = function (appoptics) {
   ao.maps.responseIsPatched = responseIsPatched;
   ao.maps.responseFinalizers = responseFinalizers;
 
-  // make these globally available
+  // make these globally available.
   Event = require('./event');
   Span = require('./span');
+  const Metrics = require('./metrics');
 
   // return the API
   return {
     // core classes
     Event,
     Span,
+    Metrics,
 
     // basic functions
     readyToSample,

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -10,6 +10,7 @@ function getUnifiedConfig () {
   const errors = [];        // for each error and array of arguments for log.error()
   const warnings = [];      // ditto for log.warn()
 
+  //
   // location: (e)nvironment, (c)onfig, (b)oth, (o)mit - when both the env var has precedence.
   // type: (s)tring, (i)nteger, (b)oolean, object {valid: value, valid2: value}
   // name: present without APPOPTICS_ prefix if not environmentalized version of key.
@@ -37,6 +38,7 @@ function getUnifiedConfig () {
     hostnameAlias: {location: 'b', type: 's'},
     ec2MetadataTimeout: {location: 'b', type: 'i'},
     triggerTraceEnabled: {location: 'b', type: 'b', default: true},
+    runtimeMetrics: {location: 'b', type: 'b', default: true},
 
     // end-user focused, env var only
     logLevel: {location: 'e', type: 'i', name: 'DEBUG_LEVEL', default: 2},

--- a/lib/index.js
+++ b/lib/index.js
@@ -451,15 +451,16 @@ if (enabled) {
     enabled = false;
   }
 
-  if (config.runtimeMetrics) {
-    ao.metrics = new ao.Metrics();
-    ao.metrics.start();
-  }
-
   //
-  // Send __Init event
+  // start metrics and send __Init event
   //
   nextTick(function () {
+
+    if (config.runtimeMetrics) {
+      ao.metrics = new ao.Metrics();
+      ao.metrics.start();
+    }
+
     ao.requestStore.run(function () {
       const v = process.versions;
       const data = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -451,8 +451,10 @@ if (enabled) {
     enabled = false;
   }
 
-  ao.metrics = new ao.Metrics();
-  ao.metrics.start();
+  if (config.runtimeMetrics) {
+    ao.metrics = new ao.Metrics();
+    ao.metrics.start();
+  }
 
   //
   // Send __Init event

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,9 +43,7 @@ ao.g = {
  * const ao = require('appoptics-apm')
  */
 
-// read the config file so that if it disables the agent it's possible to
-// skip loading the bindings. but first, set up logging so problems can be
-// logged.
+// first, set up logging so problems can be reported.
 const path = require('path')
 const env = process.env
 
@@ -106,6 +104,8 @@ if (alreadyLoaded.length && env.NODE_ENV && env.NODE_ENV.toLowerCase() === 'prod
   log.warn('the following files were loaded before appoptics-apm:', alreadyLoaded)
 }
 
+// read the config file so that if it disables the agent it's possible to
+// skip loading the bindings.
 const uc = (require('./get-unified-config'))();
 
 if (uc.unusedConfig.length) {
@@ -450,6 +450,9 @@ if (enabled) {
     // don't enable patching.
     enabled = false;
   }
+
+  ao.metrics = new ao.Metrics();
+  ao.metrics.start();
 
   //
   // Send __Init event

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -43,14 +43,16 @@ class Metrics {
     this.metrics.push({
       name: `${this.prefix}.${metric}`,
       count: n,
-      value
+      addHostTag: true,
+      value,
     });
   }
 
   addMetricI (metric, n = 1) {
     this.metrics.push({
       name: `${this.prefix}.${metric}`,
-      count: n
+      addHostTag: true,
+      count: n,
     });
   }
 
@@ -70,23 +72,20 @@ class Metrics {
   addMetrics () {
     const metrics = aob.metrics.getMetrics();
     if (metrics.gc) {
-      this.addMetricV('gc.gcCount', metrics.gc.gcCount);
-      this.addMetricV('gc.gcTime', metrics.gc.gcTime);
-      this.addMetricV('gc.p50', metrics.gc.p50);
-      this.addMetricV('gc.p75', metrics.gc.p75);
-      this.addMetricV('gc.p90', metrics.gc.p90);
-      this.addMetricV('gc.p95', metrics.gc.p95);
-      this.addMetricV('gc.p99', metrics.gc.p99);
-      this.addMetricV('gc.min', metrics.gc.min);
-      this.addMetricV('gc.max', metrics.gc.max);
-      this.addMetricV('gc.mean', metrics.gc.mean);
-      this.addMetricV('gc.stddev', metrics.gc.stddev);
-
-      const types = Object.keys(metrics.gc.gcTypeCounts);
-      for (let i = 0; i < types.length; i++) {
-        const type = types[i];
-        this.addMetricV(`gc.type.${this.gcTypeNames[type] || 'other'}`, metrics.gc.gcTypeCounts[type]);
-      }
+      this.addMetricV('gc.count', metrics.gc.gcCount);
+      this.addMetricV('gc.time', metrics.gc.gcTime);
+      ['major', 'minor'].forEach(type => {
+        this.addMetricV(`gc.${type}.count`, metrics.gc[type].count);
+        this.addMetricV(`gc.${type}.p50`, metrics.gc[type].p50);
+        this.addMetricV(`gc.${type}.p75`, metrics.gc[type].p75);
+        this.addMetricV(`gc.${type}.p90`, metrics.gc[type].p90);
+        this.addMetricV(`gc.${type}.p95`, metrics.gc[type].p95);
+        this.addMetricV(`gc.${type}.p99`, metrics.gc[type].p99);
+        this.addMetricV(`gc.${type}.min`, metrics.gc[type].min);
+        this.addMetricV(`gc.${type}.max`, metrics.gc[type].max);
+        this.addMetricV(`gc.${type}.mean`, metrics.gc[type].mean);
+        this.addMetricV(`gc.${type}.stddev`, metrics.gc[type].stddev);
+      })
     }
 
     if (metrics.eventloop) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -49,16 +49,16 @@ class Metrics {
     this.metrics.push({
       name: `${this.prefix}.${metric}`,
       count: n,
-      addHostTag: true,
       value,
+      addHostTag: true,
     });
   }
 
   addMetricI (metric, n = 1) {
     this.metrics.push({
       name: `${this.prefix}.${metric}`,
-      addHostTag: true,
       count: n,
+      addHostTag: true,
     });
   }
 
@@ -122,14 +122,14 @@ class Metrics {
     this.addMetricV('process.memoryUsage.external', mem.external);
 
     mem = v8.getHeapStatistics();
-    this.addMetricV('v8.getHeapStatistics.total_heap_size', mem.total_heap_size);
-    this.addMetricV('v8.getHeapStatistics.total_heap_size_executable', mem.total_heap_size_executable);
-    this.addMetricV('v8.getHeapStatistics.total_physical_size', mem.total_physical_size);
-    this.addMetricV('v8.getHeapStatistics.total_available_size', mem.total_available_size);
-    this.addMetricV('v8.getHeapStatistics.used_heap_size', mem.used_heap_size);
-    this.addMetricV('v8.getHeapStatistics.heap_size_limit', mem.heap_size_limit);
-    this.addMetricV('v8.getHeapStatistics.malloced_memory', mem.malloced_memory);
-    this.addMetricV('v8.getHeapStatistics.peak_malloced_memory', mem.peak_malloced_memory);
+    this.addMetricV('v8.heapStatistics.total_heap_size', mem.total_heap_size);
+    this.addMetricV('v8.heapStatistics.total_heap_size_executable', mem.total_heap_size_executable);
+    this.addMetricV('v8.heapStatistics.total_physical_size', mem.total_physical_size);
+    this.addMetricV('v8.heapStatistics.total_available_size', mem.total_available_size);
+    this.addMetricV('v8.heapStatistics.used_heap_size', mem.used_heap_size);
+    this.addMetricV('v8.heapStatistics.heap_size_limit', mem.heap_size_limit);
+    this.addMetricV('v8.heapStatistics.malloced_memory', mem.malloced_memory);
+    this.addMetricV('v8.heapStatistics.peak_malloced_memory', mem.peak_malloced_memory);
   }
 }
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -9,28 +9,34 @@ class Metrics {
     this.interval = options.interval || 60 * 1000;
     this.prefix = options.prefix || 'trace.node';
     this.metrics = [];
-    this.gcTypeNames = {
-      1: 'scavenge',
-      2: 'markSweepCompact',
-      4: 'incrementalMarking',
-      8: 'processWeakCallbacks',
-    };
+    this.state = 'initial';
   }
 
   start () {
-    // start the metrics gathered by the C++ code
-    aob.metrics.start();
+    if (this.state !== 'started') {
+      // start the metrics gathered by the C++ code
+      aob.metrics.start();
 
-    this.id = setInterval(() => {
-      this.reportMetrics();
-    }, this.interval);
-    // don't let metrics keep the process alive
-    this.id.unref();
+      this.id = setInterval(() => {
+        this.reportMetrics();
+      }, this.interval);
+      // don't let metrics keep the process alive
+      this.id.unref();
+    }
+    return this.state = 'started';
   }
 
   stop () {
+    if (this.state !== 'started') {
+      return;
+    }
     aob.metrics.stop();
     clearInterval(this.id);
+    return this.state = 'stopped';
+  }
+
+  getState () {
+    return this.state;
   }
 
   resetInterval (interval) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const {loggers: log, addon: aob} = require('.');
+const v8 = require('v8');
+
+class Metrics {
+  constructor (options = {}) {
+    this.id = undefined;
+    this.interval = options.interval || 60 * 1000;
+    this.prefix = options.prefix || 'trace.node';
+    this.metrics = [];
+  }
+
+  start () {
+    this.id = setInterval(() => {
+      this.reportMetrics();
+    }, this.interval);
+    // don't let metrics keep the process alive
+    this.id.unref();
+  }
+
+  stop () {
+    clearInterval(this.id);
+  }
+
+  resetInterval (interval) {
+    this.interval = interval;
+    this.stop();
+    this.start();
+  }
+
+  addMetricV (metric, value, n = 1) {
+    this.metrics.push({
+      name: `${this.prefix}.${metric}`,
+      count: n,
+      value
+    });
+  }
+
+  addMetricI (metric, n = 1) {
+    this.metrics.push({
+      name: `${this.prefix}.${metric}`,
+      count: n
+    });
+  }
+
+  reportMetrics () {
+    this.addCpu();
+    this.addMemory();
+    const r = aob.Reporter.sendMetrics(this.metrics);
+    if (r.errors.length > 0) {
+      r.errors.forEach(e => {
+        log.error('invalid metric', e);
+      });
+    }
+    // don't keep the previous metrics around
+    this.metrics.length = 0;
+  }
+
+  addCpu () {
+    const cpu = process.cpuUsage();
+    this.addMetricV('process.cpuUsage.user', cpu.user);
+    this.addMetricV('process.cpuUsage.system', cpu.system);
+  }
+
+  addMemory () {
+    let mem = process.memoryUsage();
+    this.addMetricV('process.memoryUsage.rss', mem.rss);
+    this.addMetricV('process.memoryUsage.heapTotal', mem.heapTotal);
+    this.addMetricV('process.memoryUsage.heapUsed', mem.heapUsed);
+    this.addMetricV('process.memoryUsage.external', mem.external);
+
+    mem = v8.getHeapStatistics();
+    this.addMetricV('v8.getHeapStatistics.total_heap_size', mem.total_heap_size);
+    this.addMetricV('v8.getHeapStatistics.total_heap_size_executable', mem.total_heap_size_executable);
+    this.addMetricV('v8.getHeapStatistics.total_physical_size', mem.total_physical_size);
+    this.addMetricV('v8.getHeapStatistics.total_available_size', mem.total_available_size);
+    this.addMetricV('v8.getHeapStatistics.used_heap_size', mem.used_heap_size);
+    this.addMetricV('v8.getHeapStatistics.heap_size_limit', mem.heap_size_limit);
+    this.addMetricV('v8.getHeapStatistics.malloced_memory', mem.malloced_memory);
+    this.addMetricV('v8.getHeapStatistics.peak_malloced_memory', mem.peak_malloced_memory);
+  }
+}
+
+module.exports = Metrics;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -89,9 +89,9 @@ class Metrics {
     }
 
     if (metrics.eventloop) {
+      this.addMetricV('eventloop.p50', metrics.eventloop.p50);
       this.addMetricV('eventloop.p75', metrics.eventloop.p75);
       this.addMetricV('eventloop.p90', metrics.eventloop.p90);
-      this.addMetricV('eventloop.p50', metrics.eventloop.p50);
       this.addMetricV('eventloop.p95', metrics.eventloop.p95);
       this.addMetricV('eventloop.p99', metrics.eventloop.p99);
       this.addMetricV('eventloop.min', metrics.eventloop.min);

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -9,9 +9,18 @@ class Metrics {
     this.interval = options.interval || 60 * 1000;
     this.prefix = options.prefix || 'trace.node';
     this.metrics = [];
+    this.gcTypeNames = {
+      1: 'scavenge',
+      2: 'markSweepCompact',
+      4: 'incrementalMarking',
+      8: 'processWeakCallbacks',
+    };
   }
 
   start () {
+    // start the metrics gathered by the C++ code
+    aob.metrics.start();
+
     this.id = setInterval(() => {
       this.reportMetrics();
     }, this.interval);
@@ -20,6 +29,7 @@ class Metrics {
   }
 
   stop () {
+    aob.metrics.stop();
     clearInterval(this.id);
   }
 
@@ -45,7 +55,7 @@ class Metrics {
   }
 
   reportMetrics () {
-    this.addCpu();
+    this.addMetrics();
     this.addMemory();
     const r = aob.Reporter.sendMetrics(this.metrics);
     if (r.errors.length > 0) {
@@ -57,8 +67,44 @@ class Metrics {
     this.metrics.length = 0;
   }
 
-  addCpu () {
-    const cpu = process.cpuUsage();
+  addMetrics () {
+    const metrics = aob.metrics.getMetrics();
+    if (metrics.gc) {
+      this.addMetricV('gc.gcCount', metrics.gc.gcCount);
+      this.addMetricV('gc.gcTime', metrics.gc.gcTime);
+      this.addMetricV('gc.p50', metrics.gc.p50);
+      this.addMetricV('gc.p75', metrics.gc.p75);
+      this.addMetricV('gc.p90', metrics.gc.p90);
+      this.addMetricV('gc.p95', metrics.gc.p95);
+      this.addMetricV('gc.p99', metrics.gc.p99);
+      this.addMetricV('gc.min', metrics.gc.min);
+      this.addMetricV('gc.max', metrics.gc.max);
+      this.addMetricV('gc.mean', metrics.gc.mean);
+      this.addMetricV('gc.stddev', metrics.gc.stddev);
+
+      const types = Object.keys(metrics.gc.gcTypeCounts);
+      for (let i = 0; i < types.length; i++) {
+        const type = types[i];
+        this.addMetricV(`gc.type.${this.gcTypeNames[type] || 'other'}`, metrics.gc.gcTypeCounts[type]);
+      }
+    }
+
+    if (metrics.eventloop) {
+      this.addMetricV('eventloop.p75', metrics.eventloop.p75);
+      this.addMetricV('eventloop.p90', metrics.eventloop.p90);
+      this.addMetricV('eventloop.p50', metrics.eventloop.p50);
+      this.addMetricV('eventloop.p95', metrics.eventloop.p95);
+      this.addMetricV('eventloop.p99', metrics.eventloop.p99);
+      this.addMetricV('eventloop.min', metrics.eventloop.min);
+      this.addMetricV('eventloop.max', metrics.eventloop.max);
+      this.addMetricV('eventloop.mean', metrics.eventloop.mean);
+      this.addMetricV('eventloop.stddev', metrics.eventloop.stddev);
+    }
+
+    let cpu = metrics.process;
+    if (!cpu) {
+      cpu = process.cpuUsage();
+    }
     this.addMetricV('process.cpuUsage.user', cpu.user);
     this.addMetricV('process.cpuUsage.system', cpu.system);
   }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,6 @@
     "ws": "^7.2.0"
   },
   "optionalDependencies": {
-    "appoptics-bindings": "^8.0.0"
+    "appoptics-bindings": "^9.0.0-alpha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,6 @@
     "ws": "^7.2.0"
   },
   "optionalDependencies": {
-    "appoptics-bindings": "^9.0.0-alpha.1"
+    "appoptics-bindings": "^9.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,6 @@
     "ws": "^7.2.0"
   },
   "optionalDependencies": {
-    "appoptics-bindings": "^9.0.0-alpha"
+    "appoptics-bindings": "^9.0.0-alpha.1"
   }
 }

--- a/test/probes/bcrypt.test.js
+++ b/test/probes/bcrypt.test.js
@@ -5,7 +5,7 @@ const {ao, startTest, endTest} = require('../1.test-common.js')
 const bcrypt = require('bcrypt')
 const pkg = require('bcrypt/package')
 
-describe('probes/bcrypt ' + pkg.version, function () {
+describe('probes.bcrypt ' + pkg.version, function () {
   let prevll
   before(function () {
     startTest(__filename, {enable: false, customFormatter: 'terse'})

--- a/test/probes/pg6-plus.js
+++ b/test/probes/pg6-plus.js
@@ -235,8 +235,9 @@ describe(`probes.pg6+ ${pkg.version} pg-native ${nativeVer}`, function () {
               },
               release: function () {}
             }
-            done()
+            return results;
           })
+          .then(done);
       })
 
       //

--- a/test/unified-config.test.js
+++ b/test/unified-config.test.js
@@ -15,6 +15,7 @@ const expectedGlobalDefaults = {
   triggerTraceEnabled: true,
   traceMode: 1,
   logLevel: 2,
+  runtimeMetrics: true,
 }
 
 const expectedProbeDefaults = require(`${relativeDir}/lib/probe-defaults`);
@@ -121,7 +122,7 @@ function toTransactionSettingsError (settings, message) {
 //==============
 // start testing
 //==============
-describe('config', function () {
+describe('unified-config', function () {
   //
   // save the configuration
   //

--- a/test/versions.js
+++ b/test/versions.js
@@ -103,7 +103,7 @@ test('mysql', '>= 2.1.0')
 test('oracledb', '>= 2.0.14')
 
 test('pino', '>= 2.3.0');
-test('pg', '>= 4.5.5')
+test('pg', '>= 4.5.5 < 7.0.0 || >= 7.5.0')
 /*
 test('pg', {
   ranges: [

--- a/test/versions.js
+++ b/test/versions.js
@@ -25,7 +25,12 @@ test('zlib')
 //test('amqp', '>= 0.2.0')
 test('amqplib', '>= 0.2.0 < 0.5.0 || > 0.5.0')
 
-test('bcrypt', '>= 0.8.6')
+test('bcrypt', selectone(process.version, [
+  {selector: '>= 8.0.0 < 10.0.0', targetSelector: '>= 1.0.3 < 3.0.0 || > 3.0.0'},
+  {selector: '>= 10.0.0 < 12.0.0', targetSelector: '>= 3.0.0'},
+  {selector: '>= 12.0.0', targetSelector: '>= 3.0.6'}
+]));
+
 test('bluebird', '>= 2.0.0')
 test('bunyan', '>= 1.0.0')
 
@@ -166,4 +171,19 @@ function test (name, ranges) {
 
 function node (op, version) {
   return semver[op](process.version, version);
+}
+
+//
+// selectone(process.version, [
+//   {selector: '> 9.0.0 < 13.0.0', targetSelector: '> 1.0.3'}
+// ])
+//
+function selectone (version, ranges) {
+  for (let i = 0; i < ranges.length; i++) {
+    if (semver.satisfies(version, ranges[i].selector)) {
+      return ranges[i].targetSelector;
+    }
+  }
+  // if nothing matches choose the last one
+  return ranges[ranges.length - 1].targetSelector;
 }


### PR DESCRIPTION
N.B. requires bindings v9 (implements `Reporter.sendMetrics()`) to be released before this.

This release implements [AO-10912] and minor test updates.

- implement `sendMetrics()` which calls `Reporter.sendMetrics()`.
- rewrite `sendMetric()` as a wrapper around `sendMetrics()` so non-breaking
- add `sendMetrics()` to guides/api.md
- deprecate `sendMetric()` in guides/api.md
- config file `runtimeMetrics` or env var `APPOPTICS_RUNTIME_METRICS`

[AO-10912]: https://swicloud.atlassian.net/browse/AO-10912