### PR TITLE
handle defaults in one place, correctly

### DIFF
--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -67,6 +67,7 @@ function getUnifiedConfig () {
     tokenBucketCapacity: {location: 'e', type: 'i', eeid: 'lambda'},
     tokenBucketRate: {location: 'e', type: 'i', eeid: 'lambda'},
     transactionName: {location: 'e', type: 's', eeid: 'lambda'},
+    testKeyWithDefault: {location: 'b', type: 'i', eeid: 'lambda', default: 42},
     // end-user but ignore as it is only used when configuring
     apmConfigNode: {location: 'e', type: 's', ignore: true},  // ignore - used to load config file
 
@@ -164,6 +165,14 @@ function getUnifiedConfig () {
   // check the keys valid for the configuration file.
   Object.keys(settings).forEach(k => {
     const setting = settings[k];
+
+    // avoid an extra iteration by setting all defaults up front
+    if ('default' in setting && setting.default !== undefined) {
+      if (!setting.eeid || setting.eeid === execEnv.id) {
+        results.global[setting.map || k] = setting.default;
+      }
+    }
+
     if (setting.location === 'c' || setting.location === 'b') {
       if (k in fileGlobalConfig) {
         const value = convert(fileGlobalConfig[k], setting.type);
@@ -179,8 +188,6 @@ function getUnifiedConfig () {
         }
         // remove the value because the key is valid even if the value wasn't.
         delete fileGlobalConfig[k];
-      } else if ('default' in setting && setting.default !== undefined) {
-        results.global[k] = setting.default;
       }
     }
   })
@@ -193,17 +200,22 @@ function getUnifiedConfig () {
     }
 
     const envVar = `APPOPTICS_${setting.name || envForm(k)}`;
+
+    // if the environment variable exists, honor it if possible. if it doesn't
+    // exist see if a default exists for the setting.
     if (envVar in aoKeys) {
+      // if the setting is restricted to a specific execution environment
+      // then skip it if wrong environment.
+      if (setting.eeid && setting.eeid !== execEnv.id) {
+        debuggings.push(`omitting ${k}: eeid: ${setting.eeid} !== ${execEnv.id}`);
+        return;
+      }
       if (setting.ignore) {
         if (typeof setting.ignore !== 'function' || setting.ignore()) {
           debuggings.push(`guc ignoring ${envVar}`);
           delete aoKeys[envVar];
           return;
         }
-      }
-      if (setting.eeid && setting.eeid !== execEnv.id) {
-        debuggings.push(`omitting ${k}: eeid: ${setting.eeid} !== ${execEnv.id}`);
-        return;
       }
       const value = convert(aoKeys[envVar], setting.type);
       if (value !== undefined) {
@@ -216,11 +228,6 @@ function getUnifiedConfig () {
       }
       // remove this key because the env var is valid even if the value wasn't.
       delete aoKeys[envVar];
-    } else if ('default' in setting && setting.default !== undefined && setting.location === 'e') {
-      // if this is also a config file option it will be set (either a value or a
-      // default value) so a default only should be set if this can only be an env
-      // var.
-      results.global[setting.map || k] = setting.default;
     }
   })
 

--- a/test/get-unified-config.test.js
+++ b/test/get-unified-config.test.js
@@ -217,7 +217,6 @@ describe('get-unified-config', function () {
 
   describe('configuration file', function () {
     it('should default correctly when no config file or env vars', function () {
-      debugger
       const cfg = guc();
 
       doChecks(cfg);
@@ -775,7 +774,6 @@ describe('get-unified-config', function () {
       const config = {transactionSettings: {type: 'url', string: 'i\'m a shrimp', tracing: 'disabled'}};
       writeConfigJSON(config);
 
-      debugger
       const cfg = guc();
 
       const transactionSettings = toInternalTransactionSettings(config.transactionSettings);


### PR DESCRIPTION
set defaults in one place, at the start.

add tests, including a test key which can be replaced with a real one when ready. the test key must have eeid 'lambda' and a default value.