### PR TITLE
AO-16676-Replace-request-with-axios

### DIFF
--- a/test/probes/express.test.js
+++ b/test/probes/express.test.js
@@ -7,8 +7,7 @@ const { ao } = require('../1.test-common')
 const legacy = ao.probes.express.legacyTxname
 
 const semver = require('semver')
-
-const request = require('request')
+const axios = require('axios')
 const express = require('express')
 const morgan = require('morgan')
 const bodyParser = require('body-parser')
@@ -334,13 +333,10 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      const options = {
-        url: 'http://localhost:' + port + (method === 'get' ? '/hello/world' : '/api/set-name')
-      }
-      if (method === 'post') {
-        options.json = { name: 'bruce' }
-      }
-      request[method](options)
+      const url = 'http://localhost:' + port + (method === 'get' ? '/hello/world' : '/api/set-name')
+
+      const options = method === 'post' ? { name: 'bruce' } : {}
+      axios[method](url, options)
     })
   }
 
@@ -455,7 +451,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   }
 
@@ -525,7 +521,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   })
 
@@ -591,7 +587,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   })
 
@@ -657,7 +653,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   })
 
@@ -704,7 +700,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   })
 
@@ -776,7 +772,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   }
 
@@ -796,7 +792,7 @@ describe('probes.express ' + pkg.version, function () {
       res.send('done')
     }
 
-    const request = require('supertest')
+    const supertest = require('supertest')
     const app = express()
 
     app.get(reqRoutePath, hello)
@@ -821,7 +817,7 @@ describe('probes.express ' + pkg.version, function () {
     ]
     helper.doChecks(emitter, validations, done)
 
-    request(app)
+    supertest(app)
       .get('/hello/world')
       .expect(200)
       .end(function (err, res) {
@@ -857,7 +853,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   })
 
@@ -923,7 +919,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port)
+      axios('http://localhost:' + port)
     })
   })
 
@@ -973,7 +969,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   })
 
@@ -1029,7 +1025,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   }
 
@@ -1072,7 +1068,7 @@ describe('probes.express ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request.get('http://localhost:' + port + '/hello/world', function (err, res, body) {
+      axios.get('http://localhost:' + port + '/hello/world', function (err, res, body) {
         if (err) {
           throw new Error('request failed')
         } else {

--- a/test/probes/hapi/hapi-16-and-below.js
+++ b/test/probes/hapi/hapi-16-and-below.js
@@ -11,7 +11,7 @@ const { ao } = require('../../1.test-common')
 
 const semver = require('semver')
 
-const request = require('request')
+const axios = require('axios')
 
 // Don't even load hapi in 0.8. Bad stuff will happen.
 const nodeVersion = process.version.slice(1)
@@ -198,12 +198,10 @@ describe('probes.hapi ' + pkg.version + ' vision ' + visionPkg.version, function
 
       p.then(() => {
         server.start(function () {
-          request({
-            method: method.toUpperCase(),
+          axios({
+            method,
             url: `http://localhost:${port}/hello/world`,
             headers: { 'accept-encoding': 'gzip' }
-          }).on('response', function (r) {
-            // console.log('got response', r.headers);
           })
         })
       })
@@ -254,7 +252,7 @@ describe('probes.hapi ' + pkg.version + ' vision ' + visionPkg.version, function
 
     p.then(() => {
       server.start(function () {
-        request('http://localhost:' + port + '/hello/world')
+        axios('http://localhost:' + port + '/hello/world')
       })
     })
   }
@@ -283,10 +281,7 @@ describe('probes.hapi ' + pkg.version + ' vision ' + visionPkg.version, function
 
     p.then(() => {
       server.start(function () {
-        request({
-          method: 'GET',
-          url: 'http://localhost:' + port + '/hello/world'
-        })
+        axios('http://localhost:' + port + '/hello/world')
       })
     })
   }

--- a/test/probes/hapi/hapi-17-and-above.js
+++ b/test/probes/hapi/hapi-17-and-above.js
@@ -11,7 +11,6 @@ const ao = global[Symbol.for('AppOptics.Apm.Once')]
 
 const semver = require('semver')
 
-const request = require('request')
 const axios = require('axios')
 
 // This test can't even be compiled if JavaScript doesn't recognize async/await.
@@ -256,7 +255,7 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
 
     await server.start()
 
-    request(`http://localhost:${port}/hello/world`)
+    axios(`http://localhost:${port}/hello/world`)
 
     return p
   }
@@ -290,7 +289,7 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
 
     await server.start()
 
-    request({ method: 'GET', url: `http://localhost:${port}/hello/world` })
+    axios(`http://localhost:${port}/hello/world`)
 
     return p
   }
@@ -452,10 +451,7 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
 
       await server.start()
 
-      request({
-        method: 'GET',
-        url: `http://localhost:${port}/hello/world`
-      })
+      axios(`http://localhost:${port}/hello/world`)
 
       return p
     }

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -17,7 +17,7 @@ const util = require('util')
 const addon = ao.addon
 
 const semver = require('semver')
-const request = require('request')
+const axios = require('axios')
 
 if (process.env.AO_TEST_HTTP !== 'http' && process.env.AO_TEST_HTTP !== 'https') {
   throw new Error(`invalid value for AO_TEST_HTTP: ${process.env.AO_TEST_HTTP}`)
@@ -190,7 +190,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         port = server.address().port
-        request(
+        axios(
           `${p}://localhost:${port}/foo?bar=baz`,
           function (error, response, body) {
             expect(response.headers).exist
@@ -225,7 +225,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request({
+        axios({
           url: `${p}://localhost:${port}`,
           headers: {
             'X-Trace': origin.toString()
@@ -262,7 +262,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request({ url: `${p}://localhost:${port}` })
+        axios({ url: `${p}://localhost:${port}` })
       })
     })
 
@@ -298,7 +298,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request({
+        axios({
           url: `${p}://localhost:${port}`,
           headers: { 'X-Trace': xtrace }
         },
@@ -333,7 +333,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request({ url: `${p}://localhost:${port}` })
+        axios({ url: `${p}://localhost:${port}` })
       })
     })
 
@@ -372,8 +372,8 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request({ url: `${p}://localhost:${port}/filtered` })
-        request({ url: `${p}://localhost:${port}/files/binary.data` })
+        axios({ url: `${p}://localhost:${port}/filtered` })
+        axios({ url: `${p}://localhost:${port}/files/binary.data` })
       })
 
       // 1/10 second should be enough to get all messages. there's no clean way to
@@ -416,7 +416,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request(`${p}://localhost:${port}`)
+        axios(`${p}://localhost:${port}`)
       })
     })
 
@@ -448,7 +448,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request(`${p}://localhost:${port}/foo?bar=baz`)
+        axios(`${p}://localhost:${port}/foo?bar=baz`)
       })
     })
 
@@ -495,7 +495,7 @@ describe(`probes.${p}`, function () {
             url: `${p}://localhost:${port}`,
             headers: headers
           }
-          request(options)
+          axios(options)
         })
       })
     })
@@ -526,7 +526,7 @@ describe(`probes.${p}`, function () {
           url: `${p}://localhost:${port}`,
           headers: { 'x-real-ip': ClientIPExpected }
         }
-        request(options)
+        axios(options)
       })
     })
 
@@ -552,7 +552,7 @@ describe(`probes.${p}`, function () {
         const options = {
           url: `${p}://localhost:${port}`
         }
-        request(options)
+        axios(options)
       })
     })
 
@@ -587,7 +587,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         port = server.address().port
-        request(`${p}://localhost:${port}/foo?bar=baz`)
+        axios(`${p}://localhost:${port}/foo?bar=baz`)
       })
     })
 
@@ -622,7 +622,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         port = server.address().port
-        request(`${p}://localhost:${port}/food?bar=baz`)
+        axios(`${p}://localhost:${port}/food?bar=baz`)
       })
     })
 
@@ -659,7 +659,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request(`${p}://localhost:${port}`)
+        axios(`${p}://localhost:${port}`)
       })
     })
   })

--- a/test/probes/koa.js
+++ b/test/probes/koa.js
@@ -9,7 +9,7 @@ const semver = require('semver')
 const koaRouterVersion = require('koa-router/package.json').version
 
 const helper = require('../helper')
-const request = require('request')
+const axios = require('axios')
 
 const { ao } = require('../1.test-common')
 
@@ -116,7 +116,7 @@ exports.basic = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port + '/hello/world')
+    axios('http://localhost:' + port + '/hello/world')
   })
 }
 
@@ -138,7 +138,7 @@ exports.disabled = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port)
+    axios('http://localhost:' + port)
   })
 }
 
@@ -163,7 +163,7 @@ exports.route = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port + '/hello/world')
+    axios('http://localhost:' + port + '/hello/world')
   })
 }
 
@@ -187,7 +187,7 @@ exports.route_disabled = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port + '/hello/world')
+    axios('http://localhost:' + port + '/hello/world')
   })
 }
 
@@ -237,7 +237,7 @@ exports.router = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port + '/hello/world')
+    axios('http://localhost:' + port + '/hello/world')
   })
 }
 
@@ -277,7 +277,7 @@ exports.router_promise = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request.post('http://localhost:' + port + '/api/visit')
+    axios.post('http://localhost:' + port + '/api/visit')
   })
 }
 
@@ -311,7 +311,7 @@ exports.router_disabled = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port + '/hello/world')
+    axios('http://localhost:' + port + '/hello/world')
   })
 }
 
@@ -341,7 +341,7 @@ exports.resourceRouter = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port + '/hello')
+    axios('http://localhost:' + port + '/hello')
   })
 }
 
@@ -369,7 +369,7 @@ exports.resourceRouter_disabled = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port + '/hello')
+    axios('http://localhost:' + port + '/hello')
   })
 }
 
@@ -411,7 +411,7 @@ exports.render = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port)
+    axios('http://localhost:' + port)
   })
 }
 
@@ -449,6 +449,6 @@ exports.render_disabled = function (emitter, done) {
 
   const server = app.listen(function () {
     const port = server.address().port
-    request('http://localhost:' + port)
+    axios('http://localhost:' + port)
   })
 }

--- a/test/probes/raw-body.test.js
+++ b/test/probes/raw-body.test.js
@@ -6,7 +6,7 @@ const { ao } = require('../1.test-common')
 
 const semver = require('semver')
 
-const request = require('request')
+const axios = require('axios')
 const express = require('express')
 const body = require('body-parser')
 const rawBody = require('raw-body')
@@ -107,7 +107,7 @@ describe('probes.raw-body ' + pkg.version, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request.post('http://localhost:' + port, {
+      axios.post('http://localhost:' + port, {
         form: {
           key: 'value'
         }

--- a/test/probes/restify.test.js
+++ b/test/probes/restify.test.js
@@ -8,7 +8,7 @@ const { ao } = require('../1.test-common')
 const expect = require('chai').expect
 const semver = require('semver')
 
-const request = require('request')
+const axios = require('axios')
 
 const pkg = require('restify/package.json')
 const opts = {
@@ -137,7 +137,7 @@ describe(`probes.restify ${pkg.version}`, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   }
 
@@ -188,7 +188,7 @@ describe(`probes.restify ${pkg.version}`, function () {
 
     const server = app.listen(function () {
       const port = server.address().port
-      request('http://localhost:' + port + '/hello/world')
+      axios('http://localhost:' + port + '/hello/world')
     })
   }
 

--- a/test/probes/vision/vision-4-and-below.js
+++ b/test/probes/vision/vision-4-and-below.js
@@ -11,7 +11,7 @@ const { ao } = require('../../1.test-common')
 
 const semver = require('semver')
 
-const request = require('request')
+const axios = require('axios')
 
 // Don't even load hapi in 0.8. Bad stuff will happen.
 const nodeVersion = process.version.slice(1)
@@ -189,10 +189,7 @@ describe('probes.vision ' + pkg.version + ' hapi ' + hapiPkg.version, function (
 
       p.then(() => {
         server.start(function () {
-          request({
-            method: method.toUpperCase(),
-            url: 'http://localhost:' + port + '/hello/world'
-          })
+          axios[method]('http://localhost:' + port + '/hello/world')
         })
       })
     }
@@ -243,7 +240,7 @@ describe('probes.vision ' + pkg.version + ' hapi ' + hapiPkg.version, function (
 
     p.then(() => {
       server.start(function () {
-        request('http://localhost:' + port + '/hello/world')
+        axios('http://localhost:' + port + '/hello/world')
       })
     })
   }
@@ -277,10 +274,7 @@ describe('probes.vision ' + pkg.version + ' hapi ' + hapiPkg.version, function (
 
     p.then(() => {
       server.start(function () {
-        request({
-          method: 'GET',
-          url: 'http://localhost:' + port + '/hello/world'
-        })
+        axios('http://localhost:' + port + '/hello/world')
       })
     })
   }

--- a/test/probes/vision/vision-5-and-above.js
+++ b/test/probes/vision/vision-5-and-above.js
@@ -11,7 +11,7 @@ const ao = global[Symbol.for('AppOptics.Apm.Once')]
 
 const semver = require('semver')
 
-const request = require('request')
+const axios = require('axios')
 
 // This test can't even be compiled if JavaScript doesn't recognize async/await.
 const nodeVersion = process.version.slice(1)
@@ -179,10 +179,7 @@ describe(`probes.${visionName} ${pkg.version} ${hapiText}`, function () {
 
       await server.start()
 
-      request({
-        method: method.toUpperCase(),
-        url: `http://localhost:${port}/hello/world`
-      })
+      axios[method](`http://localhost:${port}/hello/world`)
 
       return p
     }
@@ -238,7 +235,7 @@ describe(`probes.${visionName} ${pkg.version} ${hapiText}`, function () {
 
     await server.start()
 
-    request(`http://localhost:${port}/hello/world`)
+    axios(`http://localhost:${port}/hello/world`)
 
     return p
   }
@@ -281,7 +278,7 @@ describe(`probes.${visionName} ${pkg.version} ${hapiText}`, function () {
 
     await server.start()
 
-    request({ method: 'GET', url: `http://localhost:${port}/hello/world` })
+    axios(`http://localhost:${port}/hello/world`)
 
     return p
   }


### PR DESCRIPTION
This pull request replaces `request` with `axios` in tests as `request` is now fully deprecated.

Note that `request` itself is still instrumented and hence there is a `request` test and it is still a "dev dependency".