### PR TITLE
AO-20334-Create-GitHub-Actions-Test-Publish-Workflows-4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release - NPM Publish (on push tag)
+
+on: 
+  push: 
+    tags: 
+      # triggered only by major/minor/patch tags and those specifically tagged alpha. 
+      # standard prerelease tags do not trigger.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-alpha.*'
+
+jobs:
+  npm-publish:
+    name: NPM Publish
+    runs-on: ubuntu-latest 
+    # stopgap. we should not get unless there is a tag ref.
+    # but there are several triggering issues open for GithHub runner.
+    # so recheck.
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+  
+      - name: Setup Node 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'  # Setup .npmrc file to publish to npm
+
+      # prepack script requires files and those in turn require specific packages
+      - name: NPM Install shimmer
+        run: npm install shimmer debug-custom
+
+      # *** IMPORTANT: 
+      # by default any package published to npm registry is tagged with 'latest'. to set other pass --tag. 
+      # any pre-release package (has - in version), regardless of name defined with version preid, will be npm tagged with 'prerelease'.
+      # package is scoped to organization (@appoptics/apm-binding) set --access public to avoid 402 Payment Required
+      - name: NPM Publish (alpha)
+        run: npm publish --tag prerelease --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        if: ${{ contains(github.ref, '-') }}
+
+      - name: NPM Publish (latest)
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        if: ${{ !contains(github.ref, '-') }}


### PR DESCRIPTION
This pull request is the **4th** in a series of Pull Requests to set up GitHub Actions.

### Commits:
The Single commit () adds a Release workflow (release.yml) that is `npm` and `git` triggered, using npm builtin `version` command and `git push tag`. No github hooks needed.
    Workflow will run for release versions and alpha tagged pre-release. Other version tags are ignored.
    Workflow will:
    - Publish an NPM package.
    - When version tag is alpha, package will be NPM tagged `prerelease`. When it is a release version, package will be NPM tagged `latest`.

### Notes:
- The workflow uses similar trigger, logic and job steps as the Release workflow used in the upstream repo.
- The repo is set with `NPM_AUTH_TOKEN` secret.