### PR TITLE
extend ignore errors to all fs path-based operations

### DIFF
--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -176,16 +176,14 @@ function patchPathMethod (fs, method) {
             FilePath: args[0]
           },
         }
-        if (method === 'open') {
-          spanInfo.finalize = function (createdSpan) {
-            span = createdSpan;
-            if (conf.ignoreErrors && method in conf.ignoreErrors) {
-              span.setIgnoreErrorFn(function (err) {
-                // if looking at operation and/or path in the future:
-                // span.events.entry.kv.Operation === 'openSync' ditto.FilePath
-                return err.code in conf.ignoreErrors[method];
-              })
-            }
+        spanInfo.finalize = function (createdSpan) {
+          span = createdSpan;
+          if (conf.ignoreErrors && method in conf.ignoreErrors) {
+            span.setIgnoreErrorFn(function (err) {
+              // if looking at operation and/or path in the future:
+              // span.events.entry.kv.Operation === 'openSync' ditto.FilePath
+              return err.code in conf.ignoreErrors[method];
+            })
           }
         }
         let span


### PR DESCRIPTION
Of the synchronous path-based fs operations, only `openSync` checked for ignored operations.

My thinking was to not introduce even slight additional overhead for the synchronous functions unless it addressed the specific customer problem. while the asynchronous functions needed the finalize function in order to capture the created span, the synchronous functions didn't, so avoiding the finalize function slightly reduced the overhead. in retrospect the slight reduction was not worth 1) different behavior for async and sync operations or 2) avoiding the slight increase in overhead for synchronous operations.

this pr makes path-based operations work the same for async and sync versions - errors from any operation can be ignored. this addresses issue #65 (reopened) and [AO-18483].

[AO-18483]: https://swicloud.atlassian.net/browse/AO-18483