### PR TITLE
AO-20334-Create-GitHub-Actions-Test-Publish-Workflows-1

### DIFF
--- a/.github/docker-node/node-agent-runner.Dockerfile
+++ b/.github/docker-node/node-agent-runner.Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:20.04
+SHELL ["/bin/bash", "-c"]
+
+# general tools
+RUN apt update \
+    && apt -y install \
+                curl \
+                git \
+                g++ \
+                python \
+                make
+
+# set time zone (for github cli)
+ENV TZ=America/Los_Angeles
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# for github cli
+RUN apt -y install \
+            gnupg \
+            software-properties-common \
+            tzdata
+
+# get and install github cli
+# see: https://github.com/cli/cli/issues/1797#issuecomment-696469523
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 \
+    && apt-add-repository https://cli.github.com/packages \
+    && apt -y install gh
+
+# Install tools needed for specific service tests (pg, oracle)
+RUN apt -y install \
+            libaio1 \
+            postgresql-server-dev-12 \
+            zip \
+            unzip
+
+# get and install oracle library
+RUN curl -LO https://download.oracle.com/otn_software/linux/instantclient/195000/instantclient-basic-linux.x64-19.5.0.0.0dbru.zip \
+    && mkdir /opt/oracle \
+    && unzip instantclient-basic-linux.x64-19.5.0.0.0dbru.zip -d /opt/oracle/ \
+    && rm instantclient-basic-linux.x64-19.5.0.0.0dbru.zip
+
+# set for usage
+ENV LD_LIBRARY_PATH /opt/oracle/instantclient_19_5:$LD_LIBRARY_PATH

--- a/.github/workflows/docker-node.yml
+++ b/.github/workflows/docker-node.yml
@@ -1,0 +1,42 @@
+name: Prep - Build Docker Image (on Dockerfile push)
+
+# workflow is for a branch push only and ignores master.
+# push to master (which is also pull request merge) has a more elaborate workflow to run
+# github repo is configured with branch protection on master.
+on:
+  push:
+    branches-ignore:
+      - 'master'
+    paths:
+      - '.github/docker-node/*.Dockerfile'
+
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    # github actions triggered by on push will be triggered by both branch and tag push.
+    # the paths filter only applies to branch push and as a result the workflow will run on tag push.
+    # adding tags-ignore: filter causes the workflow to not run at all.
+    # add a conditional to prevent tag push runs.
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./.github/docker-node/
+          file: ./.github/docker-node/node-agent-runner.Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/node-agent-runner

--- a/dev/repo/reset.sh
+++ b/dev/repo/reset.sh
@@ -62,3 +62,5 @@ remote=$(git config --get remote.origin.url)
 if [[ $PWD == *${dev_name} ]] && [[ $remote == *${dev_name}.git ]]; then
   git push --all origin
 fi
+
+git checkout master


### PR DESCRIPTION
This Pull Request is the **1st** in a series of Pull Requests to set up GitHub Actions.

The first commit (2bab9f3) added the `docker-node` directory under the `.github` (hidden) directory. It houses a Dockerfile to be used as main container for GitHub Actions (Dockerfile setup similar to dev container, directory name is similar to the upstream repo).

The second commit (3dd106c) added a workflow that builds and publishes an image to GitHub Container Registry (ghcr.io). When run, the workflow creates a single package named [node-agent-runner](https://github.com/appoptics/appoptics-apm-node/pkgs/container/appoptics-apm-node%2Fnode-agent-runner) scoped to `appoptics/appoptics-apm-node` (the repo). The workflow is triggered by a push of a Dockerfile. Hence it has already [ran successfully](https://github.com/appoptics/appoptics-apm-node/actions/runs/1140130405) on commits in this Pull Request.

Third commit (eb7687a) is dev setup piggybacking this pull request.