### PR TITLE
deprecate Event.last and Span.last

### DIFF
--- a/lib/addon-sim.js
+++ b/lib/addon-sim.js
@@ -87,8 +87,10 @@ const addon = {
     clear () {},
     isValid () {},
     getTraceSettings (xtrace, localMode) {
+      const traceTaskId = Event.makeFromString(xtrace);
       return {
-        metadata: Event.makeFromString(xtrace),
+        traceTaskId,
+        metadata: traceTaskId,
         doSample: false,
         doMetrics: false,
         edge: false,

--- a/lib/api-sim.js
+++ b/lib/api-sim.js
@@ -23,10 +23,10 @@ module.exports = function (appoptics) {
   Span.init = function () {}
   Span.makeEntrySpan = function makeEntrySpan (name, settings, data) {
 
-    // use the metadata from settings or (primarily used in testing) make new.
-    const metadata = settings.metadata || ao.addon.Metadata.makeRandom(settings.doSample)
+    // use the task id from settings or (primarily used in testing) make new.
+    const traceTaskId = settings.traceTaskId || ao.addon.Event.makeRandom(settings.doSample)
 
-    const span = new Span(name, {metadata, edge: settings.edge}, data)
+    const span = new Span(name, {traceTaskId, edge: settings.edge}, data)
 
     // fill in entry-span-specific properties.
     span.doMetrics = settings.doMetrics
@@ -53,7 +53,7 @@ module.exports = function (appoptics) {
     readyToSample,
     getTraceSettings,
     sampling,
-    stringToMetadata,
+    xtraceToEvent,
 
     // emitter (http) instrumentation
     patchResponse,
@@ -261,8 +261,8 @@ function readyToSample (ms, obj) {
  * @typedef {object} TraceSettings
  * @property {boolean} doSample - the sample decision
  * @property {boolean} doMetrics - the metrics decision
- * @property {Metadata} metadata - the metadata to use
- * @property {boolean} edge - whether to edge back to metadata
+ * @property {Event} traceTaskId - an Event containing the task id to use
+ * @property {boolean} edge - edge back to previous event if truthy
  * @property {number} source - the sample decision source
  * @property {number} rate - the sample rate used
  */
@@ -276,12 +276,16 @@ function readyToSample (ms, obj) {
  */
 function getTraceSettings (xtrace, options) {
   const osettings = aob.Settings.getTraceSettings({xtrace});
+  // compatibility to avoid a synchronized bindings release
+  if (!osettings.traceTaskId) {
+    osettings.traceTaskId = osettings.metadata;
+  }
   return osettings;
 }
 
 /**
  * Determine if the sample flag is set for the various forms of
- * metadata.
+ * x-trace ids.
  *
  * @method ao.sampling
  * @param {string|Event} item - the item to get the sampling flag of
@@ -293,14 +297,14 @@ function sampling (item) {
 }
 
 /**
- * Convert an xtrace ID to a metadata object.
+ * Convert an xtrace ID to an Event object.
  *
- * @method ao.stringToMetadata
+ * @method ao.xtraceToEvent
  * @param {string} xtrace - X-Trace ID, string version of Metadata.
  * @return {bindings.Event|undefined} - bindings.Event object if
  *                                         successful.
  */
-function stringToMetadata (xtrace) {
+function xtraceToEvent (xtrace) {
   return aob.Event.makeFromString(xtrace);
 }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -49,7 +49,7 @@ module.exports = function (appoptics) {
     readyToSample,
     getTraceSettings,
     sampling,
-    stringToMetadata,
+    xtraceToEvent,
 
     // emitter (http) instrumentation
     patchResponse,
@@ -425,7 +425,7 @@ function readyToSample (ms, obj) {
  * @typedef {object} TraceSettings
  * @property {boolean} doSample - the sample decision
  * @property {boolean} doMetrics - the metrics decision
- * @property {Event} metadata - the parent event to get task id from
+ * @property {Event} traceTaskId - the parent event to get task id from
  * @property {boolean} edge - true to edge back to parent op id
  * @property {number} source - the sample decision source
  * @property {number} rate - the sample rate used
@@ -476,8 +476,12 @@ function getTraceSettings (xtrace, options = {}) {
       source: 5,
       rate: 0,
       edge: false,
-      metadata: aob.Event.makeRandom(0)
+      metadata: aob.Event.makeRandom(0),
     }, osettings);
+  }
+  // compatability across bindings versions
+  if (!('traceTaskId' in osettings)) {
+    osettings.traceTaskId = osettings.metadata;
   }
 
   return osettings
@@ -485,10 +489,10 @@ function getTraceSettings (xtrace, options = {}) {
 
 /**
  * Determine if the sample flag is set for the various forms of
- * metadata.
+ * xtrace data.
  *
  * @method ao.sampling
- * @param {string|Event|Metadata} item - the item to get the sampling flag of
+ * @param {string|Event|addon.Event} item - the item to get the sampling flag of
  * @returns {boolean} - true if the sample flag is set else false.
  */
 
@@ -509,22 +513,16 @@ function sampling (item) {
 }
 
 /**
- * Convert an xtrace ID to a metadata object.
+ * Convert an xtrace ID to an event containing metadata
  *
- * @method ao.stringToMetadata
- * @param {string} xtrace - X-Trace ID, string version of Metadata.
- * @return {bindings.Metadata|undefined} - bindings.Metadata object if
- *                                         successful.
+ * @method ao.xtraceToEvent
+ * @param {string} xtrace - X-Trace ID
+ * @return {bindings.Event|undefined} - bindings.Event object
+ *                                      containing the xtrace ID
+ *                                      if successful.
  */
-function stringToMetadata (xtrace) {
-  // if the conversion fails undefined is returned
-  let md
-
-  // the oboe conversion function doesn't check for an all-zero op ID.
-  if (xtrace.indexOf('0000000000000000', 42) !== 42) {
-    md = aob.Event.makeFromString(xtrace);
-  }
-  return md
+function xtraceToEvent (xtrace) {
+  return aob.Event.makeFromString(xtrace);
 }
 
 /**

--- a/lib/api.js
+++ b/lib/api.js
@@ -134,7 +134,7 @@ function definePropertiesOn (ao) {
    * @readOnly
    */
   Object.defineProperty(ao, 'tracing', {
-    get () {return !!Event.last}
+    get () {return !!ao.lastEvent}
   });
 
   /**
@@ -146,14 +146,10 @@ function definePropertiesOn (ao) {
    */
   Object.defineProperty(ao, 'traceId', {
     get () {
-      const last = Event && Event.last;
+      const last = ao.lastEvent;
       if (last) return last.toString();
     }
   });
-
-  //Object.defineProperty(ao, 'lastEvent', {
-  //  get () {return Event && Event.last}
-  //});
 
   const asyncHooks = require('async_hooks');
 
@@ -601,7 +597,7 @@ function addResponseFinalizer (res, finalizer) {
  */
 function instrumentHttp (build, run, options, res) {
   // If not tracing, skip
-  const last = Span.last
+  const last = ao.lastSpan
   if (!last) {
     ao.loggers.warn('instrumentHttp: no last span')
     return run()
@@ -776,7 +772,7 @@ function instrument (span, run, options, callback) {
   }
 
   // If not tracing, there is some error, skip.
-  const last = Span.last
+  const last = ao.lastSpan
   if (!last) {
     if (!ao.startup) {
       ao.loggers.info('ao.instrument found no lastSpan')
@@ -1007,7 +1003,7 @@ function startOrContinueTrace (xtrace, build, run, opts, cb) {
 
   // If already tracing, continue the existing trace ignoring any xtrace
   // passed as the first argument, unless forcing a new trace.
-  const last = Span.last;
+  const last = ao.lastSpan;
   if (last && !opts.forceNewTrace) {
     return runInstrument(last, build, run, opts, cb)
   }
@@ -1125,7 +1121,7 @@ function pStartOrContinueTrace (xtrace, name, task, options = {}) {
  * @param {Error} error - The error instance to report
  */
 function reportError (error) {
-  const last = Span.last
+  const last = ao.lastSpan
   if (last) last.error(error)
 }
 
@@ -1136,7 +1132,7 @@ function reportError (error) {
  * @param {object} data - Data to report in the info event
  */
 function reportInfo (data) {
-  const last = Span.last
+  const last = ao.lastSpan
   if (last) last.info(data)
 }
 
@@ -1350,7 +1346,8 @@ function sendMetrics (metrics, gopts = {}) {
  */
 function getFormattedTraceId (options = {}) {
   const format = options.format || aob.Event.fmtLog;
-  return Event.last ? Event.last.event.toString(format) : '0000000000000000000000000000000000000000-0';
+  const last = ao.lastEvent;
+  return last ? last.event.toString(format) : '0000000000000000000000000000000000000000-0';
 }
 
 /**
@@ -1392,8 +1389,9 @@ function getFormattedTraceId (options = {}) {
 function insertLogObject (o = {}) {
   // if truthy and tracing insert it based on sample setting. otherwise if 'always'
   // then insert a trace ID regardless. No explicit check for 'traced' is required.
-  if (ao.cfg.insertTraceIdsIntoLogs && Event.last) {
-    if (ao.cfg.insertTraceIdsIntoLogs !== 'sampledOnly' || Event.last.event.getSampleFlag()) {
+  let last;
+  if (ao.cfg.insertTraceIdsIntoLogs && (last = ao.lastEvent)) {
+    if (ao.cfg.insertTraceIdsIntoLogs !== 'sampledOnly' || last.event.getSampleFlag()) {
       o.ao = {traceId: ao.getFormattedTraceId()};
     }
   } else if (ao.cfg.insertTraceIdsIntoLogs === 'always') {

--- a/lib/event.js
+++ b/lib/event.js
@@ -146,24 +146,13 @@ Object.defineProperty(Event.prototype, 'opId', {
  *
  * @property {Event} Event.last
  */
+const getEvent = util.deprecate(() => ao.lastEvent, 'use ao.lastEvent instead of Event.last');
+const setEvent = util.deprecate(event => ao.lastEvent = event, 'use ao.lastEvent instead of Event.last');
+
 Object.defineProperty(Event, 'last', {
-  get () {
-    let last
-    try {
-      last = ao.requestStore.get('lastEvent')
-    } catch (e) {
-      log.error('Can not get cls.lastEvent. Context may be lost.')
-    }
-    return last
-  },
-  set (value) {
-    try {
-      ao.requestStore.set('lastEvent', value)
-    } catch (e) {
-      log.error('Lost context %e %s', value, e.stack.toString())
-    }
-  }
-})
+  get: getEvent,
+  set: setEvent,
+});
 
 /**
  * Set key-value pairs on this event
@@ -223,10 +212,10 @@ Event.prototype.sendReport = function (data) {
   // last event.
   if (!this.ignore) {
     log.event.enter('setting last event to: %e', this)
-    Event.last = this
+    ao.lastEvent = this
   }
 
-  // if not sampling return now that Event.last has been set (unless ignored).
+  // if not sampling return now that ao.lastEvent has been set (unless ignored).
   if (!this.event.getSampleFlag()) {
     log.event.enter('not sampling so not sending %e', this)
     return

--- a/lib/log-formatters.js
+++ b/lib/log-formatters.js
@@ -22,7 +22,7 @@ module.exports = function (d) {
 
   /**
    * Format an xtrace ID - could be a string or any object that
-   * can return metadata.
+   * contains an addon Event.
    */
   d.formatters.x = xid => (xid ? humanID(xid) : '<no xtrace>')
 

--- a/lib/probes/@hapi/hapi.js
+++ b/lib/probes/@hapi/hapi.js
@@ -81,7 +81,7 @@ function wrapPrepare (request) {
     return
   }
   shimmer.wrap(request, 'prepare', fn => function (response, callback) {
-    const last = Span.last
+    const last = ao.lastSpan
     if (!last || !conf.enabled) {
       return fn.call(this, response, callback)
     }

--- a/lib/probes/@hapi/vision.js
+++ b/lib/probes/@hapi/vision.js
@@ -40,7 +40,7 @@ module.exports = function (vision, options) {
       }
       const args = Array.from(arguments)
       args[2] = function wrappedHandler (template, context, options) {
-        const last = ao.Span.last
+        const last = ao.lastSpan;
         // if not enabled when the handler is called just call the original
         if (!last || !conf.enabled) {
           return handler.apply(this, arguments)

--- a/lib/probes/cassandra-driver.js
+++ b/lib/probes/cassandra-driver.js
@@ -102,7 +102,7 @@ function patchSendOnConnection (where, sendName, connName) {
     return
   }
   shimmer.wrap(where, sendName, method => function () {
-    const last = Span.last
+    const last = ao.lastSpan
     if (last && conf.enabled && this[connName]) {
       const {address, port} = this[connName]
       last.info({RemoteHost: `${address}:${port}`})

--- a/lib/probes/co-render.js
+++ b/lib/probes/co-render.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const ao = require('..')
-const Span = ao.Span
 const conf = ao.probes['co-render']
 
 module.exports = function (render) {
@@ -10,7 +9,7 @@ module.exports = function (render) {
 
     return function* () {
       // Check if there is a trace to continue
-      const last = Span.last
+      const last = ao.lastSpan;
       if (!last || !conf.enabled) {
         return yield ret
       }

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -6,8 +6,7 @@ const os = require('os')
 const semver = require('semver')
 
 const ao = require('..')
-const Span = ao.Span
-const Event = ao.Event
+const Span = ao.Span;
 
 const log = ao.loggers
 
@@ -41,7 +40,7 @@ function patchClient (module, options, protocol) {
   const wrapper = fn => function (...args) {
     // If no context just execute the fn with an unbound callback
     // else execute the function with a bound callback.
-    const last = Span.last
+    const last = ao.lastSpan;
     if (!last) {
       return fn(...args)
     }
@@ -355,9 +354,9 @@ function patchServer (module, options, protocol) {
     // if there is leftover context around log it. this appears to be because
     // a previous context has not received the destroy callback in the context
     // manager but until the issue is resolved debug output provides clues.
-    if (ao.Event.last) {
-      log.debug('http: ule %e', ao.Event.last);
-      res[ule] = ao.Event.last;
+    if (ao.lastEvent) {
+      log.debug('http: ule %e', ao.lastEvent);
+      res[ule] = ao.lastEvent;
     }
 
     // ao.requestStore.run(fn, {newContext: true}) forces a new context that doesn't
@@ -513,8 +512,8 @@ function patchServer (module, options, protocol) {
     // there shouldn't be any context here. cls.run() has been called to create
     // a new context. but don't log again if it's the same last-event as was seen
     // previously.
-    if (ao.Event.last && ao.Event.last !== res[ule]) {
-      log.debug('http.wrapRequestResponse: ule %e', ao.Event.last);
+    if (ao.lastEvent && ao.lastEvent !== res[ule]) {
+      log.debug('http.wrapRequestResponse: ule %e', ao.lastEvent);
     }
 
     // Ensure response is patched and add exit finalizer
@@ -523,9 +522,9 @@ function patchServer (module, options, protocol) {
     // use requestStore.bind() because there should be no context here and
     // there isn't a need to check whether the argument really is a function.
     ao.addResponseFinalizer(res, ao.requestStore.bind(() => {
-      const {last} = Event
+      const last = ao.lastEvent;
       if (last === res[ule]) {
-        log.debug('http.responseFinalizer: ule lingering - Event.last %e', last);
+        log.debug('http.responseFinalizer: ule lingering - ao.lastEvent %e', last);
       }
 
       if (last && last !== span.events.entry && !last.Async) {

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -259,14 +259,13 @@ function patchServer (module, options, protocol) {
 
     // if it is undefined make it a string
     let xtrace = req.headers['x-trace'] || ''
-
     // if there is an xtrace header see if it is good by trying
-    // to convert it to metadata.
+    // to convert it to an Event.
     if (xtrace) {
-      const md = ao.stringToMetadata(xtrace)
+      const ev = ao.xtraceToEvent(xtrace);
       // if it isn't a valid xtrace set it to an empty string so it won't be
       // used in getTraceSettings().
-      if (!md) {
+      if (!ev) {
         xtrace = ''
       }
     }

--- a/lib/probes/koa-resource-router.js
+++ b/lib/probes/koa-resource-router.js
@@ -38,7 +38,7 @@ function patch (route, Controller, Action) {
 function wrap (Controller, Action, fn) {
   return function* (next) {
     // Check if there is a trace to continue
-    const last = Span.last
+    const last = ao.lastSpan
     if (!last || !conf.enabled) {
       return yield fn.call(this, next)
     }

--- a/lib/probes/koa-route.js
+++ b/lib/probes/koa-route.js
@@ -32,7 +32,7 @@ module.exports = function (route) {
 
 function patchAsyncHandler (Controller, Action, route) {
   return function (ctx) {
-    const last = Span.last;
+    const last = ao.lastSpan;
     if (!last || !conf.enabled) {
       return route.call(this, ctx);
     }
@@ -56,7 +56,7 @@ function patchAsyncHandler (Controller, Action, route) {
 function patchGeneratorHandler (Controller, Action, route) {
   return function* (next) {
     // Check if there is a trace to continue
-    const last = Span.last
+    const last = ao.lastSpan
     if (!last || !conf.enabled) {
       return yield route.call(this, next)
     }

--- a/lib/probes/koa-router.js
+++ b/lib/probes/koa-router.js
@@ -81,7 +81,7 @@ function patchAsyncHandler (Controller, Action, route) {
   // must return a promise.
   return (ctx, next) => {
     // Check if there is a trace to continue
-    const last = Span.last
+    const last = ao.lastSpan
     if (!last || !conf.enabled) {
       return Promise.resolve(route.call(this, ctx, next))
     }
@@ -149,7 +149,7 @@ function patchGeneratorFunction (target, method) {
 function patchGeneratorHandler (Controller, Action, route) {
   return function* (next) {
     // Check if there is a trace to continue
-    const last = Span.last
+    const last = ao.lastSpan
     if (!last || !conf.enabled) {
       return yield route.call(this, next)
     }

--- a/lib/probes/koa.js
+++ b/lib/probes/koa.js
@@ -28,7 +28,7 @@ function wrapApp (app) {
       const handle = callback.call(this)
       return function (req, res) {
         // Check if there is a trace to continue
-        const last = Span.last
+        const last = ao.lastSpan
         if (!last || !conf.enabled) {
           return handle.call(this, req, res)
         }

--- a/lib/probes/memcached.js
+++ b/lib/probes/memcached.js
@@ -58,7 +58,7 @@ function runCommandSpan (ctx, desc) {
       data.KVKey = JSON.stringify(data.KVKey)
     }
 
-    const lastSpan = Span.last
+    const lastSpan = ao.lastSpan
 
     // Collect backtraces, if configured to do so
     if (conf.collectBacktraces && lastSpan.doSample) {

--- a/lib/probes/morgan.js
+++ b/lib/probes/morgan.js
@@ -38,7 +38,7 @@ module.exports = function (morgan) {
 // get the string to insert into the morgan log output
 //
 function getAutoTraceTokenString () {
-  const last = ao.Event.last;
+  const last = ao.lastEvent;
   const mode = ao.cfg.insertTraceIdsIntoMorgan;
   if ((!last && mode !== 'always') || !mode) {
     return '';

--- a/lib/probes/node-cassandra-cql.js
+++ b/lib/probes/node-cassandra-cql.js
@@ -56,7 +56,7 @@ function patchConnectionExecutors (proto, methods) {
   methods.forEach(method => {
     if (typeof proto[method] !== 'function') return
     shimmer.wrap(proto, method, fn => function (...args) {
-      const last = Span.last
+      const last = ao.lastSpan
       if (last) {
         const {host, port} = this.options
         last.info({RemoteHost: `${host}:${port}`})

--- a/lib/probes/zlib.js
+++ b/lib/probes/zlib.js
@@ -86,7 +86,7 @@ function wrapConstructor (proto, name) {
   }
   shimmer.wrap(proto, name, Real => {
     function WrappedZlib (options) {
-      const last = Span.last;
+      const last = ao.lastSpan;
       try {
         if (last && conf.enabled && !spans.get(this)) {
           const span = last.descend('zlib', makeKvPairs(name, options))

--- a/lib/span.js
+++ b/lib/span.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const asyncHooks = require('async_hooks');
+const util = require('util');
 const Event = require('./event')
 let ao;
 let log;
@@ -22,7 +22,7 @@ let dbSendError;
  * @param {object} [data] Key/Value pairs of info to add to event
  *
  * @example
- * var span = new Span('fs', Event.last, {
+ * var span = new Span('fs', ao.lastEvent, {
  *   File: file
  * })
  */
@@ -70,27 +70,13 @@ function Span (name, settings, data) {
  *
  * @property {Span} Span.last
  */
+const getSpan = util.deprecate(() => ao.lastSpan, 'use ao.lastSpan instead of Span.last');
+const setSpan = util.deprecate(span => ao.lastSpan = span, 'use ao.lastSpan instead of Span.last');
+
 Object.defineProperty(Span, 'last', {
-  get () {
-    let last
-    try {
-      last = ao.requestStore.get('lastSpan');
-    } catch (e) {
-      // avoid logging during node bootstrap phase. https://nodejs.org/api/async_hooks.html.
-      if (asyncHooks.executionAsyncId() !== 1) {
-        log.error('Cannot get cls.lastSpan. Context may be lost.');
-      }
-    }
-    return last
-  },
-  set (value) {
-    try {
-      ao.requestStore.set('lastSpan', value)
-    } catch (e) {
-      log.error('Can not set cls.lastSpan. Context may be lost.')
-    }
-  }
-})
+  get: getSpan,
+  set: setSpan,
+});
 
 /**
  * Create a new entry span. An entry span is the top span in a new trace in
@@ -147,8 +133,8 @@ Span.entrySpanExits = 0
  * })
  */
 Span.prototype.descend = function (name, data) {
-  const last = Event.last
-  log.span('span.descend %s from Event.last %e', name, last)
+  const last = ao.lastEvent
+  log.span('span.descend %s from ao.lastEvent %e', name, last)
 
   // if this trace is not sampled then avoid as much work as possible.
   if (!this.doSample) {
@@ -377,7 +363,7 @@ Span.prototype.enter = function (data) {
 
 
   try {
-    Span.last = this
+    ao.lastSpan = this
     const {entry} = this.events
 
     // Send the entry event
@@ -403,7 +389,7 @@ Span.prototype.exit = function (data) {
     const {exit} = this.events
 
     // Edge back to previous event, if not already connected
-    const {last} = Event
+    const last = ao.lastEvent
     if (last && last !== this.events.entry && !exit.ignore) {
       exit.edges.push(last)
     } else if (!last) {
@@ -461,7 +447,7 @@ Span.prototype.setExitError = function (error) {
  * @param {Object} data Key/Value pairs to add to event
  */
 Span.prototype._internal = function (label, data) {
-  const {last} = Event
+  const last = ao.lastEvent
   if (!last) {
     log.error(`${this.name} span ${label} call could not find last event`)
     return

--- a/lib/span.js
+++ b/lib/span.js
@@ -12,13 +12,13 @@ let dbSendError;
  * @class Span
  * @param {string} name Span name
  * @param {object} settings Settings returned from getTraceSettings()
- * @param {metadata} [settings.metadata] an addon.Metadata instance to create the events from.
+ * @param {Event} [settings.traceTaskId] an addon.Event instance to create the events from.
  *     Events will have the same task ID and sample bit but unique op IDs. This value is set
  *     by getTraceSettings() and must be present.
  * @param {boolean} [settings.edge=true] the entry event of this span should edge back to the
- *     metadata. The only time this is not true is when the span being created is a new top
- *     level span not being continued from an inbound X-Trace ID. This must be set explicitly
- *     to a falsey value; it's absence is true.
+ *     op id associated with settings.traceTaskId. The only time this is not true is when the
+ *     span being created is a new top level span not being continued from an inbound X-Trace
+ *     ID. This must be set explicitly to a falsey value; it's absence is true.
  * @param {object} [data] Key/Value pairs of info to add to event
  *
  * @example
@@ -46,7 +46,7 @@ function Span (name, settings, data) {
   // the sampling state needs to be in each span because it is used
   // to avoid expensive operations, e.g., collecting backtraces, when
   // not sampling.
-  this.doSample = settings.metadata.getSampleFlag()
+  this.doSample = settings.traceTaskId.getSampleFlag()
 
   // it is possible to ignore some errors. the only error that customers have
   // requested to be able to ignore is ENOENT because their application looks for
@@ -56,7 +56,7 @@ function Span (name, settings, data) {
 
   const edge = 'edge' in settings ? settings.edge : true
 
-  const entry = new Event(name, 'entry', settings.metadata, edge)
+  const entry = new Event(name, 'entry', settings.traceTaskId, edge)
   const exit = new Event(name, 'exit', entry.event, true)
 
   entry.set(data)
@@ -89,12 +89,12 @@ Object.defineProperty(Span, 'last', {
  * @param {object} kvpairs key/value pairs to be added to the entry event
  */
 Span.makeEntrySpan = function makeEntrySpan (name, settings, kvpairs) {
-  log.span('Span.makeEntrySpan %s from inbound %x', name, settings.metadata)
+  log.span('Span.makeEntrySpan %s from inbound %x', name, settings.traceTaskId)
 
-  // use the metadata from settings or make new (error getting settings or testing).
-  const metadata = settings.metadata || ao.addon.Event.makeRandom(settings.doSample)
+  // use the Event from settings or make new (error getting settings or testing).
+  const traceTaskId = settings.traceTaskId || ao.addon.Event.makeRandom(settings.doSample)
 
-  const span = new Span(name, {metadata, edge: settings.edge}, kvpairs)
+  const span = new Span(name, {traceTaskId, edge: settings.edge}, kvpairs)
 
   // fill in entry-span-specific properties.
   span.topSpan = true;
@@ -141,7 +141,7 @@ Span.prototype.descend = function (name, data) {
     let span;
     if (this.topSpan) {
       // if it is the topSpan then create a skeleton span
-      const skeletalSettings = {metadata: this.events.entry.event};
+      const skeletalSettings = {traceTaskId: this.events.entry.event};
       span = new Span('skeleton', skeletalSettings);
     } else {
       // if not the topSpan return the skeleton span again.
@@ -151,7 +151,7 @@ Span.prototype.descend = function (name, data) {
     return span;
   }
 
-  const span = new Span(name, {metadata: last.event}, data)
+  const span = new Span(name, {traceTaskId: last.event}, data)
 
   // fill in descended-span-specific properties.
   span.parent = this;

--- a/package.json
+++ b/package.json
@@ -106,6 +106,6 @@
     "ws": "^7.2.0"
   },
   "optionalDependencies": {
-    "appoptics-bindings": "^9.0.1"
+    "appoptics-bindings": "^10.0.0-alpha.4"
   }
 }

--- a/test.sh
+++ b/test.sh
@@ -157,8 +157,8 @@ fi
 
 # provide a summary of the test results.
 if [ ${#ERRORS[*]} -ne 0 ]; then
-    echo "$PASSED tests passed"
-    echo "${#ERRORS[*]} tests failed"
+    echo "$PASSED test suites passed"
+    echo "${#ERRORS[*]} test suites failed"
     for ix in ${!ERRORS[@]}
     do
         echo ${ERRORS[$ix]}
@@ -166,5 +166,5 @@ if [ ${#ERRORS[*]} -ne 0 ]; then
 
     exit 1
 else
-    echo "No errors - $PASSED tests passed"
+    echo "No errors - $PASSED test suites passed"
 fi

--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -81,7 +81,7 @@ describe('basics', function () {
     ao.serviceKey.should.be.a.String
   })
 
-  ifaob('should be able to check metadata\'s sample flag', function () {
+  ifaob('should be able to check an Event\'s sample flag', function () {
     const md0 = new ao.addon.Event.makeRandom()
     const md1 = new ao.addon.Event.makeRandom(1)
 

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -394,7 +394,7 @@ describe('custom', function () {
 
       function makeInner (data, done) {
         const name = 'inner-' + data.Index
-        const span = Span.last.descend(name)
+        const span = ao.lastSpan.descend(name)
         inner.push(span)
         span.run(function (wrap) {
           const delayed = wrap(done)
@@ -405,7 +405,7 @@ describe('custom', function () {
         })
       }
 
-      outer = Span.last.descend('link-test')
+      outer = ao.lastSpan.descend('link-test')
       outer.run(function () {
         const cb = after(2, done)
         makeInner({
@@ -781,7 +781,7 @@ describe('custom', function () {
       'x-previous',                 // span name
       function (pcb) {              // runner function, creates a new span
         ao.startOrContinueTrace(
-          Span.last.events.entry.toString(),    // continue from the last span's id.
+          ao.lastSpan.events.entry.toString(),    // continue from the last span's id.
           () => {
             return {
               name: main,
@@ -914,7 +914,7 @@ describe('custom', function () {
       return makeSettings({source: 0, rate: 0})
     }
 
-    // because a span is created and entered then Span.last & Event.last
+    // because a span is created and entered then ao.lastSpan & ao.lastEvent
     // are cleared ao.startOrContinueTrace creates a new context, so the
     // next two errors should be generated.
     const logChecks = [
@@ -926,7 +926,7 @@ describe('custom', function () {
     helper.test(
       emitter,
       function (done) {             // test function
-        Span.last = Event.last = null
+        ao.lastSpan = ao.lastEvent = null
         ao.startOrContinueTrace(null, 'sample-properly', setImmediate, conf, done)
       },
       [],                           // checks

--- a/test/helper.js
+++ b/test/helper.js
@@ -569,6 +569,6 @@ exports.makeSettings = function (settings) {
   }
 
   Object.assign(s, settings);
-  s.metadata = ao.addon.Event.makeRandom(s.doSample);
+  s.traceTaskId = s.metadata = ao.addon.Event.makeRandom(s.doSample);
   return s;
 }

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -178,7 +178,7 @@ describe('logging', function () {
     let [called, level, text, formatted] = getter() // eslint-disable-line no-unused-vars
     expect(called).equal(true)
     expect(level).equal('appoptics:error')
-    expect(formatted, 'metadata').equal(`xtrace ${md.toString(1)}`);
+    expect(formatted, '%x formatted').equal(`xtrace ${md.toString(1)}`);
 
     [logger, getter] = makeLogHandler()
     debug.log = logger

--- a/test/no-addon/custom.test.js
+++ b/test/no-addon/custom.test.js
@@ -130,8 +130,8 @@ describe('custom (without native bindings present)', function () {
     assert(ao.readyToSample() === false);
     assert(ao.getTraceSettings().doSample === false);
     assert(ao.sampling() === false);
-    assert(ao.stringToMetadata('') === undefined);
-    assert(ao.stringToMetadata(xtrace) instanceof aob.Event);
+    assert(ao.xtraceToEvent('') === undefined);
+    assert(ao.xtraceToEvent(xtrace) instanceof aob.Event);
     assert(ao.patchResponse('x') === undefined);
     assert(ao.addResponseFinalizer('x') === undefined);
     assert(ao.traceId === undefined);

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -406,8 +406,8 @@ describe(`probes.${p}`, function () {
     // Verify query param filtering support
     //
     it('should support query param filtering', function (done) {
-      if (ao.Event.last) {
-        ao.loggers.debug(`${p}.test: before creating server lastEvent = %e`, ao.Event.last);
+      if (ao.lastEvent) {
+        ao.loggers.debug(`${p}.test: before creating server lastEvent = %e`, ao.lastEvent);
       }
 
       conf.includeRemoteUrlParams = false

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -198,8 +198,8 @@ describe(`probes.${p}`, function () {
         res.end('done')
       })
 
-      const md = addon.Event.makeRandom(1);
-      const origin = new ao.Event('span-name', 'label-name', md)
+      const ev = addon.Event.makeRandom(1);
+      const origin = new ao.Event('span-name', 'label-name', ev);
 
       helper.doChecks(emitter, [
         function (msg) {

--- a/test/probes/http-trigger-trace.test.js
+++ b/test/probes/http-trigger-trace.test.js
@@ -265,7 +265,7 @@ function wrapGTS () {
     settings.doSample = false;
     settings.doMetrics = false;
     // the event that getTraceSettings returned isn't important.
-    settings.metadata = aob.Event.makeRandom(0);
+    settings.traceTaskId = aob.Event.makeRandom(0);
     return settings;
   }
 }

--- a/test/probes/morgan.test.js
+++ b/test/probes/morgan.test.js
@@ -341,13 +341,13 @@ describe(`probes.morgan ${version}`, function () {
   it('mode=\'always\' should always insert a trace ID even if not tracing', function (done) {
     ao.requestStore.run(function () {
       const traceId = getTraceIdString();
-      ao.Event.last = undefined;
+      ao.lastEvent = undefined;
 
       ao.cfg.insertTraceIdsIntoMorgan = 'always';
       logger = makeLogger();
       ao.traceMode = 0;
       ao.sampleRate = 0;
-      //console.log(ao.Event.last);
+      //console.log(ao.lastEvent);
 
       logger(fakeReq, fakeRes, function (err) {
         expect(err).not.ok;

--- a/test/span.test.js
+++ b/test/span.test.js
@@ -158,7 +158,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan('outer', makeSettings(), outerData);
 
     outer.run(function () {
-      inner = Span.last.descend('inner', innerData)
+      inner = ao.lastSpan.descend('inner', innerData)
       inner.run(function () {})
     })
   })
@@ -195,7 +195,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan('outer', makeSettings(), outerData);
 
     outer.run(function () {
-      inner = Span.last.descend('inner', innerData);
+      inner = ao.lastSpan.descend('inner', innerData);
       inner.run(function (wrap) {
         const delayed = wrap(function (err, res) {
           expect(err).not.exist;
@@ -246,7 +246,7 @@ describe('span', function () {
         expect(res).exist;
         expect(res).equal('foo');
 
-        inner = Span.last.descend('inner', innerData)
+        inner = ao.lastSpan.descend('inner', innerData)
         inner.run(function () {});
       })
 
@@ -338,7 +338,7 @@ describe('span', function () {
     const getResults = setupMockEventSending(sequencing, {verbose: false});
 
     outer.run(function () {
-      inner = Span.last.descend('inner');
+      inner = ao.lastSpan.descend('inner');
       inner.run(function () {});
     });
 
@@ -401,7 +401,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan(name, settings);
 
     outer.run(function () {
-      inner = Span.last.descend('inner');
+      inner = ao.lastSpan.descend('inner');
       inner.run(function () {});
     });
 
@@ -430,7 +430,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan(name, settings);
 
     outer.run(function () {
-      inner = Span.last.descend('inner');
+      inner = ao.lastSpan.descend('inner');
       inner.run(function (wrap) {
         const delayed = wrap(function (err, res) {
           expect(err).not.exist;
@@ -472,7 +472,7 @@ describe('span', function () {
         expect(err).not.exist;
         expect(res).equal('foo');
 
-        inner = Span.last.descend('inner')
+        inner = ao.lastSpan.descend('inner')
         inner.run(function () {});
 
         const {sendReportCalls, sendCalls, errors} = getResults();
@@ -569,7 +569,7 @@ describe('span', function () {
           return;
         }
 
-        const span = Span.last.descend(`inner-${depth}`);
+        const span = ao.lastSpan.descend(`inner-${depth}`);
         span.run(asyncDigDeeper);
       });
 
@@ -665,7 +665,7 @@ describe('span', function () {
           return;
         }
 
-        const span = Span.last.descend(`inner-${depth}`);
+        const span = ao.lastSpan.descend(`inner-${depth}`);
         alternatingRunner(span);
       });
 
@@ -678,7 +678,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan(name, settings);
 
     outer.run(function (wrapper) {
-      const span = Span.last.descend(`inner-${depth}`);
+      const span = ao.lastSpan.descend(`inner-${depth}`);
       span.run(asyncDigDeeper);
       const outerAsyncWrapped = wrapper(function (err, res) {
         expect(err).not.exist;


### PR DESCRIPTION
- Event.last => ao.lastEvent
- Span.last => ao.lastSpan

the base of this branch is `p9p-noti+minimal`; to minimize conflicts this should be reviewed and merged only *after* PR 117 has been merged. there will be 20 files changed after that. other than the deprecation code itself, all the changes are to replace `last = Event.last` and `{last} = Event` with `last = ao.lastEvent`, and analogous changes for `Span.last`