### PR TITLE
AO-20361-Replace-Oracle-DB-used-for-testing

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -100,7 +100,7 @@ jobs:
         ports:
           - "3306:3306"
       oracle:
-        image: "freundallein/oracledb" # TODO: hummmm
+        image: "traceqa/oracle-express" # traceqa is a SolarWinds account
         ports:
           - "1521:1521"
       postgres:

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -96,7 +96,7 @@ jobs:
         ports:
           - "3306:3306"
       oracle:
-        image: "freundallein/oracledb" # TODO: hummmm
+        image: "traceqa/oracle-express" # traceqa is a SolarWinds account
         ports:
           - "1521:1521"
       postgres:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -103,7 +103,7 @@ jobs:
         ports:
           - "3306:3306"
       oracle:
-        image: "freundallein/oracledb" # TODO: hummmm
+        image: "traceqa/oracle-express" # traceqa is a SolarWinds account
         ports:
           - "1521:1521"
       postgres:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -97,7 +97,7 @@ services:
 
   oracle:
     container_name: "oracle"
-    image: "freundallein/oracledb"
+    image: "traceqa/oracle-express" # traceqa is a SolarWinds account
     ports:
       - "1521:1521"
 

--- a/env.sh
+++ b/env.sh
@@ -97,12 +97,6 @@ elif [[ "$ARG" = "bash" ]]; then
     # if different port then use default user/password settings
     export AO_TEST_MYSQL_USERNAME=${AO_TEST_MYSQL_HOST_USERNAME:root}
     export AO_TEST_MYSQL_PASSWORD=${AO_TEST_MYSQL_HOST_PASSWORD+}
-    # this requires an entry in /etc/hosts because this
-    # isn't run in a container it can't use docker names.
-    # use the IP address from "docker inspect ao_oracle_1"
-    export AO_TEST_ORACLE=localhost:1521
-    export AO_TEST_ORACLE_USERNAME=system
-    export AO_TEST_ORACLE_PASSWORD=oracle
     # defaults should be fine.
     #export AO_TEST_POSTGRES_USER=postgres
     #export AO_TEST_POSTGRES_PASSWORD=
@@ -137,12 +131,6 @@ elif [[ "$ARG" = "travis" ]]; then
     #export AO_TEST_MYSQL=localhost:3306
     #export AO_TEST_MYSQL_USERNAME=root
     #export AO_TEST_MYSQL_PASSWORD=admin
-    ## this requires an entry in /etc/hosts because this
-    ## isn't run in a container it can't use docker names.
-    ## use the IP address from "docker inspect ao_oracle_1"
-    #export AO_TEST_ORACLE=oracledb.com
-    #export AO_TEST_ORACLE_USERNAME=system
-    #export AO_TEST_ORACLE_PASSWORD=oracle
     ## defaults should be fine.
     ##export AO_TEST_POSTGRES_USER=postgres
     ##export AO_TEST_POSTGRES_PASSWORD=

--- a/test/probes/oracledb.test.js
+++ b/test/probes/oracledb.test.js
@@ -15,10 +15,11 @@ try {
 }
 
 const host = process.env.AO_TEST_ORACLE || 'oracle'
-const database = process.env.AO_TEST_ORACLE_DBNAME || 'xe'
+// those are "hard set" for the test image
+const database = 'xe'
 const config = {
-  user: process.env.AO_TEST_ORACLE_USERNAME || 'system',
-  password: process.env.AO_TEST_ORACLE_PASSWORD || 'oracle',
+  user: 'system',
+  password: 'topsecret',
   connectString: host + '/' + database,
 }
 let descValid = describe.skip;


### PR DESCRIPTION
This pull request replaces the "informal" Oracle database used for testing with an [Oracle Database 18c (18.4.0) Express Edition (XE)](https://github.com/oracle/docker-images/blob/main/OracleDatabase/SingleInstance/README.md#running-oracle-database-18c-express-edition-in-a-container) from a SolarWinds Dockerhub account. Tests and workflows adapted. All pass.