### PR TITLE
additional lambda changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,12 +157,15 @@ Features
 Bug fix
 - don't log an error when `req.socket.remoteAddress` is undefined.
 
-### vNext
+### v9.0.0
 
 Features
 - lambda support
 - enable all logging to be suppressed via APPOPTICS_LOG_SETTINGS=''
 - capture agent version in init message
+
+Breaking change
+- removed `ao.serviceKey` property.
 
 Bug fix
 - change config file name `appoptics-apm.{js|json}` => `appoptics-apm-config.{js|json}`

--- a/LICENSE
+++ b/LICENSE
@@ -1,193 +1,109 @@
-Librato Open License
-Version 1.0, October, 2016
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by
+Sections 1 through 9 of this document.
 
-"License" shall mean the terms and conditions for use, reproduction, and
-distribution as defined by Sections 1 through 11 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting
+the License.
 
-"Licensor" shall mean the copyright owner or entity authorized by the copyright
-owner that is granting the License.  Licensor can include Librato as an
-original contributor to the Work as defined below.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are
+controlled by, or are under common control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding
+shares, or (iii) beneficial ownership of such entity.
 
-"Legal Entity" shall mean the union of the acting entity and all other entities
-that control, are controlled by, or are under common control with that entity.
-For the purposes of this definition, "control" means (i) the power, direct or
-indirect, to cause the direction or management of such entity, whether by
-contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
 
-"You" (or "Your") shall mean an individual or Legal Entity exercising
-permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software
+source code, documentation source, and configuration files.
 
-"Source" form shall mean the preferred form for making modifications, including
-but not limited to software source code, documentation source, and
-configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form,
+including but not limited to compiled object code, generated documentation, and conversions to other media types.
 
-"Object" form shall mean any form resulting from mechanical transformation or
-translation of a Source form, including but not limited to compiled object
-code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as
+indicated by a copyright notice that is included in or attached to the work (an example is provided in the
+Appendix below).
 
-"Work" shall mean the work of authorship, whether in Source or Object form,
-made available under the License, as indicated by a copyright notice that is
-included in or attached to the work.
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the
+Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole,
+an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
 
-"Derivative Works" shall mean any work, whether in Source or Object form, that
-is based on (or derived from) the Work and for which the editorial revisions,
-annotations, elaborations, or other modifications represent, as a whole, an
-original work of authorship. For the purposes of this License, Derivative Works
-shall not include works that remain separable from, or merely link (or bind by
-name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or
+additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the
+purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor
+or its representatives, including but not limited to communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as
+"Not a Contribution."
 
-"Contribution" shall mean any work of authorship, including the original
-version of the Work and any modifications or additions to that Work or
-Derivative Works thereof, that is intentionally submitted to Licensor for
-inclusion in the Work by the copyright owner or by an individual or Legal
-Entity authorized to submit on behalf of the copyright owner. For the purposes
-of this definition, "submitted" means any form of electronic, verbal, or
-written communication sent to the Licensor or its representatives, including
-but not limited to communication on electronic mailing lists, source code
-control systems, and issue tracking systems that are managed by, or on behalf
-of, the Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise designated in
-writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by
+Licensor and subsequently incorporated within the Work.
 
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
-of whom a Contribution has been received by Licensor and subsequently
-incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You
+a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare
+Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in
+Source or Object form.
 
-2. Grant of Copyright License.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to
+those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by
+combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent
+litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution
+incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You
+under this License for that Work shall terminate as of the date such litigation is filed.
 
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the Work and
-such Derivative Works in Source or Object form.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or
+without modifications, and in Source or Object form, provided that You meet the following conditions:
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative
+Works; and
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain
+to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display
+generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are
+for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works
+that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices
+cannot be construed as modifying the License.
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
 
-3. Grant of Patent License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the
+Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
 
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable (except as stated in this section) patent license to make, have
-made, use, offer to sell, sell, import, and otherwise transfer the Work, where
-such license applies only to those patent claims licensable by such Contributor
-that are necessarily infringed by their Contribution(s) alone or by combination
-of their Contribution(s) with the Work to which such Contribution(s) was
-submitted. If You institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work or a
-Contribution incorporated within the Work constitutes direct or contributory
-patent infringement, then any patent licenses granted to You under this License
-for that Work shall terminate as of the date such litigation is filed.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
 
-Each time You convey a covered Work, the recipient automatically receives a
-license from the original Licensor(s), to run, modify and propagate that work,
-subject to this License. You are not responsible for enforcing compliance by
-third parties with this License.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor
+provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You
+are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your
+exercise of permissions under this License.
 
-You may not impose any further restrictions on the exercise of the rights
-granted or affirmed under this License. For example, you may not impose a
-license fee, royalty, or other charge for exercise of rights granted under this
-License, and you may not initiate litigation (including a cross-claim or
-counterclaim in a lawsuit) alleging that any patent claim is infringed by
-making, using, selling, offering for sale, or importing the Work or any portion
-of it.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as
+a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been
+advised of the possibility of such damages.
 
-4. Redistribution.
-
-You may reproduce and distribute copies of the Work or Derivative Works thereof
-in any medium, with or without modifications, and in Source or Object form,
-provided that You meet the following conditions:
-
-  1. You must give any other recipients of the Work or Derivative Works a copy
-of this License; and
-  2. You must cause any modified files to carry prominent notices stating that
-You changed the files; and
-  3. You must retain, in the Source form of any Derivative Works that You
-distribute, all copyright, patent, trademark, and attribution notices from the
-Source form of the Work, excluding those notices that do not pertain to any
-part of the Derivative Works; and
-  4. If the Work includes a "NOTICE" text file as part of its distribution,
-then any Derivative Works that You distribute must include a readable copy of
-the attribution notices contained within such NOTICE file, excluding those
-notices that do not pertain to any part of the Derivative Works, in at least
-one of the following places: within a NOTICE text file distributed as part of
-the Derivative Works; within the Source form or documentation, if provided
-along with the Derivative Works; or, within a display generated by the
-Derivative Works, if and wherever such third-party notices normally appear. The
-contents of the NOTICE file are for informational purposes only and do not
-modify the License. You may add Your own attribution notices within Derivative
-Works that You distribute, alongside or as an addendum to the NOTICE text from
-the Work, provided that such additional attribution notices cannot be construed
-as modifying the License.
-
-You may add Your own copyright statement to Your modifications and may provide
-additional or different license terms and conditions for use, reproduction, or
-distribution of Your modifications, or for any such Derivative Works as a
-whole, provided Your use, reproduction, and distribution of the Work otherwise
-complies with the conditions stated in this License.
-
-5. Submission of Contributions.
-
-Unless You explicitly state otherwise, any Contribution intentionally submitted
-for inclusion in the Work by You to the Licensor shall be under the terms and
-conditions of this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify the terms
-of any separate license agreement you may have executed with Licensor regarding
-such Contributions.
-
-6. Trademarks.
-
-This License does not grant permission to use the trade names, trademarks,
-service marks, or product names of the Licensor, except as required for
-reasonable and customary use in describing the origin of the Work and
-reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty.
-
-Unless required by applicable law or agreed to in writing, Licensor provides
-the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
-including, without limitation, any warranties or conditions of TITLE,
-NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
-solely responsible for determining the appropriateness of using or
-redistributing the Work and assume any risks associated with Your exercise of
-permissions under this License.
-
-8. Limitation of Liability.
-
-In no event and under no legal theory, whether in tort (including negligence),
-contract, or otherwise, unless required by applicable law (such as deliberate
-and grossly negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special, incidental,
-or consequential damages of any character arising as a result of this License
-or out of the use or inability to use the Work (including but not limited to
-damages for loss of goodwill, work stoppage, computer failure or malfunction,
-or any and all other commercial damages or losses), even if such Contributor
-has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability.
-
-While redistributing the Work or Derivative Works thereof, You may choose to
-offer, and charge a fee for, acceptance of support, warranty, indemnity, or
-other liability obligations and/or rights consistent with this License.
-However, in accepting such obligations, You may act only on Your own behalf and
-on Your sole responsibility, not on behalf of any other Contributor, and only
-if You agree to indemnify, defend, and hold each Contributor harmless for any
-liability incurred by, or claims asserted against, such Contributor by reason
-of your accepting any such warranty or additional liability.
-
-10. Noncompetition
-
-You may install and execute the Work only in conjunction with the direct use of
-Librato software.  This Work, any file or any derivative thereof shall not be
-used in conjunction with any product that competes with any Librato software.
-
-11. Termination
-
-The License stated above is automatically terminated and revoked if you exceed
-its scope or violate any of the terms of this License or any related License or
-notice.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and
+charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License.
+However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other
+Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims
+asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
 
 END OF TERMS AND CONDITIONS

--- a/guides/api.md
+++ b/guides/api.md
@@ -667,7 +667,7 @@ logger.info(ao.insertLogObject({
 <a name="ao.wrapLambdaHandler"></a>
 
 ### ao.wrapLambdaHandler([handler]) ⇒ <code>function</code>
-Wrap the lambda handler async function so it can be traced by AppOptics APM.
+Wrap the lambda handler function so it can be traced by AppOptics APM.
 
 **Kind**: static method of [<code>ao</code>](#ao)  
 **Returns**: <code>function</code> - - an async function, wrapping handler, to be used
@@ -675,7 +675,7 @@ Wrap the lambda handler async function so it can be traced by AppOptics APM.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [handler] | <code>function</code> | wraps your lambda handler function so it                               is instrumented. your handler must return                               a promise if it is not an async function. |
+| [handler] | <code>function</code> | wraps your lambda handler function so it                               is instrumented. your handler must return                               a promise, be a JavaScript async function,                               or implement the callback signature. |
 
 **Example**  
 ```js
@@ -683,12 +683,29 @@ const ao = require('appoptics-apm');
 
 const wrappedHandler = ao.wrapLambdaHandler(myHandler);
 
-async function myHandler(event, context) {
+async function myHandler (event, context) {
   // implementation
+  // ...
 }
 
 // set the handler to the wrapped function.
 exports.handler = wrappedHandler;
+```
+**Example**  
+```js
+const ao = require('appoptics-apm');
+
+const wrappedHandler = ao.wrapLambdaHandler(myHandler);
+
+function myHandler (event, context, callback) {
+  // implementation
+  // ...
+  if (error) {
+    callback(error);
+  }
+
+  callback(null, result);
+}
 ```
 <a name="Span"></a>
 
@@ -779,7 +796,9 @@ span.run(function (wrap) {
 <a name="Span+runPromise"></a>
 
 ### span.runPromise(fn, [opts]) ⇒
-Run an promise-returning function within the context of this span.
+Run a promise-returning function within the context of this span. It
+will throw an exception if the function's return value does not have
+.then and .catch methods.
 
 **Kind**: instance method of [<code>Span</code>](#Span)  
 **Returns**: the value returned by fn()  

--- a/guides/lambda-configuration.md
+++ b/guides/lambda-configuration.md
@@ -3,15 +3,20 @@
 This covers how to configure and enable AppOptics APM for nodejs lambda functions. For
 general configuration options see `configuration.md` in the same directory.
 
-## Prerequisite
+## Prerequisites
+
+If you haven't already, set up the forwarder. This only needs to be done once per region
+for the account.
 
 Add the `appoptics-node` layer to your function
-- screen shots?
-- select `arn:aws:lambda:${your-function's-region}:858939916050:layer:appoptics-node`:41
-- forwarder setup already done (where to document this - each agent?)
+- find the current version for your region(s) at https://files.appoptics.com/lambda-layers/node/
+- copy the arn (e.g., `arn:aws:lambda:us-east-1:085151004374:layer:appoptics-node:7`)
 
-choose `Specify an ARN` and select `....` - how to find/see available `appoptics-node`
-versions for node? where to see?
+Add the `appoptics-node` layer to your function using one of the following methods
+- use the AWS web console to add a layer to your function, choose specify an ARN, and paste the arn
+copied above.
+- use the AWS CLI to execute `aws lambda update-function-configuration`
+- use the AWS SDK to invoke the update-function-configuration equivalent.
 
 ## no-code change instrumentation
 - add the environment variable `APPOPTICS_WRAP_LAMBDA_HANDLER` set to the function's current handler.
@@ -25,7 +30,7 @@ That's it! When lambda loads the function it will invoke AppOptics' handler whic
 ## manual instrumentation
 - DO NOT change the lambda function's `Handler` setting nor create the env var `APPOPTICS_WRAP_LAMBDA_HANDLER`
 - add `const ao = require('appoptics-apm');` as the first module required in your function's code.
-- wrap your function before exporting it.
+- use `ao.wrapLambdaHandler()` to wrap your function before exporting it.
 
 for example, the lambda function's `Basic Settings` `Handler` is `index.handler` and your current code
 is in the file `index.js` and looks like:
@@ -53,12 +58,7 @@ async function myHandlerEvent (event, context) {
 module.exports.handler = ao.wrapLambdaHandler(myHandlerEchoEvent);
 ```
 
-## even more manual installation
-- create your own layer that includes the appoptics-apm code? this is complicated as it involves
-building the bindings agent in an amazon linux container. punt.
-
 ## fine tuning
-
 - it is possible to adjust the sample rate but requires tweaking internal settings and taking
 the lambda function configuration and the expected loads into consideration. please contact
 customer support in order to adjust the sample rate.

--- a/guides/lambda-configuration.md
+++ b/guides/lambda-configuration.md
@@ -9,7 +9,7 @@ If you haven't already, set up the forwarder. This only needs to be done once pe
 for the account.
 
 Add the `appoptics-node` layer to your function
-- find the current version for your region(s) at https://files.appoptics.com/lambda-layers/node/
+- find the current version for your region(s) at https://files.appoptics.com/lambda-layers/appoptics-node/
 - copy the arn (e.g., `arn:aws:lambda:us-east-1:085151004374:layer:appoptics-node:7`)
 
 Add the `appoptics-node` layer to your function using one of the following methods

--- a/guides/migrating.md
+++ b/guides/migrating.md
@@ -1,11 +1,38 @@
 ### Table of Contents
+[Migrating v8 => v9](#v8tov9)<br>
 [Migrating v7 => v8](#v7tov8)<br>
 [Migrating v5 => v6](#v5tov6)
+
+<a name="v8tov9"></a>
+## appoptics-apm migration guide v8 => v9
+
+If you are using `appoptics-apm` out-of-the-box with no custom instrumentation
+then no migration is necessary. You can stop reading now.
+
+### Background
+
+In order to detect error conditions in the AWS lambda environment it was necessary
+to replace the promise-to-callback shim in `pStartOrContinueTrace()` with direct
+support of promises.
+
+### Summary of changes
+
+- in previous versions if the function passed to `pStartOrContinueTrace()` did not
+return a `thenable` the span would be completed by making the callback. In v9, the
+span will never complete because there is no callback mechanism underlying
+`pStartOrContinueTrace()`.
+- calling `span.run()` will not work for spans that return promises. `span.runPromise()`
+must be called. It is not possible for `span.run()` to detect whether the function will
+return a promise or not. `span.run()` may still be used with synchronous and callback-based
+functions. Previously this would work because promise-spans were really callback-spans.
+- some error messages have changed to be more consistent.
+
+
 
 <a name="v7tov8"></a>
 ## appoptics-apm migration guide v7 => v8
 
-If you using `appoptics-apm` out-of-the-box with no custom instrumentation
+If you are using `appoptics-apm` out-of-the-box with no custom instrumentation
 then no migration is necessary. You can stop reading now.
 
 ### Background

--- a/guides/migrating.md
+++ b/guides/migrating.md
@@ -25,6 +25,11 @@ span will never complete because there is no callback mechanism underlying
 must be called. It is not possible for `span.run()` to detect whether the function will
 return a promise or not. `span.run()` may still be used with synchronous and callback-based
 functions. Previously this would work because promise-spans were really callback-spans.
+- `ao.serviceKey` - this property has been removed; it is no longer valid in all cases. If
+you require the service key in your code either fetch it from the environment or read your
+configuration file.
+- in v8 if `APPOPTICS_LOG_SETTINGS` was the empty string then the default logging 'error,warn'
+would be used. in v9 that means no logging is enabled.
 - some error messages have changed to be more consistent.
 
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -1508,10 +1508,11 @@ function insertLogObject (o = {}) {
  * Wrap the lambda handler async function so it can be traced by AppOptics APM.
  *
  * @method ao.wrapLambdaHandler
- * @param {async function} [handler] - wraps your lambda handler function so it
- *                                    is instrumented. your handler must return
- *                                    a promise if it is not an async function.
- * @returns {async function} - the wrapped function
+ * @param {function} [handler] - wraps your lambda handler function so it
+ *                               is instrumented. your handler must return
+ *                               a promise if it is not an async function.
+ * @returns {function} - an async function, wrapping handler, to be used
+ *                       instead of handler.
  *
  * @example
  *

--- a/lib/api.js
+++ b/lib/api.js
@@ -1505,28 +1505,43 @@ function insertLogObject (o = {}) {
 }
 
 /**
- * Wrap the lambda handler async function so it can be traced by AppOptics APM.
+ * Wrap the lambda handler function so it can be traced by AppOptics APM.
  *
  * @method ao.wrapLambdaHandler
  * @param {function} [handler] - wraps your lambda handler function so it
  *                               is instrumented. your handler must return
- *                               a promise if it is not an async function.
+ *                               a promise, be a JavaScript async function,
+ *                               or implement the callback signature.
  * @returns {function} - an async function, wrapping handler, to be used
  *                       instead of handler.
  *
  * @example
- *
  * const ao = require('appoptics-apm');
  *
  * const wrappedHandler = ao.wrapLambdaHandler(myHandler);
  *
- * async function myHandler(event, context) {
+ * async function myHandler (event, context) {
  *   // implementation
+ *   // ...
  * }
  *
  * // set the handler to the wrapped function.
  * exports.handler = wrappedHandler;
  *
+ * @example
+ * const ao = require('appoptics-apm');
+ *
+ * const wrappedHandler = ao.wrapLambdaHandler(myHandler);
+ *
+ * function myHandler (event, context, callback) {
+ *   // implementation
+ *   // ...
+ *   if (error) {
+ *     callback(error);
+ *   }
+ *
+ *   callback(null, result);
+ * }
  */
 function wrapLambdaHandler (userHandler) {
   if (userHandler[ao.wrappedFlag]) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -481,6 +481,8 @@ function getTraceSettings (xtrace, options = {}) {
   if (udp) {
     osettings.doMetrics = osettings.doSample
   }
+  // capture the inbound x-trace.
+  osettings.inboundXtrace = settings.xtrace;
 
   // record this for debugging purposes
   ao.lastSettings = osettings
@@ -496,8 +498,11 @@ function getTraceSettings (xtrace, options = {}) {
       edge: false,
       metadata: aob.Event.makeRandom(0),
     }, osettings);
+    // if getTraceSettings() failed then don't count the x-trace even if it was valid.
+    osettings.inboundXtrace = false;
   }
-  // compatability across bindings versions
+
+  // compatibility across bindings versions
   if (!('traceTaskId' in osettings)) {
     osettings.traceTaskId = osettings.metadata;
   }
@@ -881,12 +886,12 @@ function pInstrument (name, task, options = {}) {
 function runInstrument (last, make, run, options, callback) {
   // Verify that a name or span-info function is given
   if (!~['function', 'string'].indexOf(typeof make)) {
-    ao.loggers.error('ao.runInstrument found no span name or span-info function')
+    ao.loggers.error('ao.runInstrument found no span name or span-info()')
     return run(callback)
   }
 
   // Build span. Because last must exist this function cannot be used
-  // for a root span.
+  // for a topSpan.
   let span
   try {
     let name = make
@@ -901,7 +906,7 @@ function runInstrument (last, make, run, options, callback) {
     if (name) {
       span = last.descend(name, kvpairs)
     } else {
-      const msg = typeof make === 'function' ? ' by span-maker function' : '';
+      const msg = typeof make === 'function' ? ' by span-info()' : '';
       ao.loggers.error(`no name supplied to runInstrument${msg}`);
     }
 
@@ -929,10 +934,12 @@ function runSpan (span, run, options, callback) {
     span.events.entry.set({Backtrace: ao.backtrace()})
   }
 
+
   // Detect if sync or async, and run span appropriately
-  return callback
-    ? span.runAsync(makeWrappedRunner(run, callback))
-    : span.runSync(run)
+  if (callback) {
+    return span.runAsync(makeWrappedRunner(run, callback));
+  }
+  return span.runSync(run);
 }
 
 // This makes a callback-wrapping span runner
@@ -1090,6 +1097,7 @@ function startOrContinueTrace (xtrace, build, run, opts, cb) {
  * @param {boolean} [opts.collectBacktraces=false] - collect backtraces
  * @param {boolean} [opts.forceNewTrace=false] - ignore any existing context and force a new trace
  * @param {string|function} [opts.customTxName] - name or function
+ *
  * @returns {Promise} the value returned by the run function or undefined if it can't be run
  *
  * @example
@@ -1112,27 +1120,102 @@ function startOrContinueTrace (xtrace, build, run, opts, cb) {
  *   functionToRun,
  * ).then(...)
  */
-function pStartOrContinueTrace (xtrace, name, task, options = {}) {
-  if (typeof task !== 'function') {
-    return startOrContinueTrace(...arguments);
+async function pStartOrContinueTrace (xtrace, protoSpan, func, opts) {
+  // Verify that a run function is given
+  if (typeof func !== 'function') {
+    ao.loggers.error(`pStartOrContinueTrace requires a function, not ${typeof func}`);
+    return;
   }
 
-  const wrapped = cb => {
-    const p = task();
-    if (!p || typeof p.then !== 'function') {
-      cb();
-      return p;
+  opts = Object.assign({enabled: true}, opts);
+
+  // If not enabled there's nothing to do. the async context should be maintained
+  // by node/v8 through the promise execution.
+  if (!opts.enabled) {
+    return func();
+  }
+
+  // If already tracing, continue the existing trace ignoring any xtrace passed as the first
+  // argument, unless forcing a new trace. startOrContinueTrace() returns runInstrument() at
+  // this point but both logic paths are kept here in this function.
+  let last;
+  if (!opts.forceNewTrace) {
+    last = ao.lastSpan;
+  }
+
+  // get information needed for the span
+  let name;
+  let kvpairs = {};
+  let finalize;
+  if (typeof protoSpan === 'string') {
+    name = protoSpan;
+  } else if (typeof protoSpan === 'function') {
+    try {
+      // last is defined only if there is a trace in progress AND not forcing a new trace.
+      ({name, kvpairs, finalize} = protoSpan(last));
+    } catch (e) {
+      ao.loggers.debug(`span-info() failed ${e.message}`);
     }
-    return p.then(r => {
-      cb(null, r);
-      return r;
-    }).catch(e => {
-      cb(e);
-      throw e;
-    });
+
+    const protoSpanErrors = [];
+    //if (error) {
+    //  protoSpanErrors.push(error.message);
+    //}
+    if (!name || typeof name !== 'string') {
+      protoSpanErrors.push('name');
+    }
+    if (kvpairs && typeof kvpairs !== 'object') {
+      protoSpanErrors.push('kvpairs');
+    }
+    if (finalize && typeof finalize !== 'function') {
+      protoSpanErrors.push('finalize function');
+    }
+    if (protoSpanErrors.length) {
+      ao.loggers.error(`pStartOrContinueTrace span-info bad values: ${protoSpanErrors.join(', ')}`);
+      return func();
+    }
+  } else {
+    ao.loggers.error(`pStartOrContinueTrace span argument must be a string or function, not ${typeof protoSpan}`);
+    return func();
   }
 
-  return startOrContinueTrace(xtrace, name, wrapped, options);
+  let span;
+  let state;      // allows more specific error message
+  try {
+    if (last) {
+      state = `execute last.descend(${name})`;
+      span = last.descend(name, kvpairs);
+    } else {
+      state = 'getTraceSettings()';
+      const settings = getTraceSettings(xtrace);
+      state = 'makeEntrySpan()';
+      span = Span.makeEntrySpan(name, settings, kvpairs);
+      // Add sampling data to entry if there was not already an xtrace ID
+      if (settings.doSample && !xtrace) {
+        span.events.entry.set({
+          SampleSource: settings.source,
+          SampleRate: settings.rate
+        });
+      }
+    }
+    state = 'finalize()';
+    if (finalize) {
+      // note that last will be undefined if there was an x-trace or forceNewTrace is true.
+      finalize(span, last);
+    }
+  } catch (e) {
+    ao.loggers.error(`pStartOrContinueTrace failed to ${state}`, e.stack);
+    return func();
+  }
+
+  // if no span can't do sampling or inbound metrics - need a context. is this possible if nothing in
+  // the try block above fails?
+  if (!span) {
+    ao.loggers.error('pStartOrContinueTrace failed to get a span, not instrumenting');
+    return func();
+  }
+
+  return span.runPromise(func, opts);
 }
 
 /**
@@ -1528,10 +1611,10 @@ function wrapLambdaHandler (userHandler) {
       // header will be returned.
       return {name, kvpairs: makeLambdaKVPairs(topSpanType, event, context), finalize};
     }
-    return lambdaStartOrContinueTrace(
+    return pStartOrContinueTrace(
       inboundXTraceID,
-      spanInfo,           // use function to add kvpairs
-      () => promiseReturningHandler(event, context),      // promise-returning handler
+      spanInfo,
+      () => promiseReturningHandler(event, context),
       {forceNewTrace: true}
     );
   }
@@ -1539,37 +1622,6 @@ function wrapLambdaHandler (userHandler) {
   userHandler[ao.wrappedFlag] = wrappedFunction;
 
   return wrappedFunction;
-}
-
-function lambdaStartOrContinueTrace (xtrace, name, task, options = {}) {
-  if (typeof task !== 'function') {
-    return startOrContinueTrace(...arguments);
-  }
-
-  const wrapped = cb => {
-    const p = task();
-    if (!p || typeof p.then !== 'function') {
-      cb();
-      return p;
-    }
-    return p
-      .then(r => {
-        // lambda promises that resolve to an error are treated
-        // as errors. but it's also the return value, so pass it
-        // as both the error and return value of the callback.
-        if (r instanceof Error) {
-          cb(r, r);
-        } else {
-          cb(null, r);
-        }
-        return r;
-      }).catch(e => {
-        cb(e);
-        throw e;
-      });
-  }
-
-  return startOrContinueTrace(xtrace, name, wrapped, options);
 }
 
 function promiseOnlyHandler (handler) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -1597,9 +1597,10 @@ function wrapLambdaHandler (userHandler) {
     if (topSpanType) {
       finalize = (span) => {
         span.defaultTxName = process.env.APPOPTICS_TRANSACTION_NAME || `${method.toUpperCase()}.${userHandlerName}`;
-        if (inboundXTraceID) {
-          span.topSpan = topSpanType;
-        }
+        span.topSpan = topSpanType;
+        //if (inboundXTraceID) {
+        //  span.topSpan = topSpanType;
+        //}
       };
     }
 

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint-disable indent */
+{
 const util = require('util');
 
 let ao;
@@ -346,3 +348,4 @@ Event.init = function (populatedAo) {
 
 module.exports = Event;
 
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,21 @@
 'use strict'
 
+/*
+Copyright 2020 SolarWinds, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // create or get this symbol.
 const aoOnce = Symbol.for('AppOptics.Apm.Once')
 

--- a/lib/span.js
+++ b/lib/span.js
@@ -102,9 +102,10 @@ Span.makeEntrySpan = function makeEntrySpan (name, settings, kvpairs) {
   log.span('Span.makeEntrySpan %s from inbound %x', name, settings.traceTaskId)
 
   // use the Event from settings or make new (error getting settings or testing).
-  const traceTaskId = settings.traceTaskId || ao.addon.Event.makeRandom(settings.doSample)
+  const traceTaskId = settings.traceTaskId || ao.addon.Event.makeRandom(settings.doSample);
+  const {edge, inboundXtrace} = settings;
 
-  const span = new Span(name, {traceTaskId, edge: settings.edge}, kvpairs);
+  const span = new Span(name, {traceTaskId, edge, inboundXtrace}, kvpairs);
 
   // if not sampling make a single skeleton span that will be used for all other spans in this
   // trace.
@@ -331,7 +332,7 @@ Span.prototype._lambdaPreExitProcessing = function (r, kvpairs) {
   if ('statusCode' in r) {
     kvpairs.Status = r.statusCode;
     if (r.statusCode >= 500 && r.statusCode <= 599) {
-      const e = new LambdaExitError('statusCode500', `response statusCode set to ${r.statusCode}`);
+      const e = new LambdaExitError('statusCode5xx', `response statusCode set to ${r.statusCode}`);
       this.setExitError(e);
     }
   }
@@ -341,6 +342,8 @@ Span.prototype._lambdaPreExitProcessing = function (r, kvpairs) {
       log.debug('set ret.headers.x-trace = %e', lastEvent);
       r.headers['x-trace'] = lastEvent.toString();
     }
+  } else {
+    log.debug(`not returning x-trace header ${this.returnXtraceHeader} headers ${typeof r.headers}`);
   }
 
   if (log.debug.enabled) {

--- a/lib/span.js
+++ b/lib/span.js
@@ -234,6 +234,24 @@ Span.prototype.isLambdaTopSpan = function () {
 // run a promise-returning function. if the function does not return
 // a promise it doesn't fail gracefully at this time.
 //
+
+/**
+ * Run a promise-returning function within the context of this span. It
+ * will throw an exception if the function's return value does not have
+ * .then and .catch methods.
+ *
+ * @method Span#runPromise
+ * @param {function} fn - the promise-returning function to run within the span context
+ * @param {object} [opts] - an options object
+ * @param {boolean} [opts.collectBacktraces=false] - add a backtrace KV to the span
+ *
+ * @returns the value returned by fn()
+ *
+ * @example
+ * span.runPromise(async function () {
+ *   return axios.get('https://google.com');
+ * });
+ */
 Span.prototype.runPromise = async function (pfunc, options) {
   let ctx;
   let startTime;

--- a/lib/span.js
+++ b/lib/span.js
@@ -259,16 +259,16 @@ Span.prototype.runPromise = async function (pfunc, options) {
 
   this.enter();
 
-  let error;
+  let errorSeen = false;
   return pfunc()
-    .catch(e => error = e)
+    .catch(e => {errorSeen = true; return e})
     .then(r => {
       const kvpairs = {};
 
       if (this.topSpan && this.doMetrics) {
         const txname = this.getTransactionName();
         const et = (Date.now() - startTime) * 1000;
-        const txnameUsed = Span.sendNonHttpSpan(txname, et, error);
+        const txnameUsed = Span.sendNonHttpSpan(txname, et, errorSeen);
         if (txname !== txnameUsed) {
           log.warn(`span ${this.name}.runPromise() txname used: %s vs %s`, txnameUsed, txname)
         }
@@ -276,27 +276,77 @@ Span.prototype.runPromise = async function (pfunc, options) {
       }
 
       if (this.isLambdaTopSpan()) {
-        // check all permutations of error returns and inject headers as specified.
+        // check all permutations of error returns and inject headers as specified. if the
+        // promise was rejected then r is just the
         this._lambdaPreExitProcessing(r, kvpairs);
-        this.exit(kvpairs);
-      } else {
-        this.exitCheckingError(error, kvpairs);
       }
+      if (errorSeen && !(r instanceof Error)) {
+        r = new LambdaExitError('handlerReject', `handler rejected with ${util.format(r)}`);
+      }
+      this.exitCheckingError(r, kvpairs);
 
       try {
         if (ctx) {
           ao.requestStore.exit(ctx);
         }
       } catch (e) {
-        log.error(`${this.name} span failed to exit context`, e.stack)
+        log.error(`${this.name} span failed to exit context`, e.stack);
       }
 
-      if (error) {
-        throw error;
+      if (errorSeen) {
+        throw r;
       }
 
       return r;
     });
+}
+
+
+class LambdaExitError extends Error {
+  constructor (code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+
+//
+// internal function that makes a decision about whether to report a trace error
+// for the span. the summary is "if it is an error or the statusCode is a 500-599
+// then add an error to the KVs". an exception is detected prior to this function.
+//
+// returns the ret value.
+//
+Span.prototype._lambdaPreExitProcessing = function (r, kvpairs) {
+  // in lambda returning an Error results in an error.
+  if (r instanceof Error) {
+    this.setExitError(r);
+    return r;
+  }
+  // if it isn't an object then there is nothing to do
+  if (!r || typeof r !== 'object') {
+    log.span(`span ${this.name} resolves to non-object: ${typeof r}`);
+    return r;
+  }
+
+  if ('statusCode' in r) {
+    kvpairs.Status = r.statusCode;
+    if (r.statusCode >= 500 && r.statusCode <= 599) {
+      const e = new LambdaExitError('statusCode500', `response statusCode set to ${r.statusCode}`);
+      this.setExitError(e);
+    }
+  }
+  if (this.returnXtraceHeader && typeof r.headers === 'object') {
+    const lastEvent = this.events.exit;
+    if (lastEvent) {
+      log.debug('set ret.headers.x-trace = %e', lastEvent);
+      r.headers['x-trace'] = lastEvent.toString();
+    }
+  }
+
+  if (log.debug.enabled) {
+    log.debug(`${this.name} lambdaPreExit returning %s`, JSON.stringify(r));
+  }
+  return r;
 }
 
 /**
@@ -372,52 +422,6 @@ Span.prototype.runAsync = function (fn) {
 
   return ret;
 
-}
-
-class LambdaExitError extends Error {
-  constructor (code, message) {
-    super(message);
-    this.code = code;
-  }
-}
-//
-// internal function that makes a decision about whether to report a trace error
-// for the span. the summary is "if it is an error or the statusCode is a 500-599
-// then add an error to the KVs". an exception is detected prior to this function.
-//
-// returns the ret value.
-//
-Span.prototype._lambdaPreExitProcessing = function (r, kvpairs) {
-  // in lambda returning an Error results in an error.
-  if (r instanceof Error) {
-    this.setExitError(r);
-    return r;
-  }
-  // if it isn't an object then there is nothing to do
-  if (!r || typeof r !== 'object') {
-    log.span(`span ${this.name} resolves to non-object: ${typeof r}`);
-    return r;
-  }
-
-  if ('statusCode' in r) {
-    kvpairs.Status = r.statusCode;
-    if (r.statusCode >= 500 && r.statusCode <= 599) {
-      const e = new LambdaExitError('statusCode500', `response statusCode set to ${r.statusCode}`);
-      this.setExitError(e);
-    }
-  }
-  if (this.returnXtraceHeader && typeof r.headers === 'object') {
-    const lastEvent = this.events.exit;
-    if (lastEvent) {
-      log.debug('set ret.headers.x-trace = %e', lastEvent);
-      r.headers['x-trace'] = lastEvent.toString();
-    }
-  }
-
-  if (log.debug.enabled) {
-    log.debug(`${this.name} lambdaPreExit returning %o`, r);
-  }
-  return r;
 }
 
 // this function is mothballed as opposed to removed because the logic might be

--- a/lib/span.js
+++ b/lib/span.js
@@ -278,9 +278,9 @@ Span.prototype.runPromise = async function (pfunc, options) {
       if (this.isLambdaTopSpan()) {
         // check all permutations of error returns and inject headers as specified.
         this._lambdaPreExitProcessing(r, kvpairs);
+      } else {
+        this.exitCheckingError(error, kvpairs);
       }
-
-      this.exitCheckingError(error, kvpairs);
 
       try {
         if (ctx) {
@@ -384,49 +384,39 @@ class LambdaExitError extends Error {
 // for the span. the summary is "if it is an error or the statusCode is a 500-599
 // then add an error to the KVs". an exception is detected prior to this function.
 //
-// returns the promise.
+// returns the ret value.
 //
-Span.prototype._lambdaPreExitProcessing = function (ret, kvpairs) {
-
-  if (!ret || !ret.then) {
-    log.warn(`${this.name} lambdaPreExit with ${typeof ret}`);
-    return ret;
+Span.prototype._lambdaPreExitProcessing = function (r, kvpairs) {
+  // in lambda returning an Error results in an error.
+  if (r instanceof Error) {
+    this.setExitError(r);
+    return r;
+  }
+  // if it isn't an object then there is nothing to do
+  if (!r || typeof r !== 'object') {
+    log.span(`span ${this.name} resolves to non-object: ${typeof r}`);
+    return r;
   }
 
-  return ret
-    .then(r => {
-      // in lambda promises that resolve to an Error generate errors.
-      if (r instanceof Error) {
-        this.setExitError(r);
-        return r;
-      }
-      // if it isn't an object then there is nothing to do
-      if (!r || typeof r !== 'object') {
-        log.span(`span ${this.name} resolves to non-object: ${typeof r}`);
-        return r;
-      }
+  if ('statusCode' in r) {
+    kvpairs.HTTPStatus = r.statusCode;
+    if (r.statusCode >= 500 && r.statusCode <= 599) {
+      const e = new LambdaExitError('statusCode500', `response statusCode set to ${r.statusCode}`);
+      this.setExitError(e);
+    }
+  }
+  if (this.returnXtraceHeader && typeof r.headers === 'object') {
+    const lastEvent = this.events.exit;
+    if (lastEvent) {
+      log.debug('set ret.headers.x-trace = %e', lastEvent);
+      r.headers['x-trace'] = lastEvent.toString();
+    }
+  }
 
-      if (typeof r === 'object') {
-        if ('statusCode' in r) {
-          kvpairs.HTTPStatus = r.statusCode;
-          if (r.statusCode >= 500 && r.statusCode <= 599) {
-            const e = new LambdaExitError('statusCode500', `response statusCode set to ${r.statusCode}`);
-            this.setExitError(e);
-          }
-        }
-        if (this.returnXtraceHeader && typeof r.headers === 'object') {
-          const lastEvent = this.events.exit;
-          if (lastEvent) {
-            log.debug('set ret.headers.x-trace = %e', lastEvent);
-            r.headers['x-trace'] = lastEvent.toString();
-          }
-        }
-      }
-      if (log.debug.enabled) {
-        log.debug(`${this.name} lambdaPreExit returning %o`, r);
-      }
-      return r;
-    });
+  if (log.debug.enabled) {
+    log.debug(`${this.name} lambdaPreExit returning %o`, r);
+  }
+  return r;
 }
 
 // this function is mothballed as opposed to removed because the logic might be

--- a/lib/span.js
+++ b/lib/span.js
@@ -388,6 +388,11 @@ class LambdaExitError extends Error {
 //
 Span.prototype._lambdaPreExitProcessing = function (ret, kvpairs) {
 
+  if (!ret || !ret.then) {
+    log.warn(`${this.name} lambdaPreExit with ${typeof ret}`);
+    return ret;
+  }
+
   return ret
     .then(r => {
       // in lambda promises that resolve to an Error generate errors.

--- a/lib/span.js
+++ b/lib/span.js
@@ -386,7 +386,7 @@ class LambdaExitError extends Error {
 //
 // returns the promise.
 //
-Span.prototype._lambdaPreExitProcessing = async function (ret, kvpairs) {
+Span.prototype._lambdaPreExitProcessing = function (ret, kvpairs) {
 
   return ret
     .then(r => {
@@ -417,7 +417,9 @@ Span.prototype._lambdaPreExitProcessing = async function (ret, kvpairs) {
           }
         }
       }
-
+      if (log.debug.enabled) {
+        log.debug(`${this.name} lambdaPreExit returning %o`, r);
+      }
       return r;
     });
 }
@@ -738,6 +740,7 @@ Span.prototype.setExitError = function (error) {
     error = Span.toError(error)
     if (error) {
       if (!this.ignoreErrorFn || !this.ignoreErrorFn(error)) {
+        log.span(`${this.name} setting exit error ${error.message}`);
         this.events.exit.error = error;
       }
     }

--- a/lib/span.js
+++ b/lib/span.js
@@ -400,7 +400,7 @@ Span.prototype._lambdaPreExitProcessing = function (r, kvpairs) {
   }
 
   if ('statusCode' in r) {
-    kvpairs.HTTPStatus = r.statusCode;
+    kvpairs.Status = r.statusCode;
     if (r.statusCode >= 500 && r.statusCode <= 599) {
       const e = new LambdaExitError('statusCode500', `response statusCode set to ${r.statusCode}`);
       this.setExitError(e);

--- a/lib/span.js
+++ b/lib/span.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint-disable indent */
+{
 const util = require('util');
 const Event = require('./event')
 let ao;
@@ -226,6 +228,9 @@ Span.prototype.run = function (fn) {
   return fn.length === 1 ? this.runAsync(fn) : this.runSync(fn)
 }
 
+// span.topSpan is normally a boolean. but if the topSpan is determined to be an http-type
+// span coming in through the AWS api-gateway then span.topSpan is set to a string value
+// specifying which api-gateway version was detected. see api.js#wrapLambdaHandler().
 Span.prototype.isLambdaTopSpan = function () {
   return typeof this.topSpan === 'string';
 }
@@ -416,9 +421,9 @@ Span.prototype.runAsync = function (fn) {
       handler.apply(this, arguments)
     } else {
       // this is the "normal", i.e., non-memcached path.
-      const et = (Date.now() - startTime) * 1000;
       const kvpairs = {};
       if (span.topSpan && span.doMetrics) {
+        const et = (Date.now() - startTime) * 1000;
         const txname = span.getTransactionName()
         const finaltxname = Span.sendNonHttpSpan(txname, et, error);
         kvpairs.TransactionName = finaltxname
@@ -954,3 +959,5 @@ Span.init = function (populatedAo) {
 }
 
 module.exports = Span;
+}
+

--- a/lib/span.js
+++ b/lib/span.js
@@ -48,6 +48,8 @@ function Span (name, settings, data) {
     exit: null
   }
 
+  this.returnXtraceHeader = ao.lambda ? !!settings.inboundXtrace : true;
+
   if (!name) {
     throw new TypeError(`invalid span name ${name}`)
   }
@@ -223,6 +225,79 @@ Span.prototype.run = function (fn) {
   return fn.length === 1 ? this.runAsync(fn) : this.runSync(fn)
 }
 
+Span.prototype.isLambdaTopSpan = function () {
+  return typeof this.topSpan === 'string';
+}
+
+//
+// run a promise-returning function. if the function does not return
+// a promise it doesn't fail gracefully at this time.
+//
+Span.prototype.runPromise = async function (pfunc, options) {
+  let ctx;
+  let startTime;
+
+  if (!this.isLambdaTopSpan()) {
+    this.async = true;
+  }
+
+  try {
+    ctx = ao.requestStore.createContext({newContext: this.topSpan});
+    ao.requestStore.enter(ctx);
+  } catch (e) {
+    log.error(`${this.name} span failed to enter context ${e.message}`, e.stack);
+  }
+
+  // Attach backtrace if sampling and enabled.
+  if (this.doSample && options.collectBacktraces) {
+    this.events.entry.set({Backtrace: ao.backtrace()})
+  }
+
+  if (this.doMetrics) {
+    startTime = Date.now();
+  }
+
+  this.enter();
+
+  let error;
+  return pfunc()
+    .catch(e => error = e)
+    .then(r => {
+      const kvpairs = {};
+
+      if (this.topSpan && this.doMetrics) {
+        const txname = this.getTransactionName();
+        const et = (Date.now() - startTime) * 1000;
+        const txnameUsed = Span.sendNonHttpSpan(txname, et, error);
+        if (txname !== txnameUsed) {
+          log.warn(`span ${this.name}.runPromise() txname used: %s vs %s`, txnameUsed, txname)
+        }
+        kvpairs.TransactionName = txnameUsed;
+      }
+
+      if (this.isLambdaTopSpan()) {
+        // check all permutations of error returns and inject headers as specified.
+        this._lambdaPreExitProcessing(r, kvpairs);
+      }
+
+      this.exitCheckingError(error, kvpairs);
+
+      try {
+        if (ctx) {
+          ao.requestStore.exit(ctx);
+        }
+      } catch (e) {
+        log.error(`${this.name} span failed to exit context`, e.stack)
+      }
+
+      if (error) {
+        throw error;
+      }
+
+      return r;
+    });
+}
+
 /**
  * Run an async function within the context of this span.
  *
@@ -238,13 +313,13 @@ Span.prototype.run = function (fn) {
 Span.prototype.runAsync = function (fn) {
   const span = this;
   // don't mark the top span async in lambda because it interferes with the display
-  // on the host.
-  if (!(span.topSpan && ao.execEnv.id === 'lambda')) {
+  // on the host. fundamentally, it is not this function's decision whether to mark the
+  // span async or not. setting/clearing it adds/removes the KV key Async.
+  if (!span.isLambdaTopSpan()) {
     span.async = true;
   }
   let ctx
   let startTime
-  const kvpairs = {}
 
   try {
     ctx = ao.requestStore.createContext({newContext: this.topSpan});
@@ -262,25 +337,25 @@ Span.prototype.runAsync = function (fn) {
   // it, then runs the user's runner function. That way our wrapper is invoked
   // before the user's callback. handler is used only for memcached. No other
   // callback function supplies it.
-  const ret = fn.call(span, (cb, handler) => ao.bind(function (err) {
+  const ret = fn.call(span, (cb, handler) => ao.bind(function (error) {
     if (handler) {
       // handler is present only for some memcached functions.
       // TODO BAM how to handle this with customTxName...
       handler.apply(this, arguments)
     } else {
       // this is the "normal", i.e., non-memcached path.
-
+      const et = (Date.now() - startTime) * 1000;
+      const kvpairs = {};
       if (span.topSpan && span.doMetrics) {
         const txname = span.getTransactionName()
-        const et = (Date.now() - startTime) * 1000;
-        const finaltxname = Span.sendNonHttpSpan(txname, et, err)
+        const finaltxname = Span.sendNonHttpSpan(txname, et, error);
         kvpairs.TransactionName = finaltxname
         if (txname !== finaltxname) {
           log.warn('Span.runAsync txname mismatch: %s !== %s', txname, finaltxname)
         }
       }
 
-      span.exitCheckingError(err, kvpairs)
+      span.exitCheckingError(error, kvpairs);
     }
 
     return cb.apply(this, arguments)
@@ -294,52 +369,145 @@ Span.prototype.runAsync = function (fn) {
     log.error(`${this.name} span failed to exit context`, e.stack)
   }
 
-  if (span.topSpan === 'lambda-api-gateway-v1' || span.topSpan === 'lambda-api-gateway-v2') {
-    log.span('attempting lambda header insertion:%s', span.topSpan);
-    if (!ret || typeof ret.then !== 'function') {
-      log.debug('span runner return value not then-able');
-      return ret;
-    }
-    return ret
-      .then(r => {
-        // in lambda promises that resolve to an Error generate errors.
-        if (r instanceof Error) {
-          return r;
-        } else if (!r || typeof r !== 'object') {
-          // nothing to do if it's version 1. the response must be correct.
-          if (span.topSpan === 'lambda-api-gateway-v1') {
-            return r;
-          }
-          log.span('injecting status code and headers');
-          // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-          // it's v2 - supply a statusCode so lambda won't treat interpret this object
-          // as the body and add a headers object. r is the body.
-          r = {statusCode: 200, body: r, headers: {}};
-        } else if (span.topSpan === 'lambda-api-gateway-v2' && !('statusCode' in r)) {
-          // it is an object but doesn't have a statusCode property. apig would interpret this as the
-          // body and stringify it, so do the same, wrapping it in an object with statusCode and headers.
-          log.span('injecting status code, headers, and stringifying');
-          r = {statusCode: 200, body: JSON.stringify(r), headers: {}};
-        } else if (!('headers' in r)) {
-          // it is an object, it has a statusCode property but not a headers object property.
-          log.span('injecting headers');
-          r.headers = {};
-        } else if (typeof r.headers !== 'object') {
-          log.span('found non-object headers, skipping injection');
-          // if headers is present but not an object don't replace it.
-          return r;
-        }
-        const lastEvent = span.events.exit;
-        if (lastEvent) {
-          log.debug('set ret.headers.x-trace = %e', lastEvent);
-          r.headers['x-trace'] = lastEvent.toString();
-        }
-        return r;
-      });
-  }
-
   return ret;
+
 }
+
+class LambdaExitError extends Error {
+  constructor (code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+//
+// internal function that makes a decision about whether to report a trace error
+// for the span. the summary is "if it is an error or the statusCode is a 500-599
+// then add an error to the KVs". an exception is detected prior to this function.
+//
+// returns the promise.
+//
+Span.prototype._lambdaPreExitProcessing = async function (ret, kvpairs) {
+
+  return ret
+    .then(r => {
+      // in lambda promises that resolve to an Error generate errors.
+      if (r instanceof Error) {
+        this.setExitError(r);
+        return r;
+      }
+      // if it isn't an object then there is nothing to do
+      if (!r || typeof r !== 'object') {
+        log.span(`span ${this.name} resolves to non-object: ${typeof r}`);
+        return r;
+      }
+
+      if (typeof r === 'object') {
+        if ('statusCode' in r) {
+          kvpairs.HTTPStatus = r.statusCode;
+          if (r.statusCode >= 500 && r.statusCode <= 599) {
+            const e = new LambdaExitError('statusCode500', `response statusCode set to ${r.statusCode}`);
+            this.setExitError(e);
+          }
+        }
+        if (this.returnXtraceHeader && typeof r.headers === 'object') {
+          const lastEvent = this.events.exit;
+          if (lastEvent) {
+            log.debug('set ret.headers.x-trace = %e', lastEvent);
+            r.headers['x-trace'] = lastEvent.toString();
+          }
+        }
+      }
+
+      return r;
+    });
+}
+
+// this function is mothballed as opposed to removed because the logic might be
+// needed if we want to support distributed tracing in lambda functions without
+// code modification. the code needs a few tweaks but is pretty close.
+//
+// internal function that makes a decision about whether to report a trace error
+// for the span. the summary is "report an error if the lambda runtime will return
+// an error to the end user". it also detects conditions in which the lambda runtime
+// will report an error.
+//
+//Span.prototype._injectLambdaReturn = function (ret) {
+//  log.span('attempting lambda header insertion:%s', this.topSpan);
+//
+//  if (!ret || typeof ret.then !== 'function') {
+//    log.debug('span runner return value not then-able');
+//    return ret;
+//  }
+//
+//  // there are two things that have to be done here. if span.returnXtraceHeader is
+//  // set then, if possible, inject an xtrace header into the response. and if the
+//  // return value indicates an error response to the end user, then add error KVs
+//  // to the span.
+//
+//  return ret
+//    .then(r => {
+//      // in lambda promises that resolve to an Error generate errors.
+//      if (r instanceof Error) {
+//        this.setExitError(r);
+//        return r;
+//      }
+//
+//      if (!r || typeof r !== 'object') {
+//        // nothing to do if it's version 1. the response must be correct or the apig will return
+//        // a 500 status, so this span gets an exit error.
+//        if (this.topSpan === 'lambda-api-gateway-v1') {
+//          const e = new LambdaExitError('InvalidV1Response', `response not valid for V1 API Gateway ${r}`);
+//          this.setExitError(e);
+//          return r;
+//        }
+//
+//        if (this.returnXtraceHeader) {
+//          log.span('injecting status code and headers');
+//          // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+//          // it's v2 - supply a statusCode so lambda won't interpret this object
+//          // as the body and add a headers object. r is the body.
+//          r = {statusCode: 200, body: r, headers: {}};
+//        }
+//      } else if (this.topSpan === 'lambda-api-gateway-v2' && !('statusCode' in r)) {
+//        // it is an object but doesn't have a statusCode property. apig would interpret this as the
+//        // body and stringify it, so do the same, wrapping it in an object with statusCode and headers.
+//        if (this.returnXtraceHeader) {
+//          log.span('injecting status code, headers, and stringifying');
+//          try {
+//            r = {statusCode: 200, body: JSON.stringify(r), headers: {}};
+//          } catch (e) {
+//            // if this fails it must be JSON.stringify(), so make an error on the span and don't
+//            // replace r. capturing the error should be more informative than apig's 500.
+//            this.setExitError(e);
+//          }
+//        }
+//      } else if (!('headers' in r)) {
+//        // it is an object, it has a statusCode property but not a headers object property.
+//        if (r.statusCode >= 500 && r.statusCode <= 599) {
+//          const e = new LambdaExitError('statusCode500', `response statusCode set to ${r.statusCode}`);
+//          this.setExitError(e);
+//        }
+//        if (this.returnXtraceHeader) {
+//          log.span('injecting headers');
+//          r.headers = {};
+//        }
+//      } else if (typeof r.headers !== 'object') {
+//        // TODO BAM does this generate an apig error?
+//        log.span('found non-object headers, skipping injection');
+//        // if headers is present but not an object don't replace it.
+//        return r;
+//      }
+//
+//      if (this.returnXtraceHeader) {
+//        const lastEvent = this.events.exit;
+//        if (lastEvent) {
+//          log.debug('set ret.headers.x-trace = %e', lastEvent);
+//          r.headers['x-trace'] = lastEvent.toString();
+//        }
+//      }
+//      return r;
+//    });
+//}
 
 /**
  * Run a sync function within the context of this span.

--- a/lib/span.js
+++ b/lib/span.js
@@ -278,6 +278,7 @@ Span.prototype.runPromise = async function (pfunc, options) {
       if (this.isLambdaTopSpan()) {
         // check all permutations of error returns and inject headers as specified.
         this._lambdaPreExitProcessing(r, kvpairs);
+        this.exit(kvpairs);
       } else {
         this.exitCheckingError(error, kvpairs);
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "metrics",
     "apm"
   ],
-  "license": "SEE LICENSE IN https://docs.appoptics.com/kb/apm_tracing/librato-open-license/",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/appoptics/appoptics-apm-node"
@@ -75,7 +75,7 @@
     "express": "^4.16.4",
     "generic-pool": "^3.7.1",
     "hapi": "^18.1.0",
-    "jsdoc-to-markdown": "^4.0.1",
+    "jsdoc-to-markdown": "^6.0.1",
     "koa": "^2.13.0",
     "koa-ejs": "^4.2.0",
     "koa-resource-router": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appoptics-apm",
   "version": "9.0.0",
   "appoptics": {
-    "version-suffix": "lambda-23"
+    "version-suffix": "lambda-24"
   },
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "appoptics": {
     "version-suffix": "lambda-27"
   },
@@ -103,7 +103,7 @@
     "should": "^8.3.1",
     "supertest": "^3.4.2",
     "tedious": "^6.6.2",
-    "testeachversion": "^8.7.1",
+    "testeachversion": "^9.0.0",
     "vision": "^5.4.4",
     "winston": "^3.2.1",
     "winston-transport": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appoptics-apm",
   "version": "9.0.0",
   "appoptics": {
-    "version-suffix": "lambda-22"
+    "version-suffix": "lambda-23"
   },
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appoptics-apm",
   "version": "9.0.0",
   "appoptics": {
-    "version-suffix": "lambda-24"
+    "version-suffix": "lambda-25"
   },
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "appoptics-apm",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "appoptics": {
-    "version-suffix": "lambda-20"
+    "version-suffix": "lambda-21"
   },
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appoptics-apm",
   "version": "9.0.0",
   "appoptics": {
-    "version-suffix": "lambda-26"
+    "version-suffix": "lambda-27"
   },
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appoptics-apm",
   "version": "9.0.0",
   "appoptics": {
-    "version-suffix": "lambda-25"
+    "version-suffix": "lambda-26"
   },
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appoptics-apm",
   "version": "9.0.0",
   "appoptics": {
-    "version-suffix": "lambda-21"
+    "version-suffix": "lambda-22"
   },
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",

--- a/test.sh
+++ b/test.sh
@@ -152,30 +152,43 @@ executeTestGroup "PROBES" "test/probes/*.test.js"
 [ $SUITES_SKIPPED -ne 1 ] && sss=s
 [ ${#SKIPPED[*]} -ne 1 ] && gss=s
 
+if [ -t 1 ]; then
+    NC='\033[0m'
+    RED='\033[1;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+else
+    NC=''
+    RED=''
+    GREEN=''
+    YELLOW=''
+fi
+
 echo "$"
+# shellcheck disable=2059
 if [ ${#ERRORS[*]} -ne 0 ]; then
-    echo "$SUITES_PASSED suite${sps} in $GROUPS_PASSED group${gps} passed"
-    echo "$SUITES_FAILED suite${sfs} in ${#ERRORS[*]} group${gfs} failed"
+    printf "${GREEN}$SUITES_PASSED suite${sps} in $GROUPS_PASSED group${gps} passed${NC}\n"
+    printf "${RED}$SUITES_FAILED suite${sfs} in ${#ERRORS[*]} group${gfs} failed${NC}\n"
     for ix in "${!ERRORS[@]}"
     do
-        echo "    ${ERRORS[$ix]}"
+        printf "${RED}    ${ERRORS[$ix]}${NC}\n"
     done
     if [ $SUITES_SKIPPED -ne 0 ]; then
-        echo "$SUITES_SKIPPED suite${sss} in ${#SKIPPED[*]} group${gss} skipped"
+        printf "${YELLOW}$SUITES_SKIPPED suite${sss} in ${#SKIPPED[*]} group${gss} skipped${NC}\n"
         for ix in "${!SKIPPED[@]}"
         do
-            echo "    ${SKIPPED[$ix]}"
+            printf "${YELLOW}    ${SKIPPED[$ix]}${NC}\n"
         done
     fi
 
     exit 1
 else
-    echo "No errors - $SUITES_PASSED suite${sps} in $GROUPS_PASSED group${gps} passed"
+    printf "${GREEN}No errors - $SUITES_PASSED suite${sps} in $GROUPS_PASSED group${gps} passed${NC}\n"
     if [ $SUITES_SKIPPED -ne 0 ]; then
-        echo "$SUITES_SKIPPED suite${sss} in ${#SKIPPED[*]} group${gss} skipped"
+        printf "${YELLOW}$SUITES_SKIPPED suite${sss} in ${#SKIPPED[*]} group${gss} skipped${NC}\n"
         for ix in "${!SKIPPED[@]}"
         do
-            echo "    ${SKIPPED[$ix]}"
+            printf "${YELLOW}    ${SKIPPED[$ix]}${NC}\n"
         done
     fi
     exit 0

--- a/test/context-no-mocha.test.js
+++ b/test/context-no-mocha.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const expect = require('chai').expect;
+const ao = require('..')
+
+const gc = global.gc || (() => true);
+
+async function t1 (main) {
+  // the promise-returning function for the span
+  function psoon (...args) {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => resolve(args), 100);
+      //soon(() => {
+      //  resolve(args)
+      //});
+    })
+  }
+
+  const pa = new Promise((resolve, reject) => {
+    resolve();
+  });
+
+  let p;
+  // promiseStartOrContinueTrace. psoon's ...args are used to resolve the promise.
+  const res = ao.pStartOrContinueTrace(
+    null,
+    main,                           // span name
+    () => p = psoon(1, 2, 3, 5),    // promise-returning runner
+    {enabled: true},
+  );
+
+  expect(res).instanceOf(Promise);
+
+  // wait for the span and the checks to complete then verify the result.
+  return Promise.all([pa, res, p]).then(r => {
+    expect(r[1]).equal(r[2]);
+    return res.then(res => {
+      expect(res).deep.equal([1, 2, 3, 5]);
+      return res;
+    });
+  });
+}
+
+function output (...args) {
+  process._rawDebug(...args);
+}
+
+const noopsCollect = false;
+
+let ix = 0;
+const tests = [
+  noop,
+  noop,
+  noop,
+  t1,
+  t1,
+  t1,
+  noop,
+  noop,
+  noop,
+  done,
+];
+
+let doneFlag = false;
+
+async function noop () {
+  if (noopsCollect) gc();
+  return ['noop', `test-${ix}`, [...ao.requestStore._contexts.keys()]]
+}
+async function done () {
+  doneFlag = true;
+  return ['set doneFlag', `test-${ix}`, [...ao.requestStore._contexts.keys()]];
+}
+
+output('start', [...ao.requestStore._contexts.keys()]);
+
+const i0 = setInterval(function () {
+  output('separate', ao.lastEvent);
+  if (doneFlag) clearInterval(i0);
+}, 1000);
+
+const interval = setInterval(function () {
+  if (ix < tests.length) {
+    tests[ix](`test-${ix}`)
+      .then(r => {
+        output('done', ...r);
+        ix += 1;
+      });
+  } else {
+    output('clearing interval 1', [...ao.requestStore._contexts.keys()]);
+    clearInterval(interval);
+  }
+}, 1000);
+
+let counter = 0;
+const i2 = setInterval(function () {
+  if (!doneFlag) {
+    return;
+  }
+
+  if (++counter > 3) {
+    output('clearing interval 2');
+    clearInterval(i2);
+    expect(ao.lastEvent).equal(undefined);
+    expect([...ao.requestStore._contexts.keys()]).property('length', 0);
+  }
+  output('countdown', ao.lastEvent, [...ao.requestStore._contexts.keys()]);
+  gc();
+}, 3000);
+

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -1,9 +1,10 @@
 'use strict'
+const ao = require('..')
+const fs = require('fs');
 const Emitter = require('events').EventEmitter
 const helper = require('./helper')
 const should = require('should')
 const expect = require('chai').expect;
-const ao = require('..')
 const aob = ao.addon;
 const Span = ao.Span
 const Event = ao.Event
@@ -17,7 +18,7 @@ const soon = global.setImmediate || process.nextTick;
 
 function psoon () {
   return new Promise((resolve, reject) => {
-    soon(() => resolve())
+    soon(resolve);
   })
 }
 
@@ -66,6 +67,8 @@ if (aob.version === 'not loaded') {
   return
 }
 
+ao.requestStore.captureHooks = false;
+
 //================================
 // custom tests with addon enabled
 //================================
@@ -79,19 +82,23 @@ describe('custom', function () {
   let main
 
   after(function () {
-    ao.loggers.debug(`enters ${ao.Span.entrySpanEnters} exits ${ao.Span.entrySpanExits}`)
-  })
+    ao.loggers.debug(`enters ${ao.Span.entrySpanEnters} exits ${ao.Span.entrySpanExits}`);
+  });
+
 
   beforeEach(function () {
     // provide up to 100 tests with a unique prefix
     pfx = ('0' + counter++).slice(-2)
     main = `${pfx}-test`
-    if (this.currentTest.title === 'x-should continue from previous trace id') {
-      ao.logLevelAdd('test:messages,event:*')
+  });
+
+  beforeEach(function () {
+    if (this.currentTest.title === 'should continue from previous trace id') {
+      //ao.logLevelAdd('test:*');
     } else {
-      ao.logLevelRemove('test:messages,event:*')
+      //ao.logLevelRemove('test:span');
     }
-  })
+  });
 
   //
   // Intercept appoptics messages for analysis
@@ -100,12 +107,15 @@ describe('custom', function () {
     ao.sampleRate = aob.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
     emitter = helper.appoptics(done)
-  })
+  });
   afterEach(function (done) {
     Span.sendNonHttpSpan = oSpanSendNon
     Event.send = oEventSend
     emitter.close(done)
-  })
+  });
+  // clear any debug marker
+  afterEach(() => delete helper.checkLogMessages.debug);
+
 
   // this test exists only to fix a problem with oboe not reporting a UDP
   // send failure.
@@ -472,11 +482,11 @@ describe('custom', function () {
 
       const logChecks = [
         {level: 'error', message: 'ao.instrument() run function is'},
-        {level: 'error', message: 'ao.runInstrument found no span name or span-info function'},
+        {level: 'error', message: 'ao.runInstrument found no span name or span-info()'},
         {level: 'error', message: 'ao.runInstrument failed to build span'},
         {level: 'error', message: 'ao.runInstrument failed to build span'},
-        {level: 'error', message: 'no name supplied to runInstrument by span-maker function'},
-      ]
+        {level: 'error', message: 'no name supplied to runInstrument by span-info()'},
+      ];
       helper.checkLogMessages(logChecks)
 
       // Verify nothing bad happens when run function is missing
@@ -503,9 +513,10 @@ describe('custom', function () {
     }, [], done)
   })
 
-  it('promise version should fail gracefully when invalid arguments are given', function (done) {
+  it('promise version should fail gracefully when invalid arguments are given', function (tdone) {
     helper.test(emitter, function (done) {
       function build (span) {return {name: main}}
+      // (i)nstrument, (s)tartOrContinueTrace
       const expected = ['ibuild', 'irun', 'sbuild', 'srun']
       const found = []
       let i = 0
@@ -519,41 +530,62 @@ describe('custom', function () {
       function run () {}
       let count = 0
 
+      const missing = undefined;
+
+      // just make the messages a little shorter.
+      const psoct = 'pStartOrContinueTrace';
       const logChecks = [
+        // verify nothing bad happens when run function is missing
         {level: 'error', message: 'ao.instrument() run function is'},
-        {level: 'error', message: 'ao.runInstrument found no span name or span-info function'},
+        {level: 'error', message: `${psoct} requires function, not ${typeof missing}`},
+        // verify nothing bad happens when spanInfo() is missing
+        {level: 'error', message: 'ao.runInstrument found no span name or span-info()'},
+        {level: 'error', message: `${psoct} span argument must be a string or function, not ${typeof protoSpan}`},
+        // verify the runner is still run when spanInfo fails to return a correct object
         {level: 'error', message: 'ao.runInstrument failed to build span'},
-        {level: 'error', message: 'ao.runInstrument failed to build span'},
-        {level: 'error', message: 'no name supplied to runInstrument by span-maker function'},
-      ]
-      helper.checkLogMessages(logChecks)
+        {level: 'error', message: `${psoct} span-info bad values: name`},
+        // verify the runner is still run when spanInfo() fails to return a name
+        {level: 'error', message: 'no name supplied to runInstrument by span-info()'},
+        {level: 'error', message: `${psoct} span-info bad values: name`},
+      ];
+
+      const [getCount] = helper.checkLogMessages(logChecks);
+      //helper.checkLogMessages.debug = true;
 
       // Verify nothing bad happens when run function is missing
-      ao.pInstrument(build)
-      ao.pStartOrContinueTrace(null, build)
+      ao.pInstrument(build, missing);
+      ao.pStartOrContinueTrace(null, build, missing);
 
-      // Verify nothing bad happens when build function is missing
-      ao.pInstrument(null, run)
-      ao.pStartOrContinueTrace(null, null, run)
+      // Verify nothing bad happens when spanInfo is missing
+      ao.pInstrument(missing, run);
+      ao.pStartOrContinueTrace(null, missing, run);
 
-      // Verify the runner is still run when spaninfo fails to return an object
+      // Verify the runner is still run when spanInfo() fails to return an object
       ao.pInstrument(getInc(), getInc())
       ao.pStartOrContinueTrace(null, getInc(), getInc())
-      found.should.deepEqual(expected)
-      count.should.equal(4)
 
-      expected.push('nnrun')
-      // Verify the runner is still run when spaninfo fails to return a name
-      ao.pInstrument(function () {return {}}, getInc())
-      found.should.deepEqual(expected)
-      count.should.equal(5)
+      expect(found).deep.equal(expected);
+      expect(count).equal(4);
+
+      // (n)o (n)ame run...
+      expected.push('nnrun');
+      expected.push('nnrun');
+      // Verify the runner is still run when spanInfo() fails to return a name
+      ao.pInstrument(function () {return {}}, getInc());
+      ao.pStartOrContinueTrace(null, () => {return {}}, getInc());
+
+      expect(found).deep.equal(expected);
+      expect(count).equal(6);
+
+      // verify that all the log messages where checked.
+      expect(getCount()).equal(logChecks.length, 'all error messages should have been checked');
 
       done()
-    }, [], done)
+    }, [], tdone);
   })
 
   it('should handle errors correctly between spanInfo and run functions', function (done) {
-    helper.test(emitter, function (done) {
+    helper.test(emitter, function (tdone) {
       const err = new Error('nope')
       function build (span) {return {name: main}}
       function nope () {count++; throw err}
@@ -582,7 +614,7 @@ describe('custom', function () {
       }, validateError)
       count.should.equal(2)
 
-      done()
+      tdone();
     }, [], done)
   })
 
@@ -691,60 +723,156 @@ describe('custom', function () {
   })
 
   it('should start a fresh trace for a promise function', function () {
-
-    // wait for the promise-returning run function and the message checks to finish
-    const all = []
-
-    // the promise-returning run function
+    // the promise-returning function for the span
     function psoon (...args) {
       return new Promise((resolve, reject) => {
-        soon(() => resolve(args))
-      })
+        setTimeout(() => resolve(args), 100);
+      });
     }
 
-    let done;
-    all.push(new Promise((resolve, reject) => {
-      done = function () {
-        resolve()
-      }
-    }))
+    let last;
+    const pa = new Promise((resolve, reject) => {
+      helper.doChecks(emitter, [
+        function (msg) {
+          expect(msg).property('Layer', main);
+          expect(msg).property('Label', 'entry');
+          expect(msg).property('SampleSource');
+          expect(msg).property('SampleRate');
+          expect(msg).not.property('Edge');
+          last = msg['X-Trace'].substr(42, 16);
+        },
+        function (msg) {
+          expect(msg).property('Layer', main);
+          expect(msg).property('Label', 'exit');
+          expect(msg).property('Edge', last);
+        }
+      ], resolve);
+    });
 
-    let last
-    helper.doChecks(emitter, [
-      function (msg) {
-        msg.should.have.property('Layer', main)
-        msg.should.have.property('Label', 'entry')
-        msg.should.have.property('SampleSource')
-        msg.should.have.property('SampleRate')
-        msg.should.not.have.property('Edge')
-        last = msg['X-Trace'].substr(42, 16)
-      },
-      function (msg) {
-        msg.should.have.property('Layer', main)
-        msg.should.have.property('Label', 'exit')
-        msg.Edge.should.equal(last)
-      }
-    ], done)
-
-    // promise-startOrContinueTrace. psoon's ...args are used to resolve the promise.
+    let p;
+    // pStartOrContinueTrace. psoon's ...args are used to resolve the promise.
     const res = ao.pStartOrContinueTrace(
       null,
       main,                           // span name
-      () => psoon(1, 2, 3, 5),        // promise-returning runner
-      conf                            // configuration
-    )
+      () => p = psoon(1, 2, 3, 5),    // promise-returning runner
+      Object.assign({forceNewTrace: true}, conf)                            // configuration
+    );
 
-    res.should.instanceof(Promise)
+    expect(res).instanceOf(Promise);
 
-    // wait for both but care only about res
-    all.push(res)
-    return Promise.all(all).then(r => {
+    // wait for the span and the checks to complete then verify the result.
+    return Promise.all([pa, res, p]).then(r => {
+      expect(r[1]).equal(r[2]);
       return res.then(res => {
-        res.should.eql([1, 2, 3, 5])
+        expect(res).deep.equal([1, 2, 3, 5], 'the function return value should be returned');
         return res;
-      })
-    })
-  })
+      });
+    });
+  });
+
+  it('should start and descend using pStartOrContinueTrace', function () {
+    // the promise-returning function for the span
+    let p;
+    let rdResult;
+    async function task () {
+      const p1 = ao.pStartOrContinueTrace(null, 'psooner', psoon)
+      const p2 = new Promise((resolve, reject) => {
+        fs.readdir('.', (error, files) => {
+          if (error) {
+            reject(error);
+          } else {
+            rdResult = files;
+            resolve(files);
+          }
+        });
+      });
+      return p = Promise.all([p1, p2]);
+    }
+
+    function psoon () {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => resolve(), 1000);
+      });
+    }
+
+    // it's possible that reading the directory could take longer than the
+    // psoon 1000ms timeout. if that's the case then 1) either make the timeout
+    // longer or 2) capture the order of completion and have the following
+    // checks take that into consideration.
+    let last;
+    let psoonEntry;
+    const pa = new Promise((resolve, reject) => {
+      helper.doChecks(emitter, [
+        function (msg) {
+          expect(msg).property('X-Trace');
+          expect(`${main}:${msg.Label}`).equal(`${main}:entry`);
+          expect(msg).property('SampleSource');
+          expect(msg).property('SampleRate');
+          expect(msg).not.property('Edge');
+          last = new Last(msg['X-Trace']);
+        },
+        function (msg) {
+          expect(msg).property('X-Trace');
+          expect(`${msg.Layer}:${msg.Label}`).equal('psooner:entry');
+          psoonEntry = last = new Last(msg['X-Trace']);
+        },
+        function (msg) {
+          expect(msg).property('X-Trace');
+          expect(`${msg.Layer}:${msg.Label}`).equal('fs:entry');
+          expect(msg).property('Spec', 'filesystem');
+          expect(msg).property('Operation', 'readdir');
+          expect(msg).property('FilePath', '.');
+          expect(msg).property('Async', true);
+          const curr = new Last(msg['X-Trace']);
+          expect(curr.taskId()).equal(last.taskId(), 'task ID must match');
+          expect(msg).property('Edge', last.opId());
+          last = curr;
+        },
+        function (msg) {
+          expect(msg).property('X-Trace');
+          expect(`${msg.Layer}:${msg.Label}`).equal('fs:exit');
+          const curr = new Last(msg['X-Trace']);
+          expect(curr.taskId()).equal(last.taskId(), 'task ID must match');
+          expect(msg).property('Edge', last.opId());
+          last = curr;
+        },
+        function (msg) {
+          expect(`${msg.Layer}:${msg.Label}`).equal('psooner:exit');
+          expect(msg).property('Edge', psoonEntry.opId());
+          last = new Last(msg['X-Trace']);
+        },
+        function (msg) {
+          expect(msg).property('X-Trace');
+          expect(msg).property('Layer', main);
+          expect(msg).property('Label', 'exit');
+          expect(msg).property('Edge', last.opId());
+          const curr = new Last(msg['X-Trace']);
+          expect(curr.taskId()).equal(last.taskId(), 'task ID must match');
+          last = curr;
+        }
+      ], resolve);
+    });
+
+    // pStartOrContinueTrace.
+    const res = ao.pStartOrContinueTrace(
+      null,
+      main,                           // span name
+      task,                           // promise-returning runner
+      Object.assign({forceNewTrace: true}, conf)                            // configuration
+    );
+
+    expect(res).instanceOf(Promise);
+
+    // wait for the span and the checks to complete then verify the result.
+    return Promise.all([pa, res, p]).then(r => {
+      expect(r[1]).equal(r[2]);
+      return res.then(res => {
+        // because res is the result of Promise.all() only compare the second element.
+        expect(res[1]).deep.equal(rdResult, 'the function return value should be returned');
+        return res;
+      });
+    });
+  });
 
   // Verify startOrContinueTrace continues from provided trace id.
   it('should continue from previous trace id', function (done) {
@@ -753,27 +881,23 @@ describe('custom', function () {
 
     helper.doChecks(emitter, [
       function (msg) {
-        msg.should.have.property('Layer', 'x-previous')
-        msg.should.have.property('Label', 'entry')
+        expect(`${msg.Layer}:${msg.Label}`).equal('x-previous:entry');
         msg.should.not.have.property('Edge')
       },
       function (msg) {
-        msg.should.have.property('Layer', main)
-        msg.should.have.property('Label', 'entry')
+        expect(`${msg.Layer}:${msg.Label}`).equal(`${main}:entry`);
         msg.should.not.have.property('SampleSource')
         msg.should.not.have.property('SampleRate')
         msg.Edge.should.equal(entry.opId)
         last = msg['X-Trace'].substr(42, 16)
       },
       function (msg) {
-        msg.should.have.property('Layer', main)
-        msg.should.have.property('Label', 'exit')
+        expect(`${msg.Layer}:${msg.Label}`).equal(`${main}:exit`);
         msg.Edge.should.equal(last)
         last = msg['X-Trace'].substr(42, 16)
       },
       function (msg) {
-        msg.should.have.property('Layer', 'x-previous')
-        msg.should.have.property('Label', 'exit')
+        expect(`${msg.Layer}:${msg.Label}`).equal('x-previous:exit');
         msg.Edge.should.equal(entry.opId)
       }
     ], done)
@@ -801,7 +925,7 @@ describe('custom', function () {
         )
         pcb()
       },
-      conf,                         // config
+      Object.assign({forceNewTrace: true}, conf),                         // config
       function () {                 // done function
       }
     )
@@ -813,7 +937,7 @@ describe('custom', function () {
     // make the container span.
     const previous = Span.makeEntrySpan('previous', makeSettings())
     // don't let this act like a real entry span
-    delete previous.topSpan
+    previous.topSpan = undefined;
 
     const entry = previous.events.entry
     const taskId = previous.events.entry.taskId;
@@ -907,8 +1031,8 @@ describe('custom', function () {
   })
 
   // Verify startOrContinueTrace handles a false sample check correctly.
-  it('should sample properly', function (done) {
-    const realSample = aob.Context.getTraceSettings
+  it('should sample properly', function () {
+    const realGetTraceSettings = aob.Context.getTraceSettings;
     let called = false
 
     aob.Context.getTraceSettings = function () {
@@ -923,88 +1047,107 @@ describe('custom', function () {
       {level: 'error', message: 'task IDs don\'t match'},
       {level: 'error', message: 'outer:exit 2b-'},
     ]
-    helper.checkLogMessages(logChecks)
+    const [getCount, clearChecks] = helper.checkLogMessages(logChecks);
 
-    helper.test(
-      emitter,
-      function (done) {             // test function
-        ao.lastSpan = ao.lastEvent = null
-        ao.startOrContinueTrace(null, 'sample-properly', setImmediate, conf, done)
-      },
-      [],                           // checks
-      function (err) {
-        called.should.equal(true, 'the sample function should be called')
-        aob.Context.getTraceSettings = realSample
-        done(err)
-      }
-    )
-  })
+    return new Promise((resolve, reject) => {
+      helper.test(
+        emitter,
+        function (done) {             // test function
+          ao.lastSpan = ao.lastEvent = null;
+          ao.startOrContinueTrace(null, 'sample-properly', setImmediate, conf, done);
+        },
+        [() => undefined, () => undefined],                           // checks
+        function (err) {
+          aob.Context.getTraceSettings = realGetTraceSettings;
+          expect(called).equal(true, 'the sample function should be called');
+          if (err) {
+            reject(err);
+          } else {
+            expect(getCount()).equal(2, 'expected 2 log messages');
+            clearChecks();
+            resolve();
+          }
+        }
+      );
+    });
+  });
 
   // Verify traceId getter works correctly
   it('should get traceId when tracing and null when not', function () {
-    should.not.exist(ao.traceId)
-    ao.startOrContinueTrace(
-      null,
-      main,
-      function (cb) {
-        should.exist(ao.traceId)
-        cb()
-      },
-      function () {
-        should.exist(ao.traceId)
-      }
-    )
-    should.not.exist(ao.traceId)
+    ao.requestStore.run(function () {
+      expect(ao.traceId).not.exist;
+      expect(ao.tracing).equal(false);
+      ao.startOrContinueTrace(
+        null,
+        main,
+        function (cb) {
+          should.exist(ao.traceId);
+          cb();
+        },
+        function () {
+          should.exist(ao.traceId);
+        }
+      )
+      should.not.exist(ao.traceId);
+    }, {newContext: true});
+
   })
 
   // it should handle bad bind arguments gracefully and issue warnings.
   it('should handle bad bind arguments correctly', function () {
-    const bind = ao.requestStore.bind
-    let threw = false
-    let called = false
+    const bind = ao.requestStore.bind;
+    let threw = false;
+    const sequence = [];
 
-    ao.requestStore.bind = function () {
-      called = true
-    }
+    ao.requestStore.run(function () {
+      let called = false;
 
-    function noop () {}
+      ao.requestStore.bind = function () {
+        called = true;
+      }
 
-    const logChecks = [
-      {level: 'warn', message: 'ao.bind(%s) - no context', values: ['noop']},
-      {level: 'warn', message: 'ao.bind(%s) - not a function', values: [null]},
-    ]
-    helper.checkLogMessages(logChecks)
+      function noop () {}
 
-    try {
-      ao.bind(noop)
-      called.should.equal(false)
-      const span = Span.makeEntrySpan(main, makeSettings())
-      // don't let it try to send metrics
-      span.doMetrics = false;
-      span.run(function () {
-        ao.bind(null)
-        called.should.equal(false)
-        ao.bind(noop)
-        called.should.equal(true)
-      })
-    } catch (e) {
-      threw = true
-    }
+      const logChecks = [
+        {level: 'warn', message: 'ao.bind(%s) - no context', values: ['noop']},
+        {level: 'warn', message: 'ao.bind(%s) - not a function', values: [null]},
+      ]
+      helper.checkLogMessages(logChecks);
+
+
+      try {
+        ao.bind(noop);
+        sequence.push(called);
+        called = false;
+        const span = Span.makeEntrySpan(main, makeSettings());
+        // don't let it try to send metrics
+        span.doMetrics = false;
+        span.run(function () {
+          ao.bind(null);
+          sequence.push(called);
+          called = false;
+          ao.bind(noop);
+          sequence.push(called);
+        });
+      } catch (e) {
+        threw = true;
+      }
+    }, {newContext: true});
 
     ao.requestStore.bind = bind
 
-    threw.should.equal(false)
+    expect(sequence).deep.equal([false, false, true]);
+    expect(threw).equal(false, 'there should not have been an exception');
   })
 
   it('should bind emitters to requestStore', function () {
     const bindEmitter = ao.requestStore.bindEmitter
-    let threw = false
+    let threw;
     let called = false
 
-    ao.requestStore.bindEmitter = function () {
+    function captureCall () {
       called = true
     }
-
     const emitter = new Emitter()
 
     // this is a little tricky - bind emitter errors are debounced so not every
@@ -1016,22 +1159,26 @@ describe('custom', function () {
     helper.checkLogMessages(logChecks)
 
     try {
+      ao.resetRequestStore();
+      // reset requestStore resets bindEmitter, so don't replace it with captureCall
+      // until after resetting the request store.
+      ao.requestStore.bindEmitter = captureCall;
       ao.bindEmitter(emitter)
-      called.should.equal(false)
+      called.should.equal(false, 'bindEmitter should not have been called when no context');
       const span = Span.makeEntrySpan(main, makeSettings())
       span.run(function () {
         ao.bindEmitter(null)
-        called.should.equal(false)
+        called.should.equal(false, 'bindEmitter should not have been called for null');
         ao.bindEmitter(emitter)
-        called.should.equal(true)
+        called.should.equal(true, 'bindEmitter should be called for an emitter');
       })
     } catch (e) {
-      threw = true
+      threw = e.message;
     }
 
     ao.requestStore.bindEmitter = bindEmitter
 
-    threw.should.equal(false)
+    expect(threw).not.exist;
   })
 
   it('should support instrumentHttp', function (done) {
@@ -1112,5 +1259,28 @@ describe('custom', function () {
     }, 250)
   })
 
-})
+  it('should not have leftover context', function () {
+
+  })
+
+});
+
+class Last {
+  constructor (xtrace) {
+    this.xtrace = xtrace.toUpperCase();
+    if (!this.xtrace.startsWith('2B')) {
+      throw new Error(`doesn't start with '2B': ${xtrace}`);
+    }
+  }
+  taskId () {
+    return this.xtrace.substr(2, 40);
+  }
+  opId () {
+    return this.xtrace.substr(42, 16);
+  }
+  flags () {
+    return this.xtrace.slice(-2);
+  }
+
+}
 

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -537,7 +537,7 @@ describe('custom', function () {
       const logChecks = [
         // verify nothing bad happens when run function is missing
         {level: 'error', message: 'ao.instrument() run function is'},
-        {level: 'error', message: `${psoct} requires function, not ${typeof missing}`},
+        {level: 'error', message: `${psoct} requires a function, not ${typeof missing}`},
         // verify nothing bad happens when spanInfo() is missing
         {level: 'error', message: 'ao.runInstrument found no span name or span-info()'},
         {level: 'error', message: `${psoct} span argument must be a string or function, not ${typeof protoSpan}`},

--- a/test/helper.js
+++ b/test/helper.js
@@ -144,9 +144,9 @@ exports.appoptics = function (done) {
   return emitter
 }
 
-exports.doChecks = function (emitter, checks, done) {
-  const addr = emitter.server.address()
-  emitter.removeAllListeners('message')
+exports.doChecks = function (emitter, checks, done, opt = {}) {
+  const addr = emitter.server.address();
+  emitter.removeAllListeners('message');
 
   log.test.info(`doChecks(${checks.length}) server address ${addr.address}:${addr.port}`)
 
@@ -155,6 +155,10 @@ exports.doChecks = function (emitter, checks, done) {
       log.test.messages('mock (' + addr.port + ') received message', msg)
     }
     const check = checks.shift()
+    if (opt.debug) {
+      // eslint-disable-next-line no-console
+      console.log('checking', check);
+    }
     if (check) {
       if (emitter.skipOnMatchFail) {
         try {
@@ -181,6 +185,10 @@ exports.doChecks = function (emitter, checks, done) {
     }
   }
 
+  if (opt.debug) {
+    // eslint-disable-next-line no-console
+    console.log('doChecks() debug on');
+  }
   emitter.on('message', onMessage)
 }
 
@@ -262,7 +270,7 @@ exports.test = function (emitter, test, validations, done) {
   // */
   // copy the caller's array so we can modify it without surprising
   // the caller.
-  validations = validations.map(e => e)
+  validations = validations.slice();
   validations.unshift(noop)
   validations.push(noop)
 
@@ -295,7 +303,7 @@ exports.test = function (emitter, test, validations, done) {
       span.exit()
       //done
     })
-  })
+  }, {newContext: true});
 }
 
 exports.httpTest = function (emitter, test, validations, done) {
@@ -508,6 +516,8 @@ function checkLogMessages (checks) {
     if (!(level in levelsToCheck && counter < checks.length)) {
       return
     }
+    // eslint-disable-next-line no-debugger
+    if (checkLogMessages.debug) debugger;
     const check = checks[counter++]
     // catch errors so this logger isn't left in place after an error is found
     try {

--- a/test/lambda/get-lambda-version.js
+++ b/test/lambda/get-lambda-version.js
@@ -1,16 +1,18 @@
 'use strict';
 
-const fsp = require('fs').promises;
+const fs = require('fs');
 
 //
 // this is modified from the apm-node-lambda-layer/util/get-lambda-version.js
 //
 // the main difference is that this does not write the modified version into package.json.
 //
+// it also reads synchronously and doesn't write to the console.
+//
 // append '-version-suffix' to the version and return that.
 //
-async function getLambdaVersion (file) {
-  const bytes = await fsp.readFile(file, 'utf8');
+function getLambdaVersion (file) {
+  const bytes = fs.readFileSync(file, 'utf8');
   const pkg = JSON.parse(bytes);
 
   // lambda releases will be numbered by the existing version number with a

--- a/test/lambda/get-lambda-version.js
+++ b/test/lambda/get-lambda-version.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const fsp = require('fs').promises;
+
+//
+// this is modified from the apm-node-lambda-layer/util/get-lambda-version.js
+//
+// the main difference is that this does not write the modified version into package.json.
+//
+// append '-version-suffix' to the version and return that.
+//
+async function getLambdaVersion (file) {
+  const bytes = await fsp.readFile(file, 'utf8');
+  const pkg = JSON.parse(bytes);
+
+  // lambda releases will be numbered by the existing version number with a
+  // version suffix appended.
+  if (!pkg.version || !pkg.appoptics || !pkg.appoptics['version-suffix']) {
+    throw new Error('expected to find version and appoptics.version-suffix properties')
+  }
+
+  // combine and return
+  return `${pkg.version}-${pkg.appoptics['version-suffix']}`;
+}
+
+module.exports = getLambdaVersion;

--- a/test/lambda/local-tests.js
+++ b/test/lambda/local-tests.js
@@ -5,6 +5,19 @@ const util = require('util');
 
 const aoLambdaTest = 'ao-lambda-test';
 
+//
+// structure - fakeLambdaPromise and fakeLambdaCallbacker are invoked by one
+// of the "agent<x>P" and "agent<x>CB" functions. The property "ao-lambda-test"
+// might be added to the context object to modify the default behavior of the
+// fake<x> functions.
+//
+// if "ao-lambda-test" is empty the functions with return {statusCode: 200}.
+//
+// "ao-lambda-test" can specify that fakeLambdaPromiser reject with a specific
+// value, throw with a specific string, or resolve with a different value. for
+// fakeLambdaCallbacker it can specify an error to return via the callback, an
+// exception to throw, or a resolve value.
+//
 async function fakeLambdaPromiser (event, context) {
   if (typeof event !== 'object') {
     throw new TypeError('event must be an object in the handler');
@@ -68,6 +81,11 @@ function fakeLambdaCallbacker (event, context, callback) {
   // callback using "lambda-supplied" callback
   callback(error, response);
 }
+
+//
+// decode the input from command line json and invoke the
+// requested function.
+//
 
 const aos = Symbol.for('AppOptics.Apm.Once');
 

--- a/test/lambda/local.test.js
+++ b/test/lambda/local.test.js
@@ -34,8 +34,7 @@ const {aoLambdaTest} = require(testFile);
 // need to spawn task executing runnable script so stdout/stderr are captured.
 // task should be a function in a module that is wrapped by our code.
 // the function should execute an async outbound http call and a sync span
-// verify that the events are correct (first pass - event count is right)
-//   then decode base64/bson events
+// verify that the events are correct.
 //
 
 const xTraceS = '2B9F41282812F1D348EE79A1B65F87656AAB20C705D5AD851C0152084301';

--- a/test/lambda/local.test.js
+++ b/test/lambda/local.test.js
@@ -133,11 +133,12 @@ describe('test lambda promise functions with mock apig events', function () {
   });
 
   const tests = [{
-    desc: 'apig-${version}${x-trace-clause} should insert x-trace header',
+    desc: 'apig-${version}${x-trace-clause} insert x-trace when headers are present',
     test: 'agentEnabledP',
     xtrace: xTraceS,
     options: {},
-    debug: ['stderr'],
+    //debug: ['stdout'],
+    modifiers: {resolve: {statusCode: 200, headers: {'x-bruce': 'headers present'}}},
     testDataChecks (o) {
       expect(o.initialao).equal(false, 'the agent should not have been loaded');
       expect(o.resolve).exist;
@@ -147,10 +148,12 @@ describe('test lambda promise functions with mock apig events', function () {
       expect(o.resolve.headers['x-trace'].slice(-2)).equal('01', 'sample bit doesn\'t match');
     }
   }, {
-    desc: 'apig-${version}${x-trace-clause} should insert x-trace header',
+    desc: 'apig-${version}${x-trace-clause} insert x-trace when headers are present',
     test: 'agentEnabledP',
     xtrace: xTraceU,
-    options: {},
+    //options: {logging: 'debug,span,error,warn'},
+    //debug: ['stdout', 'stderr'],
+    modifiers: {resolve: {statusCode: 200, headers: {'x-bruce': 'headers present'}}},
     testDataChecks (o) {
       expect(o.initialao).equal(false, 'the agent should not have been loaded');
       expect(o.resolve).exist;
@@ -160,7 +163,7 @@ describe('test lambda promise functions with mock apig events', function () {
       expect(o.resolve.headers['x-trace'].slice(-2)).equal('00', 'sample bit doesn\'t match');
     }
   }, {
-    desc: 'apig-${version}${x-trace-clause} don\'t insert x-trace header',
+    desc: 'apig-${version}${x-trace-clause} don\'t insert x-trace header when no headers',
     test: 'agentEnabledP',
     xtrace: undefined,
     options: {},
@@ -171,15 +174,15 @@ describe('test lambda promise functions with mock apig events', function () {
       expect(o.resolve).not.property('headers');
     }
   }, {
-    desc: 'apig-${version} invalid v1 response does not generate an error',
+    desc: 'apig-${version} invalid v1 response generates an error',
     test: 'agentEnabledP',
     xtrace: undefined,
     modifiers: {resolve: 'invalid-resolve-value-for-v1'},
     options: {},
     extraAoDataChecks (organized) {
-      expect(organized.topEvents.exit).not.property('ErrorClass');
-      expect(organized.topEvents.exit).not.property('ErrorMsg');
-      expect(organized.topEvents.exit).not.property('Backtrace');
+      expect(organized.topEvents.exit).property('ErrorClass');
+      expect(organized.topEvents.exit).property('ErrorMsg');
+      expect(organized.topEvents.exit).property('Backtrace');
     },
     testDataChecks (o) {
       expect(o.initialao).equal(false, 'the agent should not have been loaded');
@@ -199,16 +202,17 @@ describe('test lambda promise functions with mock apig events', function () {
       const {en} = options;
       expect(o.initialao).equal(false, 'the agent should not have been loaded');
       if (en === 'v2') {
-        expect(o.resolve).property('statusCode', 200);
-        expect(o.resolve).property('body', this.modifiers.resolve);
-        expect(o.resolve).property('headers').property('x-trace').match(/2B[0-9A-F]{56}0(0|1)/);
+        expect(o.resolve).equal(this.modifiers.resolve);
+        //expect(o.resolve).property('statusCode', 200);
+        //expect(o.resolve).property('body', this.modifiers.resolve);
+        //expect(o.resolve).property('headers').property('x-trace').match(/2B[0-9A-F]{56}0(0|1)/);
       } else {
         expect(o.resolve).equal(this.modifiers.resolve);
       }
       expect(o.reject).not.exist;
     }
   }, {
-    desc: 'apig-${version} string => body (only v2)${x-trace-clause}',
+    desc: 'apig-${version} string response is not modified${x-trace-clause}',
     test: 'agentEnabledP',
     xtrace: xTraceS,
     modifiers: {resolve: 'string-resolve-value'},
@@ -217,27 +221,23 @@ describe('test lambda promise functions with mock apig events', function () {
       expect(organized.topEvents).not.deep.equal({}, 'topEvents should be present');
     },
     testDataChecks (o, options) {
-      const {en} = options;
+      //const {en} = options;
       expect(o.initialao).equal(false, 'the agent should not have been loaded');
-      if (en === 'v2') {
-        expect(o.resolve).property('statusCode', 200);
-        expect(o.resolve).property('body', this.modifiers.resolve);
-        expect(o.resolve).property('headers').property('x-trace').match(/2B[0-9A-F]{56}0(0|1)/);
-      } else {
-        expect(o.resolve).equal(this.modifiers.resolve);
-      }
+      expect(o.resolve).equal(this.modifiers.resolve);
       expect(o.reject).not.exist;
     }
   }, {
+    // this test is not so useful now that response only adds x-trace when a headers
+    // object is present.
     desc: 'apig-${version} a string is not modified when no x-trace',
     test: 'agentEnabledP',
     xtrace: undefined,
     modifiers: {resolve: 'string-resolve-value'},
     options: {},
     extraAoDataChecks (organized) {
-      expect(organized.topEvents.exit).not.property('ErrorClass');
-      expect(organized.topEvents.exit).not.property('ErrorMsg');
-      expect(organized.topEvents.exit).not.property('Backtrace');
+      expect(organized.topEvents.exit).property('ErrorClass');
+      expect(organized.topEvents.exit).property('ErrorMsg');
+      expect(organized.topEvents.exit).property('Backtrace');
     },
     testDataChecks (o, options) {
       expect(o.initialao).equal(false, 'the agent should not have been loaded');
@@ -257,34 +257,36 @@ describe('test lambda promise functions with mock apig events', function () {
       const {en} = options;
       expect(o.initialao).equal(false, 'the agent should not have been loaded');
       if (en === 'v2') {
-        expect(o.resolve).property('statusCode', 200);
-        expect(o.resolve).property('body', JSON.stringify(this.modifiers.resolve));
+        // no longer insert statusCode; requires inference of lambda's actions.
+        //expect(o.resolve).property('statusCode', 200);
+        expect(o.resolve).property('body', this.modifiers.resolve.body);
       } else {
         const resolveKeys = Object.keys(this.modifiers.resolve);
         for (const k of resolveKeys) {
           expect(o.resolve[k]).equal(this.modifiers.resolve[k]);
         }
       }
-      expect(o.resolve).property('headers').property('x-trace').match(/2B[0-9A-F]{56}0(0|1)/);
-      expect(o.resolve.headers['x-trace'].slice(-1)).equal(this.xtrace.slice(-1));
+      //expect(o.resolve).property('headers').property('x-trace').match(/2B[0-9A-F]{56}0(0|1)/);
+      //expect(o.resolve.headers['x-trace'].slice(-1)).equal(this.xtrace.slice(-1));
       expect(o.reject).not.exist;
     }
   }, {
-    desc: 'report statusCode but not error when the function rejects',
+    desc: 'report statusCode and error when the function rejects',
     test: 'agentEnabledP',
     xtrace: undefined,
     modifiers: {reject: 404},
     options: {},
     extraAoDataChecks (organized) {
-      expect(organized.topEvents.exit).not.property('ErrorClass');
-      expect(organized.topEvents.exit).not.property('ErrorMsg');
-      expect(organized.topEvents.exit).not.property('Backtrace');
+      expect(organized.topEvents.exit).property('ErrorClass');
+      expect(organized.topEvents.exit).property('ErrorMsg');
+      expect(organized.topEvents.exit).property('Backtrace');
     },
     testDataChecks (o, options) {
       expect(o.initialao).equal(false, 'the agent should not have been loaded');
       expect(o.resolve).not.exist;
       expect(o.reject).exist;
-      expect(o.reject.statusCode).equal(this.modifiers.reject, `errorCode should be ${this.modifiers.reject}`);
+      // no longer set status code when rejecting
+      expect(o.reject.statusCode).not.exist;
     }
 
   }, {
@@ -365,9 +367,9 @@ describe('test lambda callback functions with mock apig events', function () {
       expect(o.initialao).equal(false, 'the agent should not have been loaded');
       expect(o.resolve).exist;
       expect(o.resolve).property('statusCode').equal(200, 'statusCode should be 200');
-      expect(o.resolve).property('headers').an('object').property('x-trace');
-      expect(o.resolve.headers['x-trace'].slice(2, 42)).equal(this.xtrace.slice(2, 42), 'task IDs don\'t match');
-      expect(o.resolve.headers['x-trace'].slice(-1)).equal(this.xtrace.slice(-1), 'sample bit doesn\'t match');
+      //expect(o.resolve).property('headers').an('object').property('x-trace');
+      //expect(o.resolve.headers['x-trace'].slice(2, 42)).equal(this.xtrace.slice(2, 42), 'task IDs don\'t match');
+      //expect(o.resolve.headers['x-trace'].slice(-1)).equal(this.xtrace.slice(-1), 'sample bit doesn\'t match');
     }
   }];
   executeTests(tests);
@@ -562,6 +564,8 @@ function executeTests (tests) {
         const sampled = xtrace.slice(-1) === '1' ? 'sampled' : 'unsampled';
         clause = ` ${sampled} x-trace`;
         testEvent.headers['x-trace'] = xtrace;
+        // eslint-disable-next-line no-console
+        if (dbg.event) {console.log(testEvent)}
       } else {
         clause = ' no x-trace';
       }
@@ -600,7 +604,11 @@ function executeTests (tests) {
       doit(description, function () {
         const previousLogging = process.env.APPOPTICS_LOG_SETTINGS;
         if (options.logging) {
-          process.env.APPOPTICS_LOG_SETTINGS = options.logging.join(',');
+          if (Array.isArray(options.logging)) {
+            process.env.APPOPTICS_LOG_SETTINGS = options.logging.join(',');
+          } else {
+            process.env.APPOPTICS_LOG_SETTINGS = options.logging;
+          }
         }
         return exec(`node -e 'require("${testFile}").${test}(${clEvent}, ${clContext})'`)
           .then(r => {

--- a/test/lambda/remote.test.js
+++ b/test/lambda/remote.test.js
@@ -26,15 +26,16 @@ const ignoreVersions = 'AO_TEST_LAMBDA_IGNORE_VERSIONS' in process.env;
 // modifying the test descriptions after the start doesn't work.
 let apmVersion = getLambdaVersion('package.json');
 let aobVersion = getLambdaVersion('node_modules/appoptics-bindings/package.json');
+let autoVersion = getLambdaVersion('node_modules/appoptics-auto-lambda/package.json');
 let remoteApm;
 let remoteAob;
 
 // allow testing a different version than local if desired.
 if (process.env.AO_TEST_LAMBDA_LOCAL_VERSIONS) {
   const versions = process.env.AO_TEST_LAMBDA_LOCAL_VERSIONS;
-  const m = versions.match(/^apm v(.+), bindings v(.+)/);
-  expect(m, 'AO_TEST_LAMBDA_LOCAL_VERSIONS must match /^apm v(.+), bindings v(.+)/').exist;
-  ([, apmVersion, aobVersion] = m);
+  const m = versions.match(/^apm v(.+), bindings v(.+), auto v(.+)/);
+  expect(m, 'AO_TEST_LAMBDA_LOCAL_VERSIONS must match /^apm v(.+), bindings v(.+), auto v(.+)/').exist;
+  ([, apmVersion, aobVersion, autoVersion] = m);
 }
 
 let functionArn;
@@ -42,7 +43,7 @@ let fnConfig;
 let fnInvocations;
 let initEvent;
 
-describe(`test lambda layer ${apmVersion}, ${aobVersion} works`, function () {
+describe(`lambda layer ${apmVersion}, ${aobVersion}, ${autoVersion} works`, function () {
   before(function () {
     //if (process.env.AO_TEST_LAMBDA_LOCAL_VERSIONS) {
     //  const versions = process.env.AO_TEST_LAMBDA_LOCAL_VERSIONS;
@@ -58,7 +59,7 @@ describe(`test lambda layer ${apmVersion}, ${aobVersion} works`, function () {
     //return Promise.all([p1, p2]);
   });
 
-  it('get lambda function configuration and versions from description', function () {
+  it('verify lambda function configuration and versions from description', function () {
     this.timeout(10 * 60 * 1000);
     return awsUtil.getFunctionConfiguration(lambdaTestFunction)
       // find lambdaApmLayer
@@ -111,6 +112,7 @@ describe(`test lambda layer ${apmVersion}, ${aobVersion} works`, function () {
         if (!ignoreVersions) {
           expect(r.Payload.body.response.versions.ao).equal(apmVersion);
           expect(r.Payload.body.response.versions.aob).equal(aobVersion);
+          expect(r.Payload.body.response.versions.auto).equal(autoVersion);
         }
         expect(r.Payload.body.response).property('context').an('object');
         return r.Payload.body.response;

--- a/test/span.test.js
+++ b/test/span.test.js
@@ -32,6 +32,7 @@ describe('span', function () {
     emitter.close(done)
   })
   afterEach(function () {
+    // clears any unused log message checks
     if (clear) {
       clear()
       clear = undefined
@@ -802,10 +803,9 @@ describe('span', function () {
       {level: 'error', message: 'Error: Invalid type for KV'},
       {level: 'error', message: 'Error: Invalid type for KV'},
       {level: 'error', message: 'Error: Invalid type for KV'},
-    ]
+    ];
 
-    let getCount  // eslint-disable-line
-    [getCount, clear] = helper.checkLogMessages(logChecks)
+    [, clear] = helper.checkLogMessages(logChecks);
 
     span.run(function () {
       span.info(data)
@@ -826,9 +826,8 @@ describe('span', function () {
 
     const logChecks = [
       {level: 'error', message: 'test span info call could not find last event'}
-    ]
-    let getCount  // eslint-disable-line
-    [getCount, clear] = helper.checkLogMessages(logChecks)
+    ];
+    [, clear] = helper.checkLogMessages(logChecks);
 
     span.info(data)
     Event.prototype.send = send
@@ -987,8 +986,6 @@ describe('span', function () {
     // evaluate brittleness using different timers
     const timeout = callback => setTimeout(callback, 1);
 
-    // The weird indentation is to match depth of trigerring code,
-    // it might make it easier to match a span entry to its exit.
     const checks = [
       // Start async outer
       helper.checkEntry('outer', trackOuter),


### PR DESCRIPTION
the bulk of the non-test changes are to use a native promise interface to execute lambda functions. previously `pStartOrContinueTrace` was a simple wrapper that wrapped the user's promise-returning function and then called `startOrContinueTrace` which used the existing callback mechanism to signal completion. that arrangement didn't allow the result of the promise to be evaluated before exiting the span, and that is required in the lambda environment in order to detect non-error returns that the agent should treat as errors. `pStartOrContinueTrace` now parallels `startOrContinueTrace` with a few optimizations. a related change is a new `Span.runPromise()` instance function.

the agent now captures whether an inbound-x-trace was received; lambda functions do not attempt to return an x-trace unless one was received. a fair amount of code was commented out that would insert a response x-trace header even when the user did not insert their own headers. now, if there is not a headers object in the response, an x-trace header will not be inserted. previously the agent would modify the response to insert a header object if necessary.

update to test.sh to allow skipping groups, "only" groups, and add color output.

about half the lines of the changes are to testing.
- axios updates making tests complete on promises, not callbacks
- a standalone test that doesn't use mocha as i was tracking down "why is context hanging around?"
- custom test had dramatic changes (promise changes, log message changes, should => expect)
- helper.js got a few more options for debugging testing.
- create module to compose the lambda version from another module's package.json.
- changes to lambda local and remote tests for changes in x-trace header insertion and error handling

@cheempz - including you as you might want to check out `guides/lambda-configuration.md`
