### PR TITLE
AO-20279-Update-NPM-Build-Test-Setup-7

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
   rules: {
     'node/handle-callback-err': 'warn',
     'node/no-deprecated-api': 'warn',
-    'camelcase': 'warn',
+    camelcase: 'warn',
     'no-eval': 'warn'
   }
 }

--- a/lib/addon-sim.js
+++ b/lib/addon-sim.js
@@ -45,7 +45,7 @@ Event.makeFromBuffer = function (buffer) {
 }
 
 Event.makeFromString = function (string) {
-  if (string.length != 60) {
+  if (string.length !== 60) {
     return undefined
   }
   const b = Buffer.from(string, 'hex')

--- a/lib/api-sim.js
+++ b/lib/api-sim.js
@@ -9,19 +9,18 @@ module.exports = function (appoptics) {
   aob = ao.addon
   // check for property to avoid triggering node 14 warning on
   // non-existent property in unfinished module.exports
-  if (ao.hasOwnProperty('cls')) {
+  if (Object.prototype.hasOwnProperty.call(ao, 'cls')) {
     cls = ao.cls
   }
 
   // define the properties (some of which are part of the API)
   definePropertiesOn(ao)
 
-  // make these globally avaiable
-  class Event {constructor () {}}
+  // make these globally available
+  class Event {}
   Event.init = function () {}
 
   class Span {
-    constructor () {}
     enter () {}
   }
 
@@ -40,7 +39,6 @@ module.exports = function (appoptics) {
   }
 
   class Metrics {
-    constructor () {}
     start () {}
     stop () {}
     resetInterval () {}

--- a/lib/api.js
+++ b/lib/api.js
@@ -36,7 +36,7 @@ module.exports = function (appoptics) {
   // each invocation in lambda is counted
   // use property check that does not trigger node 14 warning on
   // non-existent property in unfinished module.exports
-  if (ao.hasOwnProperty('lambda')) {
+  if (Object.prototype.hasOwnProperty.call(ao, 'lambda')) {
     ao.lambda.invocations = 0
   }
 
@@ -212,7 +212,7 @@ function definePropertiesOn (ao) {
 
   // this being defined is shorthand for being executed in a lambda environment.
   if (ao.execEnv.id === 'lambda') {
-    const lambda = new Object(null)
+    const lambda = {}
     Object.defineProperty(ao, 'lambda', {
       get () { return lambda }
     })

--- a/lib/event.js
+++ b/lib/event.js
@@ -108,7 +108,7 @@ function Event (span, label, parent, edge) {
  * @property {Error} error
  * @memberof Event
  */
-Object.defineProperty(Event.prototype, 'error', {
+Object.defineProperty(Event.prototype, 'error', { // eslint-disable-line accessor-pairs
   set (err) {
     // Allow string errors
     if (typeof err === 'string') {
@@ -154,7 +154,7 @@ Object.defineProperty(Event.prototype, 'opId', {
 })
 
 const getEvent = util.deprecate(() => ao.lastEvent, 'use ao.lastEvent instead of Event.last')
-const setEvent = util.deprecate(event => ao.lastEvent = event, 'use ao.lastEvent instead of Event.last')
+const setEvent = util.deprecate(event => ao.lastEvent = event, 'use ao.lastEvent instead of Event.last') // eslint-disable-line no-return-assign
 
 Object.defineProperty(Event, 'last', {
   get: getEvent,
@@ -323,7 +323,7 @@ Event.prototype.addKvPairs = function () {
       log.event.change(`{this} set ${key} = ${val}`)
     } catch (e) {
       // don't log null Layer for info events as errors.
-      if (key !== 'Layer' || val !== null && this.Label !== 'info') {
+      if (key !== 'Layer' || (val !== null && this.Label !== 'info')) {
         log.error(`failed to set ${key} = ${val} for %e - %s`, this, e.stack)
       }
     }

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -248,7 +248,7 @@ function getUnifiedConfig () {
     if (!validKey(cleansedKey)) {
       fatals.push(`not a valid serviceKey: ${serviceKey}`)
       results.global.serviceKey = ''
-    } else if (cleansedKey != serviceKey) {
+    } else if (cleansedKey !== serviceKey) {
       // the cleansed key is valid but the original key was not
       warnings.push(`serviceKey specified: "${mask(serviceKey)}" converted to: "${mask(cleansedKey)}"`)
       results.global.serviceKey = cleansedKey

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,7 +157,7 @@ if (config.insertTraceIdsIntoMorgan) {
 ao.getDomainPrefix = function (req) {
   const h = req.headers
   const s = req.socket || { localPort: 80 }
-  let prefix = h && h['x-forwarded-host'] || h.host || ''
+  let prefix = (h && h['x-forwarded-host']) || h.host || ''
   const parts = prefix.split(':')
   // if the port is included in the header then use it
   if (parts.length === 2 && parts[1]) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -24,7 +24,7 @@ class Metrics {
       // don't let metrics keep the process alive
       this.id.unref()
     }
-    return this.state = 'started'
+    return this.state = 'started' // eslint-disable-line no-return-assign
   }
 
   stop () {
@@ -33,7 +33,7 @@ class Metrics {
     }
     aob.metrics.stop()
     clearInterval(this.id)
-    return this.state = 'stopped'
+    return this.state = 'stopped' // eslint-disable-line no-return-assign
   }
 
   getState () {

--- a/lib/notifications-listener.js
+++ b/lib/notifications-listener.js
@@ -59,7 +59,7 @@ function notificationListener (msg) {
     //
     // oboe messages
     //
-    if (msg.type === 'keep-alive') {
+    if (msg.type === 'keep-alive') { // eslint-disable-line no-empty
 
     } else if (msg.type === 'logging') {
       let logLevel = 'info'

--- a/lib/probes/@hapi/hapi.js
+++ b/lib/probes/@hapi/hapi.js
@@ -8,7 +8,6 @@ const shimmer = require('shimmer')
 const semver = require('semver')
 const utility = require(path.resolve(ao.root, 'lib', 'utility'))
 const log = ao.loggers
-const Span = ao.Span
 const conf = ao.probes.hapi
 
 const notFunction = 'hapi - %s is not a function'

--- a/lib/probes/director.js
+++ b/lib/probes/director.js
@@ -26,7 +26,7 @@ function wrapHandler (path, handler) {
     return ao.instrumentHttp(
       () => {
         const exit = this.res._ao_http_span.events.exit
-        return {
+        return { // eslint-disable-line no-return-assign
           name: 'director-route',
           kvpairs: {
             Controller: exit.kv.Controller = '/' + path,

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -51,7 +51,7 @@ function patchClient (module, options, protocol) {
     if (typeof args[0] === 'string') {
       const urlString = args.shift()
       options = url.parse(urlString)
-    } else if (typeof url.URL === 'function' && args[0] instanceof url.URL || args[0].searchParams) {
+    } else if (typeof url.URL === 'function' && (args[0] instanceof url.URL || args[0].searchParams)) {
       options = urlToOptions(args.shift())
     } else if (typeof url.URL !== 'function') {
       log.error('url.URL is not a function, url keys:', url === undefined ? 'undefined' : Object.keys(url))

--- a/lib/probes/koa.js
+++ b/lib/probes/koa.js
@@ -10,7 +10,7 @@ module.exports = koa => {
   // allow the caller to invoke this with or without "new" by
   // not using an arrow function.
   return function (settings) {
-    const app = new koa(settings)
+    const app = new koa(settings) // eslint-disable-line new-cap
     wrapApp(app)
     return app
   }

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -31,7 +31,7 @@ module.exports = function (mongodb, options) {
   } catch (e) {
     logMissing('topologies/server.js')
   }
-  let proto = core && core.prototype || mongodb.Server && mongodb.Server.prototype
+  let proto = (core && core.prototype) || (mongodb.Server && mongodb.Server.prototype)
   if (proto) {
     patchCommands(proto)
   } else {
@@ -45,7 +45,7 @@ module.exports = function (mongodb, options) {
   } catch (e) {
     logMissing('topologies/replset.js')
   }
-  proto = core && core.prototype || mongodb.ReplSet && mongodb.ReplSet.prototype
+  proto = (core && core.prototype) || (mongodb.ReplSet && mongodb.ReplSet.prototype)
   if (proto) {
     patchCommands(proto)
   } else {
@@ -59,7 +59,7 @@ module.exports = function (mongodb, options) {
   } catch (e) {
     logMissing('topologies/mongos.js')
   }
-  proto = core && core.prototype || mongodb.Mongos && mongodb.Mongos.prototype
+  proto = (core && core.prototype) || (mongodb.Mongos && mongodb.Mongos.prototype)
   if (proto) {
     patchCommands(proto)
   } else {

--- a/lib/probes/pg.js
+++ b/lib/probes/pg.js
@@ -75,7 +75,7 @@ function patchPool (postgres, version) {
   }
 
   shimmer.wrap(postgres, 'Pool', pool => function (...args) {
-    const p = new pool(...args)
+    const p = new pool(...args) // eslint-disable-line new-cap
 
     if (typeof p.connect === 'function') {
       const maybeBind = fn => ao.lastEvent ? ao.bind(fn) : fn

--- a/lib/require-patch.js
+++ b/lib/require-patch.js
@@ -60,7 +60,7 @@ function patchedRequire (name) {
 
   // if no module, or no probe for the module, or it's already patched then there isn't
   // anything to do.
-  if (!mod || !probes.hasOwnProperty(name) || patched.get(mod)) {
+  if (!mod || !Object.prototype.hasOwnProperty.call(probes, name) || patched.get(mod)) {
     return mod
   }
 
@@ -75,7 +75,8 @@ function patchedRequire (name) {
   // don't try to read package.json if it's a built-in module.
   if (Module.builtinModules.indexOf(name) === -1) {
     try {
-      pkg = this.require.call(this, `${name}/package.json`)
+      // call is NOT useless
+      pkg = this.require.call(this, `${name}/package.json`) // eslint-disable-line no-useless-call
     } catch (e) {
       // nothing to do.
     }
@@ -131,7 +132,7 @@ try {
 
 probeFiles.forEach(file => {
   const m = file.match(/^(.*)+\.js$/)
-  if (m && m.length == 2) {
+  if (m && m.length === 2) {
     const name = m[1]
     exports.register(name, path.join(__dirname, 'probes', name))
     ao.loggers.probes(`found ${name} probe`)

--- a/lib/span.js
+++ b/lib/span.js
@@ -81,7 +81,7 @@ function Span (name, settings, data) {
 }
 
 const getSpan = util.deprecate(() => ao.lastSpan, 'use ao.lastSpan instead of Span.last')
-const setSpan = util.deprecate(span => ao.lastSpan = span, 'use ao.lastSpan instead of Span.last')
+const setSpan = util.deprecate(span => ao.lastSpan = span, 'use ao.lastSpan instead of Span.last') // eslint-disable-line no-return-assign
 
 Object.defineProperty(Span, 'last', {
   get: getSpan,
@@ -580,7 +580,7 @@ Span.prototype.runSync = function (fn) {
       const txname = this.getTransactionName()
       const et = (Date.now() - startTime) * 1000
 
-      const finaltxname = Span.sendNonHttpSpan(txname, et, error || ao.lambda && ret instanceof Error)
+      const finaltxname = Span.sendNonHttpSpan(txname, et, error || (ao.lambda && ret instanceof Error))
       kvpairs.TransactionName = finaltxname
       if (txname !== finaltxname) {
         log.warn('Span.runAsync txname error: %s !== %s', txname, finaltxname)
@@ -602,9 +602,11 @@ Span.prototype.runSync = function (fn) {
       // just let it return a value? and what about the callback version...
       if (!ret || typeof ret.then !== 'function') {
         log.debug('ret did not pass Promise checks in span.runAsync()')
-        return ret
+        // TODO: revisit
+        return ret // eslint-disable-line no-unsafe-finally
       }
-      return ret
+      // TODO: revisit
+      return ret // eslint-disable-line no-unsafe-finally
         .then(r => {
           if (!r || typeof r !== 'object') {
             return r

--- a/prepack.js
+++ b/prepack.js
@@ -2,7 +2,6 @@
 'use strict'
 
 const fs = require('fs')
-const files = fs.readdirSync('.', 'utf8')
 
 let errorCount = 0
 


### PR DESCRIPTION
This Pull Request is the **7th** in a series of pull requests to update the build setup and manage dependencies in package.json.

Core library files were linted and auto-fixed in PR #164 using new implemented configuration in PR #163. This pull request handles the cases where auto fixing did not change JavaScript code, and an eslint error was emitted.

This linting pass should **not** be considered a code change. 

Manual edits included:
1. Changes to conditionals ([no-mixed-operators](https://eslint.org/docs/rules/no-mixed-operators))
2. Removing unneeded constructors ([no-useless-constructor](https://eslint.org/docs/rules/no-useless-constructor))
3. Modifying how existence of object own properties are evaluated ([no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins))

Disabling eslint was added for:
1. Reassigning values in return statement ([no-return-assign](https://eslint.org/docs/rules/no-return-assign))
2. Return in async ([no-unsafe-finally](https://eslint.org/docs/rules/no-unsafe-finally)). (revisit TODO added).

All tests pass.