### PR TITLE
AO-18716 fix node 14 non-existent property warning

### DIFF
--- a/lib/api-sim.js
+++ b/lib/api-sim.js
@@ -7,7 +7,11 @@ let cls;
 module.exports = function (appoptics) {
   ao = appoptics;
   aob = ao.addon;
-  cls = ao.cls;
+  // check for property to avoid triggering node 14 warning on
+  // non-existent property in unfinished module.exports
+  if (ao.hasOwnProperty('cls')) {
+    cls = ao.cls;
+  }
 
   // define the properties (some of which are part of the API)
   definePropertiesOn(ao);
@@ -760,4 +764,3 @@ function insertLogObject (o = {}) {
 function wrapLambdaHandler (fn) {
   return fn;
 }
-

--- a/lib/api.js
+++ b/lib/api.js
@@ -34,7 +34,9 @@ module.exports = function (appoptics) {
   ao.maps.responseFinalizers = responseFinalizers;
 
   // each invocation in lambda is counted
-  if (ao.lambda) {
+  // use property check that does not trigger node 14 warning on
+  // non-existent property in unfinished module.exports
+  if (ao.hasOwnProperty('lambda')) {
     ao.lambda.invocations = 0;
   }
 


### PR DESCRIPTION
@bdehamer ran into the following error with our agent version 10.0.0 on Node 14.15

```
(node:1) Warning: Accessing non-existent property 'lambda' of module exports inside circular dependency
  at emitCircularRequireWarning (internal/modules/cjs/loader.js:650:11)
  at Object.get (internal/modules/cjs/loader.js:664:5)
  at module.exports (/app/node_modules/appoptics-apm/lib/api.js:37:10)
  at Object.<anonymous> (/app/node_modules/appoptics-apm/lib/index.js:372:53)
  at Module._compile (internal/modules/cjs/loader.js:1063:30)
  at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
  at Module.load (internal/modules/cjs/loader.js:928:32)
  at Function.Module._load (internal/modules/cjs/loader.js:769:14)
  at Module.require (internal/modules/cjs/loader.js:952:19)
  at Module._preloadModules (internal/modules/cjs/loader.js:1217:12)
```

Seems due to https://github.com/nodejs/node/pull/29935 introduced in Node 14, and some examples of how other packages fixed it can be found in https://github.com/nodejs/node/issues/32987