### PR TITLE
AO-20279-Update-NPM-Build-Test-Setup-9

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -87,6 +87,9 @@ jobs:
         image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
         ports:
           - "1433:1433"
+        env:
+          ACCEPT_EULA: true
+          SA_PASSWORD: MeetSQL2017requirements!
       mysql:
         image: "mysql:5.7.13"
         options: >-

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -85,6 +85,11 @@ jobs:
           - "27018:27017"
       mssql:
         image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
+        options: >-
+          --health-cmd "/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD -Q 'select 1' -b -o /dev/null"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           - "1433:1433"
         env:

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -81,6 +81,11 @@ jobs:
           - "27018:27017"
       mssql:
         image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
+        options: >-
+          --health-cmd "/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD -Q 'select 1' -b -o /dev/null"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           - "1433:1433"
         env:

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -83,6 +83,9 @@ jobs:
         image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
         ports:
           - "1433:1433"
+        env:
+          ACCEPT_EULA: true
+          SA_PASSWORD: MeetSQL2017requirements!
       mysql:
         image: "mysql:5.7.13"
         options: >-

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -220,7 +220,7 @@ jobs:
         # in testeachversion we may fail tests, and want to keep going.
         continue-on-error: true
         # some packages take a long time.
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: npx testeachversion --verbose -l ./docs/tmp -p ${{ matrix.pkg }}
 
       - name: Rename Result Artifacts

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -88,6 +88,11 @@ jobs:
           - "27018:27017"
       mssql:
         image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
+        options: >-
+          --health-cmd "/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD -Q 'select 1' -b -o /dev/null"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           - "1433:1433"
         env:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -90,6 +90,9 @@ jobs:
         image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
         ports:
           - "1433:1433"
+        env:
+          ACCEPT_EULA: true
+          SA_PASSWORD: MeetSQL2017requirements!
       mysql:
         image: "mysql:5.7.13"
         options: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,6 @@ Bug fix
 
 Features
 - lambda support
-- enable all logging to be suppressed via APPOPTICS_LOG_SETTINGS=''
 - capture agent version in init message
 
 Breaking change
@@ -169,3 +168,26 @@ Breaking change
 
 Bug fix
 - change config file name `appoptics-apm.{js|json}` => `appoptics-apm-config.{js|json}`
+
+### v10.0.0
+
+Features
+- `@appoptics/apm-bindings` replaces `appoptics-bindings`. `@appoptics/apm-bindings` uses `node-pre-gyp` so that users of LTS versions of node do not need to have the c/c++ build chain installed.
+- if `APPOPTICS_LOG_SETTINGS` is empty suppress all logging
+- use shimmer instead of ximmer
+- add `span.runPromise()` - native async span runner
+- updated to Apache 2.0 license
+
+Breaking change
+- Removed `ao.serviceKey`
+- Configuration file name-change
+
+Bug fix
+- pass options to koa constructor
+- check if module needs patching before doing builtin lookup
+- set txname when not set by frameworks
+
+### v10.0.1
+
+Bug fix
+- avoid triggering non-existent property warning during module.exports on Node 14

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -86,6 +86,9 @@ services:
     image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
     ports:
       - "1433:1433"
+    environment:
+      - ACCEPT_EULA=true
+      - SA_PASSWORD=MeetSQL2017requirements!
 
   mysql:
     container_name: "mysql_5_7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,24 @@
         "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/ms-rest-js": "^2.0.4",
         "adal-node": "^0.2.2"
+      },
+      "dependencies": {
+        "adal-node": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
+          "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
+          "dev": true,
+          "requires": {
+            "@xmldom/xmldom": "^0.7.0",
+            "async": "^2.6.3",
+            "axios": "^0.21.1",
+            "date-utils": "*",
+            "jws": "3.x.x",
+            "underscore": ">= 1.3.1",
+            "uuid": "^3.1.0",
+            "xpath.js": "~1.1.0"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -678,6 +696,12 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
     },
+    "@js-joda/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==",
+      "dev": true
+    },
     "@mapbox/node-pre-gyp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz",
@@ -730,16 +754,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
       "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
       "dev": true
-    },
-    "@types/readable-stream": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.11.tgz",
-      "integrity": "sha512-0z+/apYJwKFz/RHp6mOMxz/y7xOvWPYPevuCEyAY3gXsjtaac02E26RvxA+I96rfvmVH/dEMGXNvyJfViR1FSQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "safe-buffer": "*"
-      }
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -827,19 +841,28 @@
       "dev": true
     },
     "adal-node": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
-      "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
+      "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
       "dev": true,
       "requires": {
-        "@xmldom/xmldom": "^0.7.0",
-        "async": "^2.6.3",
-        "axios": "^0.21.1",
+        "@types/node": "^8.0.47",
+        "async": ">=0.6.0",
         "date-utils": "*",
         "jws": "3.x.x",
+        "request": ">= 2.52.0",
         "underscore": ">= 1.3.1",
         "uuid": "^3.1.0",
+        "xmldom": ">= 0.1.x",
         "xpath.js": "~1.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.66",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
+          "dev": true
+        }
       }
     },
     "adm-zip": {
@@ -8638,30 +8661,24 @@
       "dev": true
     },
     "tedious": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-6.7.1.tgz",
-      "integrity": "sha512-61eg/mvUa5vIqZcRizcqw/82dY65kR2uTll1TaUFh0aJ45XOrgbc8axiVR48dva8BahIAlJByaHNfAJ/KmPV0g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-10.0.0.tgz",
+      "integrity": "sha512-vw0TaRuB2GY5ex4hNMAT5c+JAeP8BoQMo0FMgVU3EnjIp8M0j4wl/msRO8G+aDfEsbDe2Keyn2YAlxtsFmSZLw==",
       "dev": true,
       "requires": {
-        "@azure/ms-rest-nodeauth": "^3.0.10",
-        "@types/node": "^12.12.17",
-        "@types/readable-stream": "^2.3.5",
+        "@azure/ms-rest-nodeauth": "^3.0.6",
+        "@js-joda/core": "^3.1.0",
+        "adal-node": "^0.1.28",
         "bl": "^3.0.0",
         "depd": "^2.0.0",
-        "iconv-lite": "^0.5.0",
-        "jsbi": "^3.1.1",
+        "iconv-lite": "^0.6.2",
+        "jsbi": "^3.1.3",
         "native-duplexpair": "^1.0.0",
         "punycode": "^2.1.0",
-        "readable-stream": "^3.4.0",
+        "readable-stream": "^3.6.0",
         "sprintf-js": "^1.1.2"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "12.20.25",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
-          "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
-          "dev": true
-        },
         "bl": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
@@ -8678,12 +8695,12 @@
           "dev": true
         },
         "iconv-lite": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-          "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         },
         "readable-stream": {
@@ -9375,6 +9392,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
       "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
       "dev": true
     },
     "xpath.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,9 +219,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.5.tgz",
-      "integrity": "sha512-2hQstc6I7T6tQsWzlboMh3SgMRPaS4H6H7cPQsJkdzTzEGqQrpLDsE2BGASU5sBPoEQyHzeqU6C8uKbFeEk6sg==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
       "dev": true
     },
     "@babel/template": {
@@ -281,9 +281,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
-      "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -726,9 +726,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.0.tgz",
-      "integrity": "sha512-nmP+VR4oT0pJUPFbKE4SXj3Yb4Q/kz3M9dSAO1GGMebRKWHQxLfDNmU/yh3xxCJha3N60nQ/JwXWwOE/ZSEVag==",
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
       "dev": true
     },
     "@types/readable-stream": {
@@ -748,9 +748,9 @@
       "dev": true
     },
     "@xmldom/xmldom": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.4.tgz",
-      "integrity": "sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
       "dev": true
     },
     "abbrev": {
@@ -843,9 +843,9 @@
       }
     },
     "adm-zip": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.5.tgz",
-      "integrity": "sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.6.tgz",
+      "integrity": "sha512-nUeYhBHLG08VFOkVwai0pLXge6NNlahH+ccwxXodvl+SLa5l9mXHjg40jRVzofRPz29goiTGze7vIKmCltKtSA==",
       "dev": true
     },
     "agent-base": {
@@ -1009,9 +1009,9 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
+      "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
       "dev": true
     },
     "array-flatten": {
@@ -1097,9 +1097,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.985.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.985.0.tgz",
-      "integrity": "sha512-Al1oFENrrDeKRpxlklk5sONqzCgEkrhaJ1vtIfpLYYqhNlAY+ku/z1hG1+qSlvgmljGyn7T6/zAb2EcbbAFZLQ==",
+      "version": "2.989.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.989.0.tgz",
+      "integrity": "sha512-sMjvqeF9mEOxXkhOAUjCrBt2iYafclkmaIbgSdjJ+te7zKXeReqrc6P3VgIGUxU8kwmdSro0n1NjrXbzKQJhcw==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -1363,9 +1363,9 @@
       "dev": true
     },
     "bson": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.1.tgz",
-      "integrity": "sha512-XqFP74pbTVLyLy5KFxVfTUyRrC1mgOlmu/iXHfXqfCKT59jyP9lwbotGfbN59cHBRbJSamZNkrSopjv+N0SqAA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.2.tgz",
+      "integrity": "sha512-8CEMJpwc7qlQtrn2rney38jQSEeMar847lz0LyitwRmVknAW8iHXrzW4fTjHfyWm0E3sukyD/zppdH+QU1QefA==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0"
@@ -1461,6 +1461,14 @@
         "array-back": "^4.0.1",
         "fs-then-native": "^2.0.0",
         "mkdirp2": "^1.0.4"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+          "dev": true
+        }
       }
     },
     "call": {
@@ -1655,9 +1663,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -2301,23 +2309,23 @@
       "dev": true
     },
     "dmd": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-5.0.2.tgz",
-      "integrity": "sha512-npXsE2+/onRPk/LCrUmx7PcUSqcSVnbrDDMi2nBSawNZ8QXlHE/8xaEZ6pNqPD1lQZv8LGr1xEIpyxP336xyfw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.0.0.tgz",
+      "integrity": "sha512-PwWZlqZnJPETwqZZ70haRa+UDZcD5jeBD3ywW1Kf+jYYv0MHu/S7Ri9jsSoeTMwkcMVW9hXOMA1IZUMEufBhOg==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^5.0.0",
         "cache-point": "^2.0.0",
         "common-sequence": "^2.0.0",
         "file-set": "^4.0.1",
-        "handlebars": "^4.7.6",
-        "marked": "^1.1.0",
+        "handlebars": "^4.7.7",
+        "marked": "^2.0.0",
         "object-get": "^2.1.1",
         "reduce-flatten": "^3.0.0",
         "reduce-unique": "^2.0.1",
         "reduce-without": "^1.0.1",
         "test-value": "^3.0.0",
-        "walk-back": "^4.0.0"
+        "walk-back": "^5.0.0"
       },
       "dependencies": {
         "reduce-flatten": {
@@ -2625,9 +2633,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "argparse": {
@@ -3095,14 +3103,6 @@
       "requires": {
         "array-back": "^5.0.0",
         "glob": "^7.1.6"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
-          "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
-          "dev": true
-        }
       }
     },
     "file-uri-to-path": {
@@ -3224,48 +3224,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
       "dev": true
-    },
-    "foreground-child": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^4",
-        "signal-exit": "^3.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
-        }
-      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -3598,12 +3560,6 @@
         "readable-stream": "^2.0.1",
         "wbuf": "^1.1.0"
       }
-    },
-    "html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
     },
     "htmlparser2": {
       "version": "3.8.3",
@@ -4035,15 +3991,6 @@
         }
       }
     },
-    "istanbul-reports": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
-      "dev": true,
-      "requires": {
-        "html-escaper": "^2.0.0"
-      }
-    },
     "items": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
@@ -4100,9 +4047,9 @@
       }
     },
     "jsbi": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.3.tgz",
-      "integrity": "sha512-j6G1XZPxyYxALX0XvgJMkyfwCpG/NOmzS8vDwXcAO5y3l2aclpabU9W0yli+G7Bfpv4j9Sg+Ln70i+wENNcaaw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.4.tgz",
+      "integrity": "sha512-iOygwxPzMYli5xrjfd83Vy4Wyu9Ovpw6wWWFy5Kj7XP+pZxPp7Cy72F92iAt2j+6tTDYunvLtC+2tH3xCX37ng==",
       "dev": true
     },
     "jsbn": {
@@ -4138,12 +4085,6 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         },
-        "marked": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-          "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -4159,49 +4100,57 @@
       }
     },
     "jsdoc-api": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-6.0.0.tgz",
-      "integrity": "sha512-zvfB63nAc9e+Rv2kKmJfE6tmo4x8KFho5vKr6VfYTlCCgqtrfPv0McCdqT4betUT9rWtw0zGkNUVkVqeQipY6Q==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-7.0.1.tgz",
+      "integrity": "sha512-SttT7mAvl/L9liIoOoa647ksFlD+fyNP2Vy80MBRi6akOmJQ4ryQjMBOPfg1veKfwVp/8f3My8Bb2JnVGL9wVg==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^5.0.0",
         "cache-point": "^2.0.0",
-        "collect-all": "^1.0.3",
-        "file-set": "^4.0.1",
+        "collect-all": "^1.0.4",
+        "file-set": "^4.0.2",
         "fs-then-native": "^2.0.0",
-        "jsdoc": "^3.6.4",
-        "object-to-spawn-args": "^2.0.0",
+        "jsdoc": "^3.6.6",
+        "object-to-spawn-args": "^2.0.1",
         "temp-path": "^1.0.0",
-        "walk-back": "^4.0.0"
+        "walk-back": "^5.0.0"
       }
     },
     "jsdoc-parse": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-5.0.0.tgz",
-      "integrity": "sha512-Khw8c3glrTeA3/PfUJUBvhrMhWpSClORBUvL4pvq2wFcqvUVmA96wxnMkCno2GfZY4pnd8BStK5WGKGyn4Vckg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.0.1.tgz",
+      "integrity": "sha512-ij3Az5y2dp+ajMxYnEJH7kjKK5v6+yZ3Cg/KtRdoT15pIm6qTk/W8q72QdNLZ9jQm/U2/ifENFXXTOe6xIxGeA==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^6.1.1",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
         "reduce-extract": "^1.0.0",
-        "sort-array": "^4.1.1",
+        "sort-array": "^4.1.4",
         "test-value": "^3.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.0.tgz",
+          "integrity": "sha512-mixVv03GOOn/ubHE4STQ+uevX42ETdk0JoMVEjNkSOCT7WgERh7C8/+NyhWYNpE3BN69pxFyJIBcF7CxWz/+4A==",
+          "dev": true
+        }
       }
     },
     "jsdoc-to-markdown": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-6.0.1.tgz",
-      "integrity": "sha512-hUI2PAR5n/KlmQU3mAWO9i3D7jVbhyvUHfQ6oYVBt+wnnsyxpsAuhCODY1ryLOb2U9OPJd4GIK9mL2hqy7fHDg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-7.0.1.tgz",
+      "integrity": "sha512-wN6WAHAPiCyAU7m/+F3FbEEV40CGVWMae49SBPIvfy7kDq/2fBrOw86vdbnLdmjt6u/tHnoxHNrHWYbYFN+4UA==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^5.0.0",
         "command-line-tool": "^0.8.0",
         "config-master": "^3.1.0",
-        "dmd": "^5.0.1",
-        "jsdoc-api": "^6.0.0",
-        "jsdoc-parse": "^5.0.0",
-        "walk-back": "^4.0.0"
+        "dmd": "^6.0.0",
+        "jsdoc-api": "^7.0.0",
+        "jsdoc-parse": "^6.0.0",
+        "walk-back": "^5.0.0"
       }
     },
     "jsesc": {
@@ -4912,9 +4861,9 @@
       "dev": true
     },
     "marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
       "dev": true
     },
     "mdurl": {
@@ -5035,9 +4984,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
+      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -5227,9 +5176,9 @@
       "optional": true
     },
     "mongodb": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.0.tgz",
-      "integrity": "sha512-JOAYjT9WYeRFkIP6XtDidAr3qvpfLRJhT2iokRWWH0tgqCQr9kmSfOJBZ3Ry0E5A3EqKxVPVhN3MV8Gn03o7pA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.1.tgz",
+      "integrity": "sha512-iSVgexYr8ID0ieeNFUbRfQeOZxOchRck6kEDVySQRaa8VIw/1Pm+/LgcpZcl/BWV6nT0L8lP9qyl7dRPJ6mnLw==",
       "dev": true,
       "requires": {
         "bl": "^2.2.1",
@@ -5764,6 +5713,15 @@
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -5814,6 +5772,13 @@
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
+        },
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true,
+          "optional": true
         },
         "commondir": {
           "version": "1.0.1",
@@ -5995,6 +5960,26 @@
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
           "dev": true
         },
+        "handlebars": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+          "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+          "dev": true,
+          "requires": {
+            "async": "^2.5.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -6126,6 +6111,15 @@
             }
           }
         },
+        "istanbul-reports": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+          "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.1.0"
+          }
+        },
         "json-parse-better-errors": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -6162,6 +6156,12 @@
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
         },
         "lodash.flattendeep": {
           "version": "4.4.0",
@@ -6240,6 +6240,29 @@
             "brace-expansion": "^1.1.7"
           }
         },
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -6287,6 +6310,22 @@
           "requires": {
             "wrappy": "1"
           }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "dev": true
         },
         "os-locale": {
           "version": "3.1.0",
@@ -6532,6 +6571,20 @@
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
+          }
+        },
         "spdx-correct": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -6607,6 +6660,26 @@
             "require-main-filename": "^1.0.1"
           }
         },
+        "uglify-js": {
+          "version": "3.4.9",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -6636,6 +6709,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
@@ -6703,9 +6782,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
@@ -6885,7 +6964,8 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "optional": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -8077,12 +8157,6 @@
         "typical": "^6.0.1"
       },
       "dependencies": {
-        "array-back": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
-          "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
-          "dev": true
-        },
         "typical": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-6.0.1.tgz",
@@ -8105,31 +8179,6 @@
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
-      }
-    },
-    "spawn-wrap": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
-      "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
-      "dev": true,
-      "requires": {
-        "foreground-child": "^1.5.6",
-        "mkdirp": "^0.5.0",
-        "os-homedir": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.2",
-        "which": "^1.3.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "spdx-correct": {
@@ -8481,9 +8530,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -8493,9 +8542,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -8608,9 +8657,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
-          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+          "version": "12.20.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+          "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
           "dev": true
         },
         "bl": {
@@ -9097,9 +9146,9 @@
       "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
     },
     "walk-back": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-4.0.0.tgz",
-      "integrity": "sha512-kudCA8PXVQfrqv2mFTG72vDBRi8BKWxGgFLwPpzHcpZnSwZk93WMwUDVcLHWNsnm+Y0AC4Vb6MUNRgaHfyV2DQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.0.tgz",
+      "integrity": "sha512-Uhxps5yZcVNbLEAnb+xaEEMdgTXl9qAQDzKYejG2AZ7qPwRQ81lozY9ECDbjLPNWm7YsO1IK5rsP1KoQzXAcGA==",
       "dev": true
     },
     "wbuf": {
@@ -9115,6 +9164,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "optional": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -9226,9 +9276,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -9366,9 +9416,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "restify": "^7.7.0",
     "should": "^8.3.1",
     "supertest": "^3.4.2",
-    "tedious": "^6.6.2",
+    "tedious": "^10.0.0",
     "testeachversion": "^9.0.0",
     "vision": "^5.4.4",
     "winston": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "express": "^4.17.1",
     "generic-pool": "^3.8.2",
     "hapi": "^18.1.0",
-    "jsdoc-to-markdown": "^6.0.1",
+    "jsdoc-to-markdown": "^7.0.1",
     "koa": "^2.13.1",
     "koa-ejs": "^4.2.0",
     "koa-resource-router": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "redis": "^3.1.2",
     "request": "^2.61.0",
     "request-promise-native": "^1.0.7",
-    "restify": "^7.7.0",
+    "restify": "^8.5.1",
     "should": "^8.3.1",
     "supertest": "^3.4.2",
     "tedious": "^10.0.0",


### PR DESCRIPTION
This Pull Request is the **9th** and hopefully the real last one in a series of pull requests to update the build setup and manage dependencies in package.json in preparation for release.

First commit (0aefb39) updates a service package to address Dependabot concerns.

Second (13a8627) and third (b31c9f0) commits handled issues specific to the `tedious` probe, MSSQL server and Document workflow results. Test now fail when they should and pass when they can. Tedious package support is two versions back from latest (there is a need and ticket for a probe update).
 
Fourth (3bf1909) and fifth (3276d10) commits handled issues specific to the `restify` probe tests and Document workflow results. 

Last commit updated CHANGELOG.md with missing data from past releases.