### PR TITLE
AO-14556-Remove-sampleTrace-From-Tests

### DIFF
--- a/lib/addon-sim.js
+++ b/lib/addon-sim.js
@@ -85,7 +85,6 @@ const addon = {
   Settings: {
     setTracingMode () {},
     setDefaultSampleRate (r) { return r },
-    sampleTrace () {},
     toString () { return '' },
     set () {},
     clear () {},

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -13,7 +13,6 @@ describe('error', function () {
   const conf = { enabled: true }
   let error
   let emitter
-  let realSampleTrace
 
   function testSpan (span) {
     return span.descend('test')
@@ -42,13 +41,8 @@ describe('error', function () {
     emitter = helper.appoptics(done)
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
   })
   after(function (done) {
-    ao.addon.Context.sampleTrace = realSampleTrace
     emitter.close(done)
   })
 

--- a/test/probes/amqp.skip-test.js
+++ b/test/probes/amqp.skip-test.js
@@ -19,7 +19,6 @@ describe('probes.amqp ' + pkg.version, function () {
   var ctx = {}
   var client
   var db
-  var realSampleTrace
 
   // increase timeout for travis-ci.
   this.timeout(10000)
@@ -60,13 +59,8 @@ describe('probes.amqp ' + pkg.version, function () {
     emitter = helper.appoptics(done)
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
   })
   after(function (done) {
-    ao.addon.Context.sampleTrace = realSampleTrace
     emitter.close(done)
   })
 

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -45,7 +45,6 @@ describe('probes.fs once', function () {
 describe('probes.fs', function () {
   let emitter
   let mode
-  let realSampleTrace
 
   beforeEach(function (done) {
     // wait a tenth of a second between tests.
@@ -104,14 +103,9 @@ describe('probes.fs', function () {
     emitter = helper.appoptics(done)
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
   })
   after(function (done) {
     emitter.close(done)
-    ao.addon.Context.sampleTrace = realSampleTrace
   })
 
   const resolved = path.resolve('fs-output/foo.bar.link')

--- a/test/probes/http-websocket-common.js
+++ b/test/probes/http-websocket-common.js
@@ -36,7 +36,6 @@ const options = p === 'https' ? httpsOptions : {}
 
 describe(`probes.${p} websocket`, function () {
   let emitter
-  let realSampleTrace
   const previousHttpEnabled = ao.probes[p].enabled
   const previousHttpClientEnabled = ao.probes[`${p}-client`].enabled
   let clear
@@ -45,16 +44,11 @@ describe(`probes.${p} websocket`, function () {
   before(function (done) {
     ao.sampleRate = addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
     ao.g.testing(__filename)
     // intercept message for analysis
     emitter = helper.appoptics(done)
   })
   after(function (done) {
-    ao.addon.Context.sampleTrace = realSampleTrace
     emitter.close(done)
   })
   after(function () {

--- a/test/probes/koa-router.test.js
+++ b/test/probes/koa-router.test.js
@@ -17,7 +17,6 @@ try {
 describe('probes/koa-router ' + pkg.version, function () {
   let emitter
   const tests = canGenerator && require('./koa')
-  let realSampleTrace
 
   //
   // Intercept appoptics messages for analysis
@@ -28,17 +27,11 @@ describe('probes/koa-router ' + pkg.version, function () {
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
 
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
-
     ao.g.testing(__filename)
   })
   after(function (done) {
     ao.probes.fs.enabled = true
 
-    ao.addon.Context.sampleTrace = realSampleTrace
     emitter.close(done)
   })
 

--- a/test/probes/memcached.test.js
+++ b/test/probes/memcached.test.js
@@ -14,7 +14,6 @@ describe('probes.memcached ' + pkg.version, function () {
   this.timeout(10000)
   let emitter
   let mem
-  let realSampleTrace
 
   //
   // Intercept appoptics messages for analysis
@@ -24,15 +23,9 @@ describe('probes.memcached ' + pkg.version, function () {
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
 
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
-
     ao.g.testing(__filename)
   })
   after(function (done) {
-    ao.addon.Context.sampleTrace = realSampleTrace
     emitter.close(done)
   })
 

--- a/test/probes/oracledb.test.js
+++ b/test/probes/oracledb.test.js
@@ -31,7 +31,6 @@ if (oracledb && host && database && config.user && config.password) {
 
 descValid(`probes.oracledb ${pkg.version}`, function () {
   let emitter
-  let realSampleTrace
   let lastConnection
 
   //
@@ -42,15 +41,9 @@ descValid(`probes.oracledb ${pkg.version}`, function () {
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
 
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
-
     ao.g.testing(__filename)
   })
   after(function (done) {
-    ao.addon.Context.sampleTrace = realSampleTrace
     emitter.close(done)
   })
 

--- a/test/probes/pg6-minus.js
+++ b/test/probes/pg6-minus.js
@@ -41,7 +41,6 @@ if (canNative) {
 
 describe('probes.pg ' + pkg.version, function () {
   let emitter
-  let realSampleTrace
 
   it('should sanitize SQL by default', function () {
     conf.should.have.property('sanitizeSql', true)
@@ -57,15 +56,9 @@ describe('probes.pg ' + pkg.version, function () {
     ao.traceMode = 'always'
     ao.probes.fs.enabled = false
 
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
-
     ao.g.testing(__filename)
   })
   after(function (done) {
-    ao.addon.Context.sampleTrace = realSampleTrace
     ao.probes.fs.enabled = true
     emitter.close(done)
   })

--- a/test/probes/pg6-plus.js
+++ b/test/probes/pg6-plus.js
@@ -41,7 +41,6 @@ try {
 
 describe(`probes.pg6+ ${pkg.version} pg-native ${nativeVer}`, function () {
   let emitter
-  let realSampleTrace
   const ctx = { ao, tName, addr }
 
   it('should sanitize SQL by default', function () {
@@ -71,15 +70,9 @@ describe(`probes.pg6+ ${pkg.version} pg-native ${nativeVer}`, function () {
   // basic test setup and teardown
   //
   before(function () {
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
-
     ao.g.testing(__filename)
   })
   after(function () {
-    ao.addon.Context.sampleTrace = realSampleTrace
     ao.probes.fs.enabled = true
   })
 

--- a/test/probes/redis.test.js
+++ b/test/probes/redis.test.js
@@ -20,7 +20,6 @@ const client = redis.createClient(addr.port, addr.host, {})
 describe('probes.redis ' + pkg.version, function () {
   const ctx = { redis: client }
   let emitter
-  let realSampleTrace
 
   //
   // Intercept appoptics messages for analysis
@@ -30,15 +29,9 @@ describe('probes.redis ' + pkg.version, function () {
     ao.sampleRate = addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
 
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
-
     ao.g.testing(__filename)
   })
   after(function (done) {
-    ao.addon.Context.sampleTrace = realSampleTrace
     emitter.close(done)
   })
 

--- a/test/probes/zlib.test.js
+++ b/test/probes/zlib.test.js
@@ -72,7 +72,6 @@ describe('probes.zlib once', function () {
 describe('probes.zlib', function () {
   const options = { chunkSize: 1024 }
   let emitter
-  let realSampleTrace = ao.addon.Context.sampleTrace
 
   //
   // Intercept appoptics messages for analysis
@@ -81,13 +80,8 @@ describe('probes.zlib', function () {
     emitter = helper.appoptics(done)
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
-    realSampleTrace = ao.addon.Context.sampleTrace
-    ao.addon.Context.sampleTrace = function () {
-      return { sample: true, source: 6, rate: ao.sampleRate }
-    }
   })
   after(function (done) {
-    ao.addon.Context.sampleTrace = realSampleTrace
     emitter.close(done)
   })
 


### PR DESCRIPTION
This pull request removes reference to sampleTrace(), an old function, replaced by getTraceSettings() circa 2019, from tests and addon sim.

All tests pass.