### PR TITLE
AO-20334-Create-GitHub-Actions-Test-Publish-Workflows-2

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -1,0 +1,144 @@
+name: Accept - Matrix Node Full Test Suite (on merge)
+
+# triggered by pull request approval triggers which is a merge to default branch
+# github repo is configured with branch protection on master.
+on: 
+  push: 
+    branches: 
+      - master
+
+jobs:
+  node-versions-full-tests:
+    name: Node Versions Full Tests
+    runs-on: ubuntu-latest
+
+    # Docker Hub image that `container-job` executes (our runner)
+    container: 
+      image: ghcr.io/appoptics/appoptics-apm-node-dev/node-agent-runner:latest
+      env:
+        AO_TOKEN_STG: ${{ secrets.AO_TOKEN_STG }}
+        AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}
+        # tests run against a "local" udp "collector"
+        APPOPTICS_LOG_SETTINGS: error,warn,patching,bind,debug
+        APPOPTICS_COLLECTOR: localhost:7832
+        APPOPTICS_REPORTER: udp
+        APPOPTICS_SERVICE_KEY: ${{ secrets.AO_TOKEN_STG }}:ao-node-test
+        AO_TEST_CASSANDRA_2_2: cassandra:9042
+        AO_TEST_MEMCACHED_1_4: memcached:11211
+        AO_TEST_MONGODB_2_4: mongo_2_4:27017
+        AO_TEST_MONGODB_2_6: mongo_2_6:27017
+        AO_TEST_MONGODB_3_0: mongo_3_0:27017
+        AO_TEST_SQLSERVER_EX: mssql:1433
+        AO_TEST_MYSQL: mysql:3306
+        AO_TEST_ORACLE: oracle:1521
+        AO_TEST_POSTGRES: postgres:5432
+        AO_TEST_RABBITMQ_3_5: rabbitmq:5672
+        AO_TEST_REDIS_3_0: redis:6379
+
+    # Service containers to run with `runner-job`
+    services:
+      cassandra:
+        image: cassandra:2 
+        options: >-
+          --health-cmd "nodetool ring"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "9042:9042"
+      memcached:
+        image: memcached 
+        ports:
+          - "11211:11211"
+      mongo_2_4:
+        image: mongo:2.4 
+        ports:
+          # host:container
+          - "27016:27017"
+      mongo_2_6:
+        image: mongo:2.6 
+        ports:
+          - "27017:27017"
+      mongo_3_0:
+        image: mongo:3 
+        ports:
+          # host:container
+          - "27018:27017"
+      mssql:
+        image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
+        ports:
+          - "1433:1433"
+      mysql:
+        image: "mysql:5.7.13"
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          MYSQL_ROOT_PASSWORD: admin
+        ports:
+          - "3306:3306"
+      oracle:
+        image: "freundallein/oracledb" # TODO: hummmm
+        ports:
+          - "1521:1521"
+      postgres:
+        image: "postgres"
+        options: >-
+          --health-cmd "pg_isready"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "5432:5432"
+        env:
+          # sets password to this so make pg.test.js agree
+          POSTGRES_PASSWORD: xyzzy
+      rabbitmq:
+        image: rabbitmq:3-management 
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "5672:5672"
+          - "5671:5671"
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    strategy:
+      fail-fast: false
+      matrix: 
+        node: ['10', '12', '14']
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node  }}
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      - name: NPM Install
+        run: npm install  --unsafe-perm
+
+      - name: Run Full Test Suite
+        run: npm test

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -14,7 +14,7 @@ jobs:
 
     # Docker Hub image that `container-job` executes (our runner)
     container: 
-      image: ghcr.io/appoptics/appoptics-apm-node-dev/node-agent-runner:latest
+      image: ghcr.io/${{ github.repository }}/node-agent-runner:latest
       env:
         AO_TOKEN_STG: ${{ secrets.AO_TOKEN_STG }}
         AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,54 @@
+name: Push - Core Tests (on push)
+
+# workflow is for a branch push only and ignores master.
+# push to master (which is also pull request merge) has a more elaborate workflow to run
+# github repo is configured with branch protection on master.
+on: 
+  push:
+    branches-ignore:
+      - 'master'
+      # any branch with a name ending in -no-action will not trigger this workflow.
+      - '*-no-action'
+
+  workflow_dispatch:
+    inputs: 
+      node:
+        required: false
+        description: 'A node version (e.g 10.16.0)'
+        default: '14' # TODO: update to 16 when support is added
+
+jobs:
+  core-tests:
+    name: Core Tests
+    runs-on: ubuntu-latest # environment job will run in
+
+    env:
+      AO_TOKEN_STG: ${{ secrets.AO_TOKEN_STG }}
+      AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}
+      # tests run against a "local" udp "collector"
+      APPOPTICS_LOG_SETTINGS: error,warn,patching,bind,debug
+      APPOPTICS_COLLECTOR: localhost:7832
+      APPOPTICS_REPORTER: udp
+      APPOPTICS_SERVICE_KEY: ${{ secrets.AO_TOKEN_STG }}:ao-node-test
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Setup Node ${{ github.event.inputs.node || '14' }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ github.event.inputs.node || '14' }}
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      - name: NPM Install
+        run: npm install  --unsafe-perm
+
+      - name: Run Core Tests
+        run: npm run test:core

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,137 @@
+name: Review - Full Test Suite (on pull)
+
+on: 
+  pull_request: 
+
+  workflow_dispatch:
+
+jobs:
+ full-tests:
+    name: Full Tests
+    runs-on: ubuntu-latest
+
+    # Docker Hub image that `container-job` executes (our runner)
+    container: 
+      image: ghcr.io/appoptics/appoptics-apm-node-dev/node-agent-runner:latest
+      env:
+        AO_TOKEN_STG: ${{ secrets.AO_TOKEN_STG }}
+        AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}
+        # tests run against a "local" udp "collector"
+        APPOPTICS_LOG_SETTINGS: error,warn,patching,bind,debug
+        APPOPTICS_COLLECTOR: localhost:7832
+        APPOPTICS_REPORTER: udp
+        APPOPTICS_SERVICE_KEY: ${{ secrets.AO_TOKEN_STG }}:ao-node-test
+        AO_TEST_CASSANDRA_2_2: cassandra:9042
+        AO_TEST_MEMCACHED_1_4: memcached:11211
+        AO_TEST_MONGODB_2_4: mongo_2_4:27017
+        AO_TEST_MONGODB_2_6: mongo_2_6:27017
+        AO_TEST_MONGODB_3_0: mongo_3_0:27017
+        AO_TEST_SQLSERVER_EX: mssql:1433
+        AO_TEST_MYSQL: mysql:3306
+        AO_TEST_ORACLE: oracle:1521
+        AO_TEST_POSTGRES: postgres:5432
+        AO_TEST_RABBITMQ_3_5: rabbitmq:5672
+        AO_TEST_REDIS_3_0: redis:6379
+
+    # Service containers to run with `runner-job`
+    services:
+      cassandra:
+        image: cassandra:2 
+        options: >-
+          --health-cmd "nodetool ring"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "9042:9042"
+      memcached:
+        image: memcached 
+        ports:
+          - "11211:11211"
+      mongo_2_4:
+        image: mongo:2.4 
+        ports:
+          # host:container
+          - "27016:27017"
+      mongo_2_6:
+        image: mongo:2.6 
+        ports:
+          - "27017:27017"
+      mongo_3_0:
+        image: mongo:3 
+        ports:
+          # host:container
+          - "27018:27017"
+      mssql:
+        image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
+        ports:
+          - "1433:1433"
+      mysql:
+        image: "mysql:5.7.13"
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          MYSQL_ROOT_PASSWORD: admin
+        ports:
+          - "3306:3306"
+      oracle:
+        image: "freundallein/oracledb" # TODO: hummmm
+        ports:
+          - "1521:1521"
+      postgres:
+        image: "postgres"
+        options: >-
+          --health-cmd "pg_isready"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "5432:5432"
+        env:
+          # sets password to this so make pg.test.js agree
+          POSTGRES_PASSWORD: xyzzy
+      rabbitmq:
+        image: rabbitmq:3-management 
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "5672:5672"
+          - "5671:5671"
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Setup Node ${{ github.event.inputs.node || '14' }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ github.event.inputs.node || '14' }}
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      - name: NPM Install
+        run: npm install  --unsafe-perm
+
+      - name: Run Full Test Suite
+        run: npm test

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -12,7 +12,7 @@ jobs:
 
     # Docker Hub image that `container-job` executes (our runner)
     container: 
-      image: ghcr.io/appoptics/appoptics-apm-node-dev/node-agent-runner:latest
+      image: ghcr.io/${{ github.repository }}/node-agent-runner:latest
       env:
         AO_TOKEN_STG: ${{ secrets.AO_TOKEN_STG }}
         AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,6 +4,11 @@ on:
   pull_request: 
 
   workflow_dispatch:
+    inputs: 
+      node:
+        required: false
+        description: 'A node version (e.g 10.16.0)'
+        default: '14' # TODO: update to 16 when support is added
 
 jobs:
  full-tests:

--- a/test/probes/http-websocket-common.js
+++ b/test/probes/http-websocket-common.js
@@ -175,7 +175,7 @@ describe(`probes.${p} websocket`, function () {
       ], done)
     });
 
-    it(`${p} connect to a public server`, function (done) {
+    it.skip(`${p} connect to a public server`, function (done) {
       this.timeout(10000);
       const options = makeOptions(parsedUrl);
 
@@ -217,7 +217,7 @@ describe(`probes.${p} websocket`, function () {
       );
     });
 
-    it('WebSocket connect to a public server', function (done) {
+    it.skip('WebSocket connect to a public server', function (done) {
       helper.test(
         emitter,
         function (xdone) {
@@ -243,7 +243,7 @@ describe(`probes.${p} websocket`, function () {
       );
     });
 
-    it(`${p} connect with missing headers should fail`, function (done) {
+    it.skip(`${p} connect with missing headers should fail`, function (done) {
       const options = makeOptions(parsedUrl);
       // a server should disconnect if the key is missing
       delete options.headers['Sec-WebSocket-Version'];


### PR DESCRIPTION
This Pull Request is the **2nd** in a series of Pull Requests to set up GitHub Actions.

### Commits:

1. First commit (5ec2565) added **Push** workflow (triggered by a push) that runs core tests on node 14. Node is set on the GitHub Actions runner and tests run on it. Since the workflow is triggered by a push it has already [ran successfully](https://github.com/appoptics/appoptics-apm-node/actions/runs/1144733650) on commits in this Pull Request.

2. Second commit (801298d) added **Review** workflow (triggered by a pull request) that runs full test suite on node 14 inside a container linked to a network of service containers. Since the workflow is triggered by a pull request it has already [ran successfully](https://github.com/appoptics/appoptics-apm-node/actions/runs/1144865750) on this Pull Request.


3. Third commit (7614482) added **Accept** workflow (triggered by a merge to master) that runs full test suite on matrix node version (10, 12, 14) inside a container linked to a network of service containers.

4. Fourth commit is a fix.

4. Fifth commit (7c3230d) skips tests used by `test/probes/http-websocket.test.js` and `test/probes/https-websocket.test.js` which were connecting to `websocket.org`. Service is [no longer available](https://websocket.org/). It was [still available last week](https://web.archive.org/web/20210813101831/https://websocket.org/)...

### Notes:

- The repo is set with two secrets required by workflows:
`AO_TOKEN_PROD`
`AO_TOKEN_STG`

- This is a baseline version of actions meant to provide basic confidence en route to end-to-end package publication using GitHub Actions (this repo and upstream repo). What-Runs-When as well as OS additions will be revisited later.
- An action using `testeachversion` will be included in own pull request.
