### PR TITLE
Dev setup

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - "${PWD}:/usr/src/work"
+      - "${PWD}/../appoptics-bindings-node:/usr/src/bindings"
+      - "${PWD}/../instrumented:/usr/src/instrumented"
       - ~/.gitconfig:/root/.gitconfig
       - ~/.ssh:/root/.ssh 
       - ~/.aws/credentials:/root/.aws/credentials
@@ -15,7 +17,7 @@ services:
     env_file:
       - ../.env # contains AO_TOKEN_STG, AO_TOKEN_PROD, APPOPTICS_SERVICE_KEY. TODO: remove last after modifying tests
     environment:
-      APPOPTICS_LOG_SETTINGS: error,warn,patching,bind,debug
+      APPOPTICS_LOG_SETTINGS: error,warn,patching,bind,debug,info
       APPOPTICS_COLLECTOR: localhost:7832
       APPOPTICS_REPORTER: udp
 
@@ -32,6 +34,7 @@ services:
       AO_TEST_REDIS_3_0: redis:6379
     ports:
       - "9229:9229"
+      - "3000:3000"
     links:
       - cassandra
       - memcached

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "10.1.0",
+  "version": "10.1.1-internal.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "10.1.0",
+  "version": "10.1.1-internal.0",
   "appoptics": {
     "version-suffix": "lambda-1"
   },

--- a/test/probes/tedious.test.js
+++ b/test/probes/tedious.test.js
@@ -199,13 +199,13 @@ describe('probes.tedious ' + pkg.version, function () {
         type: 'default',
         options: {
           userName: user,
-          password: pass,
+          password: pass
         }
       },
       server: addr.host,
       port: addr.port,
       options: {
-        "enableArithAbort": true,
+        enableArithAbort: true,
         tdsVersion: '7_1',
         encrypt: false
       }
@@ -216,7 +216,7 @@ describe('probes.tedious ' + pkg.version, function () {
     const connection = new Connection(settings)
 
     connection.on('connect', function (err) {
-      if(err) {
+      if (err) {
         throw err
       }
       connection.execSql(fn())


### PR DESCRIPTION
This pull request is to update dev setup for future tasks.

Commit eb1a701 modified the dev container to mount local sibling directories `appoptics-bindings-node` (assumed clone from repo) and `instrumented` (a working directory for apps) into `bindings` and `instrumented` on container. It is now possible to `npm link` package source from `instrumented` via `work` to `bindings`.  It also opened port 3000 for browser access to instrumented apps and changed debug setup.

Commit 1a80d7b unsets published version and sets it to internal.

