### PR TITLE
AO-20643-Verify-Workflow-flaky-due-to-AppOptics-not-ready-to-sample

### DIFF
--- a/.github/utils/server.js
+++ b/.github/utils/server.js
@@ -8,7 +8,7 @@ const args = arg({ '--preflight': Boolean, '--port': Number })
 
 const preflight = async () => {
   // server must be instrumented and will exit with error if not
-  const isReady = await ao.readyToSample(1000)
+  const isReady = await ao.readyToSample(5000)
   if (!isReady) throw new Error('AppOptics not ready to sample.')
 }
 


### PR DESCRIPTION
This pull request applies the simplest solution to the "flakiness" problem - allow oboe to try by itself - it increased readyToSample wait five fold to 5000 ms.