### PR TITLE
lib/probes: use info.version

### DIFF
--- a/lib/probes/bunyan.js
+++ b/lib/probes/bunyan.js
@@ -2,7 +2,6 @@
 
 const ao = require('..');
 
-const requirePatch = require('../require-patch');
 const shimmer = require('ximmer');
 const semver = require('semver');
 
@@ -15,22 +14,12 @@ function patchEmit (_emit) {
   }
 }
 
-module.exports = function (bunyan) {
+module.exports = function (bunyan, info) {
   if (!ao.probes.bunyan.enabled) {
     return bunyan;
   }
 
-  requirePatch.disable();
-  let pkg;
-  try {
-    pkg = requirePatch.relativeRequire('bunyan/package.json');
-  } catch (e) {
-    pkg = {version: '0.0.0'};
-    logMissing('prerequisites', e);
-  }
-  requirePatch.enable();
-
-  if (semver.gte(pkg.version, '1.0.0')) {
+  if (semver.gte(info.version, '1.0.0')) {
     if (typeof bunyan.prototype._emit === 'function') {
       shimmer.wrap(bunyan.prototype, '_emit', patchEmit);
     } else {

--- a/lib/probes/generic-pool.js
+++ b/lib/probes/generic-pool.js
@@ -4,16 +4,14 @@ const shimmer = require('ximmer')
 const ao = require('..')
 const log = ao.loggers
 
-const requirePatch = require('../require-patch')
 const semver = require('semver')
-const clientVersion = requirePatch.relativeRequire('generic-pool/package').version
-const majorVersion = semver.major(clientVersion)
 const nodeVersion = semver.major(process.version)
 
 const logMissing = ao.makeLogMissing('generic-pool')
 
-
-module.exports = function (gp) {
+module.exports = function (gp, info) {
+  const version = info.version;
+  const majorVersion = semver.major(version);
   if (majorVersion >= 3 && nodeVersion >= 8) {
     // version 3 is a major overhaul. only patch it if running node version 8.
     // https://github.com/coopernurse/node-pool/blob/master/CHANGELOG.md
@@ -31,7 +29,7 @@ module.exports = function (gp) {
       patchPool2(gp)
     }
   } else {
-    log.patching('generic-pool - not patching version ' + clientVersion)
+    log.patching(`generic-pool - not patching version ${version}`);
   }
 
   return gp

--- a/lib/probes/koa-route.js
+++ b/lib/probes/koa-route.js
@@ -5,18 +5,14 @@ const methods = require('methods')
 const semver = require('semver')
 
 const ao = require('../')
-const requirePatch = require('../require-patch')
 const utility = require('../utility')
 
-const Span = ao.Span
 const conf = ao.probes['koa-route']
 
-const {version} = requirePatch.relativeRequire('koa-route/package.json')
-
-module.exports = function (route) {
+module.exports = function (route, info) {
 
   let patcher;
-  if (semver.gte(version, '3.0.0')) {
+  if (semver.gte(info.version, '3.0.0')) {
     patcher = patchAsyncHandler;
   } else {
     patcher = patchGeneratorHandler;

--- a/lib/probes/koa-router.js
+++ b/lib/probes/koa-router.js
@@ -6,17 +6,13 @@ const semver = require('semver')
 
 const utility = require('../utility')
 const ao = require('../')
-const requirePatch = require('../require-patch')
-const Span = ao.Span
 const conf = ao.probes['koa-router']
-
-const {version} = requirePatch.relativeRequire('koa-router/package.json')
 
 const logMissing = ao.makeLogMissing('koa-router')
 
-module.exports = function (_router) {
+module.exports = function (_router, info) {
 
-  if (semver.gte(version, '6.0.0')) {
+  if (semver.gte(info.version, '6.0.0')) {
     // allow the caller to invoke this with or without "new" by not using
     // an arrow function.
     return function () {
@@ -29,7 +25,7 @@ module.exports = function (_router) {
     }
   }
 
-  const v5 = semver.gte(version, '5.0.0')
+  const v5 = semver.gte(info.version, '5.0.0')
 
   // version 5 and below
   return function (app) {

--- a/lib/probes/mongoose.js
+++ b/lib/probes/mongoose.js
@@ -99,6 +99,9 @@ function patchExec (proto) {
     return
   }
   shimmer.wrap(proto, 'exec', fn => function (op, cb) {
+    // todo-api:82 => mongoose/model:2050 => mongoose/query:1996 => ao/mongoose:106
+    // 'op' is callback and cb is undefined. if 2 args op is 'find', etc.
+    // eventually gets down to node_modules/mquery/lib/collection/nodejs
     return fn.call(this, ao.bind(op), ao.bind(cb))
   })
 }

--- a/lib/probes/mysql.js
+++ b/lib/probes/mysql.js
@@ -9,12 +9,11 @@ const conf = ao.probes.mysql
 
 function noop () {}
 
-module.exports = function (mysql) {
+module.exports = function (mysql, info) {
   try {
-    const pkg = requirePatch.relativeRequire('mysql/package.json')
 
     // Things got more complicated in 2.x.x
-    if (semver.satisfies(pkg.version, '>= 2.0.0')) {
+    if (semver.satisfies(info.version, '>= 2.0.0')) {
       const Query = requirePatch.relativeRequire(
         'mysql/lib/protocol/sequences/Query'
       )
@@ -37,7 +36,7 @@ module.exports = function (mysql) {
         if (proto) patchPool(proto)
       }
     } else {
-      const Query = semver.satisfies(pkg.version, '>= 0.9.2')
+      const Query = semver.satisfies(info.version, '>= 0.9.2')
         ? requirePatch.relativeRequire('mysql/lib/query')
         : requirePatch.relativeRequire('mysql/lib/mysql/query')
 

--- a/lib/probes/node-cassandra-cql.js
+++ b/lib/probes/node-cassandra-cql.js
@@ -1,18 +1,15 @@
 'use strict'
 
-const requirePatch = require('../require-patch')
 const shimmer = require('ximmer')
 const semver = require('semver')
-const Span = require('../span')
 const ao = require('..')
 const Sanitizer = ao.addon.Sanitizer
 const conf = ao.probes['node-cassandra-cql']
 
-module.exports = function (cassandra) {
+const logMissing = ao.makeLogMissing('cassandra')
+
+module.exports = function (cassandra, info) {
   try {
-    const {version} = requirePatch.relativeRequire(
-      'node-cassandra-cql/package.json'
-    )
 
     // Create reversed map of consistencies back to their names
     const types = cassandra.types
@@ -27,16 +24,24 @@ module.exports = function (cassandra) {
     // Patch Connection
     {
       const proto = cassandra.Connection && cassandra.Connection.prototype
-      if (proto) patchConnection(proto)
+      if (proto) {
+        patchConnection(proto);
+      } else {
+        logMissing('Connection.prototype');
+      }
     }
 
     // Patch Client
     {
       const proto = cassandra.Client && cassandra.Client.prototype
-      if (proto) patchClient(proto, version, consistencies)
+      if (proto) {
+        patchClient(proto, info.version, consistencies);
+      } else {
+        logMissing('Client.prototype');
+      }
     }
   } catch (e) {
-    console.error(e.stack)
+    ao.loggers.patching('failed to patch cassandra', e.stack);
   }
 
   return cassandra
@@ -44,7 +49,10 @@ module.exports = function (cassandra) {
 
 function passthrough (proto, methods) {
   methods.forEach(method => {
-    if (typeof proto[method] !== 'function') return
+    if (typeof proto[method] !== 'function') {
+      logMissing(`Connection.prototype.${method}`);
+      return;
+    }
     shimmer.wrap(proto, method, fn => function (...args) {
       if (args.length) args.push(ao.bind(args.pop()))
       return fn.apply(this, args)
@@ -54,7 +62,10 @@ function passthrough (proto, methods) {
 
 function patchConnectionExecutors (proto, methods) {
   methods.forEach(method => {
-    if (typeof proto[method] !== 'function') return
+    if (typeof proto[method] !== 'function') {
+      logMissing(`Connection.prototype.${method}`);
+      return;
+    }
     shimmer.wrap(proto, method, fn => function (...args) {
       const last = ao.lastSpan
       if (last) {
@@ -82,7 +93,10 @@ function patchConnection (proto) {
 
 function patchClientExecutors (proto, methods, consistencies) {
   methods.forEach(method => {
-    if (typeof proto[method] !== 'function') return
+    if (typeof proto[method] !== 'function') {
+      logMissing(`Client.prototype.${method}`);
+      return;
+    }
     shimmer.wrap(proto, method, fn => function (...args) {
       const cb = args.pop()
       const [query, params = [], consistency] = args

--- a/lib/probes/pg.js
+++ b/lib/probes/pg.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const requirePatch = require('../require-patch')
 const shimmer = require('ximmer')
 const semver = require('semver')
 const ao = require('..')
@@ -9,29 +8,27 @@ const conf = ao.probes.pg
 
 const logMissing = ao.makeLogMissing('pg')
 
-const {version} = requirePatch.relativeRequire('pg/package.json')
-
-module.exports = function (postgres) {
+module.exports = function (postgres, info) {
   //
   // Patch postgres, but only patch the native driver when available
   //
-  if (!version) {
+  if (!info.version) {
     logMissing('pg version')
     return postgres
   }
 
   if (process.env.NODE_PG_FORCE_NATIVE) {
-    patchNative(postgres)
+    patchNative(postgres, info.version)
   } else {
-    if (semver.gte(version, '7.0.0')) {
-      patchPool(postgres)
+    if (semver.gte(info.version, '7.0.0')) {
+      patchPool(postgres, info.version)
     }
 
     const proto = postgres.Client && postgres.Client.prototype
     if (proto) {
-      patchClient(proto)
+      patchClient(proto, info.version);
     } else {
-      logMissing('Client.prototype')
+      logMissing('Client.prototype');
     }
 
     const origGetter = postgres.__lookupGetter__('native')
@@ -48,19 +45,19 @@ module.exports = function (postgres) {
 
 // Yes, this is really necessary. Before 4.x, pg used a builder function
 // to construct a client rather than exposing the constructor directly.
-function patchNative (pg) {
+function patchNative (pg, version) {
   if (semver.satisfies(version, '>= 4.0.0')) {
     const proto = pg.Client && pg.Client.prototype
     if (proto) {
-      patchClient(proto)
+      patchClient(proto, version);
     } else {
-      logMissing('Client.prototype')
+      logMissing('Client.prototype');
     }
 
   } else if (typeof pg.Client === 'function') {
     shimmer.wrap(pg, 'Client', fn => function () {
       const client = fn.apply(this, arguments)
-      patchClient(client.constructor.prototype)
+      patchClient(client.constructor.prototype, version);
       return client
     })
   } else {
@@ -72,7 +69,7 @@ function patchNative (pg) {
 // wrap the pool constructor so the connect function of each pool
 // created can be wrapped.
 //
-function patchPool (postgres) {
+function patchPool (postgres, version) {
   if (typeof postgres.Pool !== 'function') {
     logMissing('Pool()')
     return
@@ -97,7 +94,7 @@ function patchPool (postgres) {
 
 
 // Enable context passthrough for Client::connect
-function patchClientConnect (client) {
+function patchClientConnect (client, version) {
   if (typeof client.connect !== 'function') {
     logMissing('client.connect()')
     return
@@ -117,7 +114,7 @@ function patchClientConnect (client) {
   })
 }
 
-function patchClientQuery (client) {
+function patchClientQuery (client, version) {
   if (typeof client.query !== 'function') {
     logMissing('client.query()')
     return
@@ -209,9 +206,9 @@ function patchClientQuery (client) {
   })
 }
 
-function patchClient (client) {
-  patchClientConnect(client)
-  patchClientQuery(client)
+function patchClient (client, version) {
+  patchClientConnect(client, version);
+  patchClientQuery(client, version);
 }
 
 //

--- a/lib/probes/pino.js
+++ b/lib/probes/pino.js
@@ -2,7 +2,6 @@
 
 const ao = require('..');
 
-const requirePatch = require('../require-patch');
 const shimmer = require('ximmer');
 const semver = require('semver');
 
@@ -16,24 +15,14 @@ function patchWrite (write) {
   }
 }
 
-module.exports = function (pino) {
+module.exports = function (pino, info) {
   if (!ao.probes.pino.enabled) {
     return pino;
   }
 
-  requirePatch.disable();
-  let pkg;
-  try {
-    pkg = requirePatch.relativeRequire('pino/package.json');
-  } catch (e) {
-    pkg = {version: '0.0.0'};
-    logMissing('prerequisites', e);
-  }
-  requirePatch.enable();
-
   // sequence through the versions, starting at the highest.
   // version 5 recognized that packages like this need to access internals
-  if (semver.gte(pkg.version, '5.0.0')) {
+  if (semver.gte(info.version, '5.0.0')) {
     const proto = Object.getPrototypeOf(pino());
     if (typeof proto[pino.symbols.writeSym] === 'function') {
       shimmer.wrap(proto, pino.symbols.writeSym, patchWrite);
@@ -42,7 +31,7 @@ module.exports = function (pino) {
     }
 
   // version 4 was locked down tight requiring this ugly solution
-  } else if (semver.gte(pkg.version, '4.0.0')) {
+  } else if (semver.gte(info.version, '4.0.0')) {
     const loggerProxy = {
       get (logger, prop) {
         if (prop !== 'write') {
@@ -63,7 +52,7 @@ module.exports = function (pino) {
     pino = new Proxy(pino, pinoProxy);
 
   // versions 3 and 2 are just a bit different
-  } else if (semver.gte(pkg.version, '2.0.0')) {
+  } else if (semver.gte(info.version, '2.0.0')) {
     const proto = Object.getPrototypeOf(pino());
     if (typeof proto.asJson === 'function') {
       shimmer.wrap(proto, 'asJson', patchWrite);

--- a/lib/probes/raw-body.js
+++ b/lib/probes/raw-body.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const requirePatch = require('../require-patch')
 const semver = require('semver')
 const ao = require('..')
 const conf = ao.probes['raw-body']
@@ -64,10 +63,9 @@ function thunker (fn) {
   }
 }
 
-module.exports = function (fn) {
+module.exports = function (fn, info) {
   try {
-    const {version} = requirePatch.relativeRequire('raw-body/package.json')
-    return semver.satisfies(version, '< 2') ? thunker(fn) : promiser(fn)
+    return semver.satisfies(info.version, '< 2') ? thunker(fn) : promiser(fn);
   } catch (e) {
     return fn
   }

--- a/lib/probes/winston.js
+++ b/lib/probes/winston.js
@@ -49,19 +49,16 @@ function patchLog (log) {
 // winston's logger module. but patching logger is triggered by winston being
 // required.
 //
-module.exports = function (winston) {
+module.exports = function (winston, info) {
   if (!ao.probes.winston.enabled) {
     return winston;
   }
 
   requirePatch.disable();
-  let pkg;
   let target;
   try {
-    pkg = requirePatch.relativeRequire('winston/package.json');
     target = requirePatch.relativeRequire('winston/lib/winston/logger.js');
   } catch (e) {
-    pkg = {version: '0.0.0'};
     logMissing('winston prerequisites', e);
   }
   requirePatch.enable();
@@ -70,13 +67,13 @@ module.exports = function (winston) {
     return winston;
   }
 
-  if (semver.gte(pkg.version, '3.0.0')) {
+  if (semver.gte(info.version, '3.0.0')) {
     if (typeof target.prototype.write === 'function') {
       shimmer.wrap(target.prototype, 'write', patchWrite);
     } else {
       logMissing('Logger.prototype.write()');
     }
-  } else if (semver.gte(pkg.version, '1.0.0') && semver.lt(pkg.version, '3.0.0')) {
+  } else if (semver.gte(info.version, '1.0.0') && semver.lt(info.version, '3.0.0')) {
     if (typeof target.Logger.prototype.log === 'function') {
       shimmer.wrap(target.Logger.prototype, 'log', patchLog);
     } else {

--- a/lib/probes/winston.js
+++ b/lib/probes/winston.js
@@ -73,7 +73,7 @@ module.exports = function (winston, info) {
     } else {
       logMissing('Logger.prototype.write()');
     }
-  } else if (semver.gte(info.version, '1.0.0') && semver.lt(info.version, '3.0.0')) {
+  } else if (semver.gte(info.version, '1.0.0')) {
     if (typeof target.Logger.prototype.log === 'function') {
       shimmer.wrap(target.Logger.prototype, 'log', patchLog);
     } else {


### PR DESCRIPTION
require-patch fetches the version; remove version fetches from probes.
- bunyan
- generic-pool
- koa-route
- koa-router
- mongoose
- mysql
- cassandra-driver
- pg
- pino
- raw-body
- winston