### PR TITLE
AO-20279-Update-NPM-Build-Test-Setup-9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -647,9 +647,9 @@
       "dev": true
     },
     "@js-joda/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-OWm/xa9O9e4ugzNHoRT3IsXZZYfaV6Ia1aRwctOmCQ2GYWMnhKBzMC1WomqCh/oGxEZKNtPy5xv5//VIAOgMqw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-XfqsWzY2jRUcVesKJ/vbZPDzfBZo2jHBWofabPozJQFguSQ0XEaUbdFPBeUICUmfeRsQn/Z+/SPTHSboT0XO3A==",
       "dev": true
     },
     "@mapbox/node-pre-gyp": {
@@ -8559,20 +8559,20 @@
       "dev": true
     },
     "tedious": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-8.3.1.tgz",
-      "integrity": "sha512-HraoUHvXbbVrdLcYSh1KBiffqvtuXubEe8zmuKFdWAEwTUi3fS3swM1HdSq5tq/Q+A0NowYf/qvkOM4qoBpNRw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-8.0.1.tgz",
+      "integrity": "sha512-Wjgk4yHRHjyw0mnY/fu+offE/Yef2N2YKxsq2zv4Hsx7rEem4PnskFFgsYmjD86m5T0O7hKecrWY0fX9CptESw==",
       "dev": true,
       "requires": {
         "@azure/ms-rest-nodeauth": "2.0.2",
-        "@js-joda/core": "^2.0.0",
+        "@js-joda/core": "^1.12.0",
         "bl": "^3.0.0",
         "depd": "^2.0.0",
         "iconv-lite": "^0.5.0",
         "jsbi": "^3.1.1",
         "native-duplexpair": "^1.0.0",
         "punycode": "^2.1.0",
-        "readable-stream": "^3.6.0",
+        "readable-stream": "^3.4.0",
         "sprintf-js": "^1.1.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "restify": "^8.5.1",
     "should": "^8.3.1",
     "supertest": "^3.4.2",
-    "tedious": "^8.0.1",
+    "tedious": "8.0.1",
     "testeachversion": "^9.0.0",
     "vision": "^5.4.4",
     "winston": "^3.3.3",


### PR DESCRIPTION
This is a further update pull request to AO-20279-Update-NPM-Build-Test-Setup-9. It locks tedious dev dependency to version 8.0.1 for node 10 and 12.