### PR TITLE
AO-20334-Create-GitHub-Actions-Test-Publish-Workflows-3

### DIFF
--- a/.github/scripts/testeachversion-clean-output.sh
+++ b/.github/scripts/testeachversion-clean-output.sh
@@ -3,8 +3,8 @@
 path_to_file="$1"
 
 # remove excessive test data header
-sed -i '/^appoptics-apm-dev/d' "$path_to_file"
-sed -i '/^ appoptics-apm-dev/d' "$path_to_file"
+sed -i '/^appoptics-apm/d' "$path_to_file"
+sed -i '/^ appoptics-apm/d' "$path_to_file"
 sed -i '/^ node v/d' "$path_to_file"
 
 # remove excessive labeling

--- a/.github/scripts/testeachversion-clean-output.sh
+++ b/.github/scripts/testeachversion-clean-output.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+path_to_file="$1"
+
+# remove excessive test data header
+sed -i '/^appoptics-apm-dev/d' "$path_to_file"
+sed -i '/^ appoptics-apm-dev/d' "$path_to_file"
+sed -i '/^ node v/d' "$path_to_file"
+
+# remove excessive labeling
+sed -i '/^packages:/d' "$path_to_file"
+
+# remove all white space
+sed -i '/^$/d' "$path_to_file"

--- a/.github/scripts/testeachversion-rename-files.sh
+++ b/.github/scripts/testeachversion-rename-files.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+workdir="$1"
+node="$2"
+pkg="${3////_}" # remove any / from package name (scoped packages have that)
+
+# clean : to allow file upload
+for fn in "$workdir"/*":"*; do
+  mv -- "$fn" "${fn//:/_}"; 
+done
+
+# add package & node prefix to test results file name
+fn=$(ls "$workdir"/*Z)
+mv "$fn" "$workdir"/"$node"-"$pkg"-"$(basename -- "$fn")".raw
+
+# add package & node prefix to summary file name
+fn=$(ls "$workdir"/*.json)
+mv "$fn" "$workdir"/"$node"-"$pkg"-"$(basename -- "$fn" .json)".json
+
+# some output
+ls "$workdir"

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -10,7 +10,7 @@ jobs:
 
     # Docker Hub image that `container-job` executes (our runner)
     container: 
-      image: ghcr.io/appoptics/appoptics-apm-node-dev/node-agent-runner:latest
+      image: ghcr.io/${{ github.repository }}/node-agent-runner:latest
       env:
         AO_TOKEN_STG: ${{ secrets.AO_TOKEN_STG }}
         AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -240,10 +240,6 @@ jobs:
         run: |
           git checkout -b test-each-version-${{ steps.date.outputs.date }}
 
-      - name: Create Directory
-        run: |
-          mkdir -p supported-components-data
-
       - name: Download Test Matrix Artifacts
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -1,0 +1,275 @@
+name: Document - Test Each Version Matrix (manual)
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  test-each-version:
+    name: Test Each Version
+    runs-on: ubuntu-latest
+
+    # Docker Hub image that `container-job` executes (our runner)
+    container: 
+      image: ghcr.io/appoptics/appoptics-apm-node-dev/node-agent-runner:latest
+      env:
+        AO_TOKEN_STG: ${{ secrets.AO_TOKEN_STG }}
+        AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}
+        # tests run against a "local" udp "collector"
+        APPOPTICS_LOG_SETTINGS: error,warn,patching,bind,debug
+        APPOPTICS_COLLECTOR: localhost:7832
+        APPOPTICS_REPORTER: udp
+        APPOPTICS_SERVICE_KEY: ${{ secrets.AO_TOKEN_STG }}:ao-node-test
+        AO_TEST_CASSANDRA_2_2: cassandra:9042
+        AO_TEST_MEMCACHED_1_4: memcached:11211
+        AO_TEST_MONGODB_2_4: mongo_2_4:27017
+        AO_TEST_MONGODB_2_6: mongo_2_6:27017
+        AO_TEST_MONGODB_3_0: mongo_3_0:27017
+        AO_TEST_SQLSERVER_EX: mssql:1433
+        AO_TEST_MYSQL: mysql:3306
+        AO_TEST_ORACLE: oracle:1521
+        AO_TEST_POSTGRES: postgres:5432
+        AO_TEST_RABBITMQ_3_5: rabbitmq:5672
+        AO_TEST_REDIS_3_0: redis:6379
+
+    # Service containers to run with `runner-job`
+    services:
+      cassandra:
+        image: cassandra:2 
+        options: >-
+          --health-cmd "nodetool ring"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "9042:9042"
+      memcached:
+        image: memcached 
+        ports:
+          - "11211:11211"
+      mongo_2_4:
+        image: mongo:2.4 
+        ports:
+          # host:container
+          - "27016:27017"
+      mongo_2_6:
+        image: mongo:2.6 
+        ports:
+          - "27017:27017"
+      mongo_3_0:
+        image: mongo:3 
+        ports:
+          # host:container
+          - "27018:27017"
+      mssql:
+        image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
+        ports:
+          - "1433:1433"
+      mysql:
+        image: "mysql:5.7.13"
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          MYSQL_ROOT_PASSWORD: admin
+        ports:
+          - "3306:3306"
+      oracle:
+        image: "freundallein/oracledb" # TODO: hummmm
+        ports:
+          - "1521:1521"
+      postgres:
+        image: "postgres"
+        options: >-
+          --health-cmd "pg_isready"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "5432:5432"
+        env:
+          # sets password to this so make pg.test.js agree
+          POSTGRES_PASSWORD: xyzzy
+      rabbitmq:
+        image: rabbitmq:3-management 
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "5672:5672"
+          - "5671:5671"
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    strategy:
+      fail-fast: false
+      matrix: 
+        node: ['10', '12', '14']
+        pkg: [
+          '@hapi/hapi',
+          '@hapi/vision',
+          'amqplib',
+          'bcrypt',
+          'bluebird',
+          'bunyan',
+          'cassandra-driver',
+          'co-render',
+          'director',
+          'express',
+          'generic-pool',
+          'hapi',
+          'http',
+          'https',
+          'koa',
+          'koa-resource-router',
+          'koa-route',
+          'koa-router',
+          'level',
+          'memcached',
+          'mongodb',
+          'mongodb-core',
+          'mongoose',
+          'morgan',
+          'mysql',
+          'oracledb',
+          'pg',
+          'pino',
+          'q',
+          'raw-body',
+          'redis',
+          'restify',
+          'tedious',
+          'vision',
+          'winston',
+          # core modules
+          'crypto',
+          'fs',
+          'http',
+          'https',
+          'zlib'
+        ]
+
+    steps:
+      # the working directory is created by the runner and mounted to the container.
+      # container user is root and the runner is not a user in the container.
+      # this is a github actions design flaw.
+      # when npm 7 is run as root, scripts are always run with the effective uid and gid of the working directory owner.
+      # node 16 can't install under default setup.
+      # specifying workdir for container and path for checkout does not work due to bug.
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node  }}
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      - name: NPM Install
+        run: npm install  --unsafe-perm
+
+      - name: Create tmp Directory
+        run: |
+          mkdir -p docs/tmp
+
+      - name: Test ${{ matrix.pkg }} versions
+        # in testeachversion we may fail tests, and want to keep going.
+        continue-on-error: true
+        # some packages take a long time.
+        timeout-minutes: 30
+        run: npx testeachversion --verbose -l ./docs/tmp -p ${{ matrix.pkg }}
+
+      - name: Rename Result Artifacts
+        # substitution needed because:
+        # 1. files contain characters that are illegal for uploaded files
+        # 2. we need to keep a specific file name pattern for testeachversion to process later
+        # 3. we want to use matrix data to tag the files
+        # bash needed for substitution. 
+        shell: bash
+        run: .github/scripts/testeachversion-rename-files.sh docs/tmp ${{ matrix.node }} ${{ matrix.pkg }}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: supported-components-data
+          path: docs/tmp/ # or path/to/artifact
+
+
+  create-pull-request:
+    name: Create Pull Request
+    runs-on: ubuntu-latest # environment job will run in
+    needs:  test-each-version
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Init Git
+        run: |
+         git config user.name "GitHub Actions"
+         git config user.email noreply@github.com
+
+      # job is running on the github runner not in pre-configured container
+      - name: Set Time Zone & Current Date
+        id: date
+        run: |
+          sudo timedatectl set-timezone America/Los_Angeles
+          echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')" # must be valid branch name
+
+      - name: Create Git Branch
+        run: |
+          git checkout -b test-each-version-${{ steps.date.outputs.date }}
+
+      - name: Create Directory
+        run: |
+          mkdir -p supported-components-data
+
+      - name: Download Test Matrix Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: docs/
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+
+      - name: NPM Install
+        run: npm install testeachversion
+
+      - name: Humanize
+        # clean output needed because the merge of multiple matrix runs results in unreadable format (not human...)
+        # bash needed for sed. 
+        shell: bash
+        run: |
+          npx humanize -m docs/supported-components-data > ./docs/supported-components.human
+          .github/scripts/testeachversion-clean-output.sh docs/supported-components.human
+
+      - name: Commit Results
+        run: |
+          git add docs
+          git commit --message "Test Each Version Results ${{ steps.date.outputs.date }}"
+          git push origin test-each-version-${{ steps.date.outputs.date }}
+
+      - name: Open Pull Request
+        run: gh pr create --title "Test Each Version Results ${{ steps.date.outputs.date }}" --body ""
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This Pull Request is the **3rd** in a series of Pull Requests to set up GitHub Actions.

### Commits 
Commit (859ab3c) adds a Document workflow triggered manually, supporting scripts in `.github/scripts` and a target directory (`docs`) that is currently empty.

Workflow runs a [`testeachversion`](https://www.npmjs.com/package/testeachversion) per package in a matrix, generates a summary file, creates an automated commit into branch and opens a pull request. End result is a docs directory containing supported-components.human file and supported-components-data directory with summary and raw data for each package.

### General Notes:

- The workflow is of the "dip a toe in the water" type. If all works as expected over time, it will replace https://github.com/appoptics/apm-test-node and the corresponding @aws setup.

- `testeachversion` is used as-is. Since it was not built for parallel run on @github @actions, some “rough patching” is required.

- Main goal is to provide additional confidence en route to end-to-end package publication using GitHub Actions (this repo and upstream repo).

### Result Notes:
- Since this is a manually triggered workflow that is on a branch, we can not run it before we merge it to master. There is however a sample at the dev repo:
    - Workflow run: https://github.com/appoptics/appoptics-apm-node-dev/actions/runs/1148854623
    - Pull Request: https://github.com/appoptics/appoptics-apm-node-dev/pull/89
    - Downloadable Results: https://github.com/appoptics/appoptics-apm-node-dev/suites/3547083183/artifacts/84988458
 
- Workflow uses `continue-on-error: true` so that if a set of tests fails for a specific version of a package, the whole workflow will still complete. Thus in the run above the jobs are all ✅ while there is annotations below suggesting failures ❌. 

- Those annotated failures are as-should-be and the failing package version is removed from supported components list. To illustrate:
   - Annotation is: ❌ **Test Each Version (10, amqplib)** Process completed with exit code 1.
   - [Raw data](https://github.com/appoptics/appoptics-apm-node-dev/blob/test-each-version-2021-08-19-17-09-06/docs/supported-components-data/10-amqplib-ubuntu-20.04-node-v10.24.1-details-2021-08-19T23_38_46.447Z.raw) shows: [fail at 0.2.0](https://github.com/appoptics/appoptics-apm-node-dev/blob/test-each-version-2021-08-19-17-09-06/docs/supported-components-data/10-amqplib-ubuntu-20.04-node-v10.24.1-details-2021-08-19T23_38_46.447Z.raw#L27) and [fail at 0.4.0](https://github.com/appoptics/appoptics-apm-node-dev/blob/test-each-version-2021-08-19-17-09-06/docs/supported-components-data/10-amqplib-ubuntu-20.04-node-v10.24.1-details-2021-08-19T23_38_46.447Z.raw#L256)
   - [Summary Data](https://github.com/appoptics/appoptics-apm-node-dev/blob/test-each-version-2021-08-19-17-09-06/docs/supported-components-data/10-amqplib-ubuntu-20.04-node-v10.24.1-summary-2021-08-19T23_38_46.447Z.json) captures fails [0.2.0](https://github.com/appoptics/appoptics-apm-node-dev/blob/test-each-version-2021-08-19-17-09-06/docs/supported-components-data/10-amqplib-ubuntu-20.04-node-v10.24.1-summary-2021-08-19T23_38_46.447Z.json#L59) and [0.4.0](https://github.com/appoptics/appoptics-apm-node-dev/blob/test-each-version-2021-08-19-17-09-06/docs/supported-components-data/10-amqplib-ubuntu-20.04-node-v10.24.1-summary-2021-08-19T23_38_46.447Z.json#L80)
   - [Humanized file](https://github.com/appoptics/appoptics-apm-node-dev/blob/test-each-version-2021-08-19-17-09-06/docs/supported-components.human) has results in [readable format](https://github.com/appoptics/appoptics-apm-node-dev/blob/test-each-version-2021-08-19-17-09-06/docs/supported-components.human#L8)
   - Compare to what is [published on website](https://documentation.solarwinds.com/en/success_center/appoptics/content/kb/apm_tracing/nodejs/support-matrix.htm) and we can see that neither failing versions were ever supported (i.e. they always failed) and that we support more versions including latest (0.8.0).
   - in future runs the Humanized file, once merged, should be easily "diffable".



