### PR TITLE
AO-20334-Create-GitHub-Actions-Test-Publish-Workflows-5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: Release - NPM Publish (on push tag)
 on: 
   push: 
     tags: 
-      # triggered only by major/minor/patch tags and those specifically tagged alpha. 
+      # triggered only by major/minor/patch tags and those specifically tagged prerelease.
       # standard prerelease tags do not trigger.
       - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-alpha.*'
+      - 'v[0-9]+.[0-9]+.[0-9]+-prerelease.*'
 
 jobs:
   npm-publish:
@@ -41,7 +41,7 @@ jobs:
       # *** IMPORTANT: 
       # by default any package published to npm registry is tagged with 'latest'. to set other pass --tag. 
       # any pre-release package (has - in version), regardless of name defined with version preid, will be npm tagged with 'prerelease'.
-      - name: NPM Publish (alpha)
+      - name: NPM Publish (prerelease)
         run: npm publish --tag prerelease
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
This pull-request changes the git tag used to trigger the Release workflow from `alpha` to `prerelease`.

Moving fwd:
- Version promotion will be done with: `npm version prerelease --preid prerelease`.
- Resulting in `"version": "10.0.2-prerelease.1"` in `package.json`. 
- Will be npm tagged `prerelease`. 