### PR TITLE
AO-20593-Add-Support-for-Node-17

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        node: ['10', '12', '14', '16']
+        node: ['10', '12', '14', '16', '17']
 
     steps:
       - name: Checkout ${{ github.ref }}

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -141,7 +141,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        node: ['10', '12', '14', '16']
+        node: ['10', '12', '14', '16', '17']
         pkg: [
           '@hapi/hapi',
           '@hapi/vision',

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -32,11 +32,13 @@ ENV NVM_DIR /root/.nvm
 
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 
-# these are the stable versions as of July 2021
-# cant use lts alias due to all sorts of Dockerfile limitations.
+# these are the stable versions as of November 2021
+# can't use lts alias due to all sorts of Dockerfile limitations.
 RUN source $NVM_DIR/nvm.sh \
-    && nvm install v14.17.3 \
-    && nvm install v12.22.3 \
+    && nvm install v14.18.1 \
+    && nvm install v17.0.1 \
+    && nvm install v16.13.0 \
+    && nvm install v12.22.7 \
     && nvm install v10.24.1 \
     && nvm install stable
 
@@ -44,8 +46,8 @@ RUN source $NVM_DIR/nvm.sh \
 # stay with 14.
 
 # add node and npm to path so the commands are available
-ENV NODE_PATH $NVM_DIR/v14.17.3/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v14.17.3/bin:$PATH
+ENV NODE_PATH $NVM_DIR/v14.18.1/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v14.18.1/bin:$PATH
 
 # Install tools needed for specific service tests (pg, oracle)
 RUN apt -y install \


### PR DESCRIPTION
This pull request adds support or Node 17.

Changes are limited to dev setup and GitHub Actions workflows.
Bindings support was added in: https://github.com/appoptics/appoptics-bindings-node/pull/84

All [acceptance tests pass](https://github.com/appoptics/appoptics-apm-node/actions/runs/1492694206).
Document workflow [ran as expected](https://github.com/appoptics/appoptics-apm-node/actions/runs/1493552952). [Supported components](https://github.com/appoptics/appoptics-apm-node/blob/test-each-version-2021-11-22-23-26-44/docs/supported-components.human) data generated.
