### PR TITLE
8.1.0 ClientIP fix

### DIFF
--- a/appoptics-apm.json
+++ b/appoptics-apm.json
@@ -10,6 +10,12 @@
             "ENOENT": true
           }
         }
+      },
+      "http": {
+        "client-ip-header": ""
+      },
+      "https": {
+        "client-ip-header": ""
       }
     }
 }

--- a/lib/probe-defaults.js
+++ b/lib/probe-defaults.js
@@ -30,12 +30,14 @@ module.exports = {
 
   http: {
     enabled: true,
-    includeRemoteUrlParams: true
+    includeRemoteUrlParams: true,
+    'client-ip-header': undefined,        // when behind nginx remote_addr is nginx
   },
 
   https: {
     enabled: true,
-    includeRemoteUrlParams: true
+    includeRemoteUrlParams: true,
+    'client-ip-header': undefined,        // when behind nginx remote_addr is nginx
   },
 
   'http-client': {

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -365,12 +365,12 @@ function patchServer (module, options, protocol) {
     ao.requestStore.run(() => {
       try {
         // Bind streams to the request store now that there is a context.
-        ao.bindEmitter(req)
-        ao.bindEmitter(res)
+        ao.bindEmitter(req);
+        ao.bindEmitter(res);
 
         const kvpairs = {
           'Spec': 'ws',
-          'ClientIP': req.socket.remoteAddress,
+          'ClientIP': getClientIP(req, conf),
           'HTTP-Host': getHost(req),
           'Port': getPort(req),
           'Method': req.method,
@@ -454,6 +454,18 @@ function patchServer (module, options, protocol) {
 
     return ret
   })
+
+  function getClientIP (req, conf) {
+    let ClientIP = req.socket.remoteAddress;
+
+    if (conf['client-ip-header'] && req.headers[conf['client-ip-header']]) {
+      ClientIP = req.headers[conf['client-ip-header']];
+    }
+    // KV set logs an error if undefined.
+    if (!ClientIP) ClientIP = '';
+
+    return ClientIP;
+  }
 
   function getHost (req) {
     return (req.headers.host || os.hostname()).split(':')[0]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -509,7 +509,32 @@ describe(`probes.${p}`, function () {
         }
         request(options);
       });
-    })
+    });
+
+    it('should set ClientIP when req[\'client-ip-header\'] is undefined', function (done) {
+      const server = createServer(options, function (req, res) {
+        res.end('done');
+      });
+
+      helper.doChecks(emitter, [
+        function (msg) {
+          check.server.entry(msg);
+        },
+        function (msg) {
+          check.server.exit(msg);
+        }
+      ], function () {
+        server.close(done);
+      });
+
+      server.listen(function () {
+        const port = server.address().port;
+        const options = {
+          url: `${p}://localhost:${port}`,
+        };
+        request(options);
+      });
+    });
 
     //
     // Test errors emitted on http request object

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -481,6 +481,36 @@ describe(`probes.${p}`, function () {
       })
     })
 
+    it('should map a specific header to ClientIP when specified', function (done) {
+      const server = createServer(options, function (req, res) {
+        res.end('done');
+      });
+
+      ao.probes[p]['client-ip-header'] = 'x-real-ip';
+      const ClientIPExpected = '777.777.333.333';
+
+      helper.doChecks(emitter, [
+        function (msg) {
+          check.server.entry(msg);
+          expect(msg).property('ClientIP', ClientIPExpected);
+        },
+        function (msg) {
+          check.server.exit(msg);
+        }
+      ], function () {
+        server.close(done);
+      });
+
+      server.listen(function () {
+        const port = server.address().port;
+        const options = {
+          url: `${p}://localhost:${port}`,
+          headers: {'x-real-ip': ClientIPExpected}
+        }
+        request(options);
+      });
+    })
+
     //
     // Test errors emitted on http request object
     //

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -518,6 +518,7 @@ describe(`probes.${p}`, function () {
 
       helper.doChecks(emitter, [
         function (msg) {
+          // this checks that ClientIP is set.
           check.server.entry(msg);
         },
         function (msg) {


### PR DESCRIPTION
- http server behind nginx ClientIP is missing/not useful
- add configuration option to specify remote address header
- set ClientIP to '' when ClientIP is undefined so Event.set() doesn't log error.