### PR TITLE
W3C -race-Context

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -35,6 +35,9 @@ services:
     ports:
       - "9229:9229"
       - "3000:3000"
+      - "3100:3100"
+      - "3200:3200"
+
     links:
       - cassandra
       - memcached

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -339,9 +339,6 @@ function patchServer (module, options, protocol) {
     // add any URL filter (if none will be undefined which is ignored).
     settingsOptions.mode = getUrlFilterMode(req)
 
-    // declare no edge
-    settingsOptions.edge = (w3c.info.type !== 'Source' && w3c.info.type !== 'Downstream')
-
     // xtrace will be defined in any case where either x-trace or transparent are received via header
     // knock it out for Downstream type so that when called getTraceSettings makes a fresh tracing decision.
     // validate by creating an event.

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -78,7 +78,7 @@ function patchClient (module, options, protocol) {
       span.async = true
 
       // generate w3c headers from event data
-      const w3c = w3cTraceContext.fromData({
+      const w3c = w3cTraceContext.prepHeaders({
         xtrace: span.events.entry.toString(),
         tracestate: ao.requestStore.get('tracestatestate')
       })
@@ -265,9 +265,6 @@ function patchServer (module, options, protocol) {
     // setup for metrics
     res._ao_metrics = { doMetrics: true }
 
-    // take whatever headers received and create a full w3c set from them
-    const w3c = w3cTraceContext.fromHeaders(req.headers)
-
     // get xtrace options headers too. these are used for trigger-trace,
     // i.e., forcing a trace, as well as providing KV pairs to be added
     // to a trace.
@@ -339,10 +336,14 @@ function patchServer (module, options, protocol) {
     // add any URL filter (if none will be undefined which is ignored).
     settingsOptions.mode = getUrlFilterMode(req)
 
+    // take whatever headers received and create a full w3c set from them
+    const w3c = w3cTraceContext.fromHeaders(req.headers)
+    const reqType = w3cTraceContext.reqType(req.headers)
+
     // xtrace will be defined in any case where either x-trace or transparent are received via header
     // knock it out for Downstream type so that when called getTraceSettings makes a fresh tracing decision.
     // validate by creating an event.
-    const xtrace = ao.xtraceToEvent(w3c.xtrace) && w3c.info.type !== 'Downstream' ? w3c.xtrace : ''
+    const xtrace = ao.xtraceToEvent(w3c.xtrace) && reqType !== 'Downstream' ? w3c.xtrace : ''
 
     // get decisions about sampling, metrics, trigger-trace, etc. i.e., life,
     // the universe, and everything.
@@ -354,13 +355,13 @@ function patchServer (module, options, protocol) {
 
     // if Downstream a new xtrace was created ignoring transparent
     // fix that by placing the original compatible xtrace in settings object
-    if (!xtrace && w3c.info.type === 'Downstream') {
+    if (!xtrace && reqType === 'Downstream') {
       settings.traceTaskId = ao.xtraceToEvent(w3c.xtrace)
     }
 
     // if xtrace was not defined (or not good) a new xtrace was created in format that is not w3c compatible
     // fix that by creating an xtrace that is compatible with w3c and place it in settings object
-    if (!xtrace && w3c.info.type !== 'Downstream') {
+    if (!xtrace && reqType !== 'Downstream') {
       const compatibleXtrace =
         settings.metadata.toString().slice(0, 34) +
         w3cTraceContext.padding +
@@ -407,8 +408,8 @@ function patchServer (module, options, protocol) {
           Proto: protocol
         }
         // set per w3c key value pairs per spec
-        if (w3c.info.type === 'Continuation') {
-          kvpairs['sw.parent_id'] = w3c.info.savedSpanId
+        if (reqType === 'Continuation') {
+          kvpairs['sw.parent_id'] = w3c.savedSpanId
           kvpairs['sw.w3c.tracestate'] = w3c.tracestate
         }
 

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -395,7 +395,8 @@ function patchServer (module, options, protocol) {
           Port: getPort(req),
           Method: req.method,
           URL: getPath(req),
-          Proto: protocol
+          Proto: protocol,
+          'sw.trace_context': w3c.traceparent
         }
         // set per w3c key value pairs per spec
         if (w3c.info.type === 'Continuation') {

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -395,8 +395,7 @@ function patchServer (module, options, protocol) {
           Port: getPort(req),
           Method: req.method,
           URL: getPath(req),
-          Proto: protocol,
-          'sw.trace_context': w3c.traceparent
+          Proto: protocol
         }
         // set per w3c key value pairs per spec
         if (w3c.info.type === 'Continuation') {

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -6,10 +6,9 @@ const os = require('os')
 const semver = require('semver')
 
 const ao = require('..')
-const Span = ao.Span
+const w3cTraceContext = require('../w3c-trace-context')
 
 const log = ao.loggers
-
 // avoid issuing too many errors on bad transactions
 const dbSendError = new log.Debounce('error')
 
@@ -78,13 +77,23 @@ function patchClient (module, options, protocol) {
       span = last.descend(name)
       span.async = true
 
+      // generate w3c headers from event data
+      const w3c = w3cTraceContext.fromData({
+        xtrace: span.events.entry.toString(),
+        tracestate: ao.requestStore.get('tracestatestate')
+      })
+
       options.headers = options.headers || {}
       // Add X-Trace header to trace hops unless omit is set. this should be set when a package
       // checksums headers. if there is no error, it's not generally a problem, but on errors a
       // retry will get a different x-trace value and will fail authentication at the remote end.
       // this was added to handle the AWS api.
       if (!options.headers[ao.omitTraceId]) {
-        options.headers['x-trace'] = span.events.entry.toString()
+        options.headers.traceparent = w3c.traceparent
+        options.headers.tracestate = w3c.tracestate
+        // TODO: revisit
+        // send out x-trace header to ensure compatibility with older agents
+        options.headers['x-trace'] = w3c.xtrace
       }
 
       // Set default protocol
@@ -112,7 +121,9 @@ function patchClient (module, options, protocol) {
         Spec: 'rsc',
         IsService: 'yes',
         RemoteURL: url.format(filtered),
-        HTTPMethod: (options.method || 'GET').toUpperCase()
+        HTTPMethod: (options.method || 'GET').toUpperCase(),
+        W3C_traceparent: w3c.traceparent,
+        W3C_tracestate: w3c.tracestate
       }
 
       if (conf.collectBacktraces && last.doSample) {
@@ -164,6 +175,7 @@ function patchClient (module, options, protocol) {
         ret.prependListener('response', res => {
           // Continue from X-Trace header, if present
           const xtrace = res.headers['x-trace']
+
           // validate that task ID matches and op ID is not all zeros.
           if (xtrace) {
             // get this span's entry event's xtrace ID.
@@ -255,18 +267,8 @@ function patchServer (module, options, protocol) {
     // setup for metrics
     res._ao_metrics = { doMetrics: true }
 
-    // if it is undefined make it a string
-    let xtrace = req.headers['x-trace'] || ''
-    // if there is an xtrace header see if it is good by trying
-    // to convert it to an Event.
-    if (xtrace) {
-      const ev = ao.xtraceToEvent(xtrace)
-      // if it isn't a valid xtrace set it to an empty string so it won't be
-      // used in getTraceSettings().
-      if (!ev) {
-        xtrace = ''
-      }
-    }
+    // take whatever headers received and create a full w3c set from them
+    const w3c = w3cTraceContext.fromHeaders(req.headers)
 
     // get xtrace options headers too. these are used for trigger-trace,
     // i.e., forcing a trace, as well as providing KV pairs to be added
@@ -339,11 +341,34 @@ function patchServer (module, options, protocol) {
     // add any URL filter (if none will be undefined which is ignored).
     settingsOptions.mode = getUrlFilterMode(req)
 
-    //
+    // x-trace will be defined in any case where either x-trace or transparent are received via header
+    // validate by creating an event.
+    const xtrace = ao.xtraceToEvent(w3c.xtrace) ? w3c.xtrace : ''
+
+    // declare no edge
+    settingsOptions.edge = (w3c.info.type !== 'Source' && w3c.info.type !== 'Downstream')
+
     // get decisions about sampling, metrics, trigger-trace, etc. i.e., life,
     // the universe, and everything.
-    //
     const settings = ao.getTraceSettings(xtrace, settingsOptions)
+
+    // if xtrace was not defined (or not good) a new xtrace was created in format that is not w3c compatible
+    // create an xtrace that is compatible with w3c and place it in setting object
+    if (!xtrace) {
+      const compatibleXtrace =
+        settings.metadata.toString().slice(0, 34) +
+        w3cTraceContext.padding +
+        settings.metadata.toString().slice(-18, -2) +
+        (settings.doSample ? '01' : '00') // need to set from flag in case of manipulated
+
+      settings.traceTaskId = ao.xtraceToEvent(compatibleXtrace)
+
+      // TODO: revisit.
+      // migration guide from v7 to v8 says:
+      // "ao.getTraceSettings()` now returns a settings object with the `traceTaskId`property instead of the `metadata` property."
+      // however both are still present. Thus set both to match.
+      settings.metadata = ao.xtraceToEvent(compatibleXtrace)
+    }
 
     const args = arguments
 
@@ -372,8 +397,18 @@ function patchServer (module, options, protocol) {
           Port: getPort(req),
           Method: req.method,
           URL: getPath(req),
-          Proto: protocol
+          Proto: protocol,
+          W3C_type: w3c.info.type
         }
+        if (w3c.info.type === 'Continuation') {
+          kvpairs.W3C_savedSpanId = w3c.info.savedSpanId
+          kvpairs.W3C_savedFlags = w3c.info.savedFlags
+          kvpairs.W3C_spanId = w3c.info.spanId
+          kvpairs.W3C_tracestate = w3c.tracestate
+        }
+
+        // keep tracestate so that it can be picked by client and forwarded downstream
+        ao.requestStore.set('tracestatestate', w3c.tracestate)
 
         // helper to add x-trace-options-specified keys to the kvpairs.
         function addKeysToKVPairs () {
@@ -427,7 +462,7 @@ function patchServer (module, options, protocol) {
           xtraceOptsResponse = responseParts.join(';')
         }
 
-        const span = res._ao_http_span = Span.makeEntrySpan('nodejs', settings, kvpairs)
+        const span = res._ao_http_span = ao.Span.makeEntrySpan('nodejs', settings, kvpairs)
 
         // add a counter to track how many times a custom name's been set
         res._ao_metrics.customNameFuncCalls = 0
@@ -509,6 +544,7 @@ function patchServer (module, options, protocol) {
     const { exit } = span.events
     exit.ignore = true
     res.setHeader('X-Trace', exit.toString())
+
     if (optionsResponse) {
       res.setHeader('X-Trace-Options-Response', optionsResponse)
     }

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -121,9 +121,7 @@ function patchClient (module, options, protocol) {
         Spec: 'rsc',
         IsService: 'yes',
         RemoteURL: url.format(filtered),
-        HTTPMethod: (options.method || 'GET').toUpperCase(),
-        W3C_traceparent: w3c.traceparent,
-        W3C_tracestate: w3c.tracestate
+        HTTPMethod: (options.method || 'GET').toUpperCase()
       }
 
       if (conf.collectBacktraces && last.doSample) {
@@ -397,14 +395,12 @@ function patchServer (module, options, protocol) {
           Port: getPort(req),
           Method: req.method,
           URL: getPath(req),
-          Proto: protocol,
-          W3C_type: w3c.info.type
+          Proto: protocol
         }
+        // set per w3c key value pairs per spec
         if (w3c.info.type === 'Continuation') {
-          kvpairs.W3C_savedSpanId = w3c.info.savedSpanId
-          kvpairs.W3C_savedFlags = w3c.info.savedFlags
-          kvpairs.W3C_spanId = w3c.info.spanId
-          kvpairs.W3C_tracestate = w3c.tracestate
+          kvpairs['sw.parent_id'] = w3c.info.savedSpanId
+          kvpairs['sw.w3c.tracestate'] = w3c.tracestate
         }
 
         // keep tracestate so that it can be picked by client and forwarded downstream

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -339,34 +339,46 @@ function patchServer (module, options, protocol) {
     // add any URL filter (if none will be undefined which is ignored).
     settingsOptions.mode = getUrlFilterMode(req)
 
-    // x-trace will be defined in any case where either x-trace or transparent are received via header
-    // validate by creating an event.
-    const xtrace = ao.xtraceToEvent(w3c.xtrace) ? w3c.xtrace : ''
-
     // declare no edge
     settingsOptions.edge = (w3c.info.type !== 'Source' && w3c.info.type !== 'Downstream')
 
+    // xtrace will be defined in any case where either x-trace or transparent are received via header
+    // knock it out for Downstream type so that when called getTraceSettings makes a fresh tracing decision.
+    // validate by creating an event.
+    const xtrace = ao.xtraceToEvent(w3c.xtrace) && w3c.info.type !== 'Downstream' ? w3c.xtrace : ''
+
     // get decisions about sampling, metrics, trigger-trace, etc. i.e., life,
     // the universe, and everything.
+    // note:
+    // the call goes via api and bindings abstractions to liboboe
+    // it is the only interface to liboboe's oboe_tracing_decisions and the only such call in this probe.
+    // it is also the only such call in any probe.
     const settings = ao.getTraceSettings(xtrace, settingsOptions)
 
+    // if Downstream a new xtrace was created ignoring transparent
+    // fix that by placing the original compatible xtrace in settings object
+    if (!xtrace && w3c.info.type === 'Downstream') {
+      settings.traceTaskId = ao.xtraceToEvent(w3c.xtrace)
+    }
+
     // if xtrace was not defined (or not good) a new xtrace was created in format that is not w3c compatible
-    // create an xtrace that is compatible with w3c and place it in setting object
-    if (!xtrace) {
+    // fix that by creating an xtrace that is compatible with w3c and place it in settings object
+    if (!xtrace && w3c.info.type !== 'Downstream') {
       const compatibleXtrace =
         settings.metadata.toString().slice(0, 34) +
         w3cTraceContext.padding +
         settings.metadata.toString().slice(-18, -2) +
-        (settings.doSample ? '01' : '00') // need to set from flag in case of manipulated
+        (settings.doSample ? '01' : '00') // need to explicitly set from flag due to manipulation in test setup.
 
       settings.traceTaskId = ao.xtraceToEvent(compatibleXtrace)
-
-      // TODO: revisit.
-      // migration guide from v7 to v8 says:
-      // "ao.getTraceSettings()` now returns a settings object with the `traceTaskId`property instead of the `metadata` property."
-      // however both are still present. Thus set both to match.
-      settings.metadata = ao.xtraceToEvent(compatibleXtrace)
     }
+
+    // TODO: revisit.
+    // migration guide from v7 to v8 says:
+    // "ao.getTraceSettings()` now returns a settings object with the `traceTaskId`property instead of the `metadata` property."
+    // however both are still present in the code in various places.
+    // to ensure nothing breaks, set both metadata and traceTaskId to match after traceTaskId manipulation above
+    settings.metadata = ao.xtraceToEvent(settings.traceTaskId.toString())
 
     const args = arguments
 

--- a/lib/w3c-trace-context.js
+++ b/lib/w3c-trace-context.js
@@ -31,11 +31,8 @@ const validateTraceparent = (traceparent) => {
 }
 
 const validateTracestate = (tracestate) => {
-  // valid tracestate has it an org id = xtrace part
-  const regExp = new RegExp(`${orgId}=[0-9a-f]{16}-0[0-9]{1}`)
-  const matches = regExp.exec(tracestate)
-
-  return matches ? tracestate : ''
+  // currently no validation of incoming tracestate. only care if can find org in it.
+  return tracestate || ''
 }
 
 const validate = (filtered) => {

--- a/lib/w3c-trace-context.js
+++ b/lib/w3c-trace-context.js
@@ -19,7 +19,7 @@ const validateXtrace = (xtrace) => {
   const regExp = /\b2B[0-9A-F]{40}[0-9A-F]{16}0[0-1]{1}\b/
   const matches = regExp.exec(xtrace)
 
-  return matches ? matches[0] : ''
+  return matches ? xtrace : ''
 }
 
 const validateTraceparent = (traceparent) => {
@@ -27,30 +27,32 @@ const validateTraceparent = (traceparent) => {
   const regExp = /\b00-[0-9a-f]{32}-[0-9a-f]{16}-0[0-1]{1}\b/
   const matches = regExp.exec(traceparent)
 
-  return matches ? matches[0] : ''
+  return matches ? traceparent : ''
 }
 
 const validateTracestate = (tracestate) => {
-  // https://www.w3.org/TR/trace-context/#tracestate-header-field-values
-  // limit to 32 members in list
-  // additional validations as decided internally
-  // remove trailing/leading comma
-  // filter any entry that is not key=value
-  return tracestate
-    ? tracestate.split(',')
-      .filter(item => item !== '')
-      .filter(item => item.split('=')[1])
-      .slice(0, 32)
-      .join(',')
-    : ''
+  // valid tracestate has it an org id = xtrace part
+  const regExp = new RegExp(`${orgId}=[0-9a-f]{16}-0[0-9]{1}`)
+  const matches = regExp.exec(tracestate)
+
+  return matches ? tracestate : ''
 }
 
 const validate = (filtered) => {
-  return {
-    traceparent: validateTraceparent(filtered.traceparent),
-    tracestate: validateTracestate(filtered.tracestate),
-    xtrace: validateXtrace(filtered.xtrace)
-  }
+  const empty = { traceparent: '', tracestate: '', xtrace: '' }
+
+  // each valid by itself
+  const traceparent = validateTraceparent(filtered.traceparent)
+  const tracestate = validateTracestate(filtered.tracestate)
+  const xtrace = validateXtrace(filtered['x-trace'])
+
+  // validate the trio
+
+  // tracestate without traceparent is not valid
+  if (tracestate && !traceparent) return empty
+  // xtrace and traceparent headers that are not matching are not valid
+  if ((xtrace && traceparent) && (xtrace !== PtoX(traceparent))) return empty
+  return { traceparent, tracestate, xtrace }
 }
 
 /* extraction */
@@ -69,13 +71,6 @@ const extractOrgPartFromTracestate = (tracestate) => {
   return matches ? matches[0] : ''
 }
 
-const extractOthersFromTracestate = (tracestate) => {
-  // anything that has sw= as key is "not others" and is thus filtered out
-  const others = tracestate.split(',').filter(item => item.split('=')[0] !== orgId).join(',')
-
-  return others
-}
-
 const extractSpanIdFromTracestate = (tracestate) => {
   const orgPart = extractOrgPartFromTracestate(tracestate)
 
@@ -86,78 +81,6 @@ const extractFlagsFromTracestate = (tracestate) => {
   const orgPart = extractOrgPartFromTracestate(tracestate)
 
   return orgPart ? orgPart.slice(-2) : ''
-}
-
-/* manipulation */
-
-// https://www.w3.org/TR/trace-context/#tracestate-limits
-// decided internally not to send out anything over 512
-const truncateTracestate = (tracestate) => {
-  let t = tracestate
-
-  // only if too long
-  if (t.length > 512) {
-    // find the last (right) entry that is over 128 chars (if any) and filter it out
-    // repeat as long as too long and there are any such entries
-    while (t.length > 512 && t.split(',').reverse().find(item => item.length > 128)) {
-      t = t.split(',').filter(item => item !== t.split(',').reverse().find(item => item.length > 128)).join(',')
-    }
-
-    // while still too long, remove last (right) entry
-    // repeat as long as too long
-    while (t.length > 512) {
-      t = t.split(',').slice(0, -1).join(',')
-    }
-  }
-
-  return t
-}
-
-/* conversion */
-
-// note: all inputs considered validated
-const xtraceFromtraceparent = (traceparent) => {
-  if (!traceparent) return ''
-
-  // traceparent delimited parts
-  const parts = traceparent.split('-')
-
-  // transform to xtrace
-  // https://github.com/librato/trace/tree/master/docs/specs
-  const taskId = `${parts[1]}${padding}`.toUpperCase()
-  const opId = parts[2].toUpperCase()
-  const flags = parts[3]
-
-  return `2B${taskId}${opId}${flags}`
-}
-
-const xtraceFromTracestate = (traceparent, tracestate) => {
-  const parts = traceparent.split('-')
-
-  // transform to xtrace
-  // https://github.com/librato/trace/tree/master/docs/specs
-  const taskId = `${parts[1]}${padding}`.toUpperCase()
-  const opId = extractSpanIdFromTracestate(tracestate).toUpperCase()
-  const flags = extractFlagsFromTracestate(tracestate).toUpperCase()
-
-  return `2B${taskId}${opId}${flags}`
-}
-
-const traceparentFromXtrace = (xtrace) => {
-  if (!xtrace) return ''
-
-  // xtrace parts
-  // https://github.com/librato/trace/tree/master/docs/specs
-  const taskId = xtrace.slice(2, -18)
-  const opId = xtrace.slice(-18, -2)
-  const flags = xtrace.slice(-2)
-
-  // transform to traceparent
-  // https://www.w3.org/TR/trace-context/
-  const traceId = taskId.toLowerCase().slice(0, -8)
-  const spanId = opId.toLowerCase()
-
-  return `00-${traceId}-${spanId}-${flags}`
 }
 
 const tracestatefromXtrace = (xtrace) => {
@@ -174,112 +97,156 @@ const tracestatefromXtrace = (xtrace) => {
   return `${orgId}=${spanId}-${flags}`
 }
 
-/* logic */
-
-const detectContinuation = (traceparent, tracestate) => {
-  const tracestateSpanId = extractSpanIdFromTracestate(tracestate)
-  const traceparentSpanId = extractSpanIdFromTraceParent(traceparent)
-
-  // Continuation is when:
-  // there is a valid span id from traceparent
-  // there is a valid org span id in tracestate
-  // 1 and 2 DO NOT match
-  return !!traceparentSpanId && !!tracestateSpanId && (tracestateSpanId !== traceparentSpanId)
-}
-
-const detectFlow = (traceparent, tracestate) => {
-  const tracestateSpanId = extractSpanIdFromTracestate(tracestate)
-  const traceparentSpanId = extractSpanIdFromTraceParent(traceparent)
-
-  // Flow is when:
-  // there is a valid span id from traceparent
-  // there is a valid org span id in tracestate
-  // 1 and 2 match
-  return !!traceparentSpanId && !!tracestateSpanId && (tracestateSpanId === traceparentSpanId)
-}
-
-const getType = (xtrace, traceparent, tracestate) => {
-  // TODO: revisit
-  // allow x-trace header to ensure compatibility with older agents
-  if (xtrace && !traceparent) return 'Flow'
-
-  // when the request chain was AppOptics to this
-  if (detectFlow(traceparent || '', tracestate || '')) return 'Flow'
-  // when the request chain was AppOptics to OTel to this
-  if (detectContinuation(traceparent || '', tracestate || '')) return 'Continuation'
-  // when the request chain chain is OTel to this
-  if (traceparent) return 'Downstream'
-  // else
-  return 'Source'
-}
-
-const getTraceparent = (traceparent, xtrace) => {
-  return traceparent || traceparentFromXtrace(xtrace)
-}
-
-const getXtrace = (xtrace, traceparent, tracestate) => {
-  // in Continuation - the opId in xtrace is taken from tracestate
-  if (detectContinuation(traceparent, tracestate)) return xtraceFromTracestate(traceparent, tracestate)
-
-  return xtrace || xtraceFromtraceparent(traceparent)
-}
-
-// note: incoming values may be either from headers (server patch) OR from data object (client patch)
-// function encapsulates both use cases
-const getTracestate = (tracestate, traceparent, xtrace) => {
-  // transparent in - alway tracparent and tracestate out. tracestate as is or defined empty.
-  if (traceparent) return tracestate || ''
-  // neither traceparent nor xtrace in - thus tracestate should also be empty
-  if (!xtrace) return ''
-
-  // xtrace and no traceparent in - means either legacy or generation from xtrace
-  // build proper tracestate
-  const others = extractOthersFromTracestate(tracestate)
-  const us = tracestatefromXtrace(xtrace)
-
-  return others ? truncateTracestate(`${us},${others}`) : us
-}
-
 /* exportable */
 
 const orgId = 'sw'
 const padding = '00000000'
 
-const fromHeaders = (dirty = {}) => {
-  const { traceparent, tracestate } = validate(filterObject(dirty, ['traceparent', 'tracestate']))
+const XtoP = (xtrace) => {
+  if (!xtrace) return ''
+
+  // xtrace parts
+  // https://github.com/librato/trace/tree/master/docs/specs
+  const taskId = xtrace.slice(2, -18)
+  const opId = xtrace.slice(-18, -2)
+  const flags = xtrace.slice(-2)
+
+  // transform to traceparent
+  // https://www.w3.org/TR/trace-context/
+  const traceId = taskId.toLowerCase().slice(0, -8)
+  const spanId = opId.toLowerCase()
+
+  return `00-${traceId}-${spanId}-${flags}`
+}
+
+const PtoX = (traceparent) => {
+  if (!traceparent) return ''
+
+  // traceparent delimited parts
+  const parts = traceparent.split('-')
+
+  // transform to xtrace
+  // https://github.com/librato/trace/tree/master/docs/specs
+  const taskId = `${parts[1]}${padding}`.toUpperCase()
+  const opId = parts[2].toUpperCase()
+  const flags = parts[3]
+
+  return `2B${taskId}${opId}${flags}`
+}
+
+const mutS = (tracestate, xtrace) => {
+  // https://www.w3.org/TR/trace-context/#tracestate-header-field-values
+  // - limit to 32 members in list
+  // additional decided internally:
+  // - remove trailing/leading comma
+  // - filter any entry that is not key=value
+
+  // https://www.w3.org/TR/trace-context/#tracestate-limits
+  // decided internally:
+  // - do not to send anything over 512
+  // - removing entries over 128 first
+  const truncateTracestate = (tracestate = '') => {
+    let t = tracestate
+
+    // limit to 32 entries
+    t = tracestate.split(',')
+      .filter(item => item !== '')
+      .filter(item => item.split('=')[1])
+      .slice(0, 32)
+      .join(',')
+
+    // https://www.w3.org/TR/trace-context/#tracestate-limits
+    // decided internally: not to send out anything over 512
+
+    // only if too long
+    if (t.length > 512) {
+      // find the last (right) entry that is over 128 chars (if any) and filter it out
+      // repeat as long as too long and there are any such entries
+      while (t.length > 512 && t.split(',').reverse().find(item => item.length > 128)) {
+        t = t.split(',').filter(item => item !== t.split(',').reverse().find(item => item.length > 128)).join(',')
+      }
+
+      // while still too long, remove last (right) entry
+      // repeat as long as too long
+      while (t.length > 512) {
+        t = t.split(',').slice(0, -1).join(',')
+      }
+    }
+
+    return t
+  }
+
+  const extractOthersFromTracestate = (tracestate = '') => {
+    // anything that has sw= as key is "not others" and is thus filtered out
+    const others = tracestate.split(',').filter(item => item.split('=')[0] !== orgId).join(',')
+
+    return others
+  }
+
+  const others = extractOthersFromTracestate(tracestate)
+  const us = `${tracestatefromXtrace(xtrace)}`
+
+  return others ? truncateTracestate(`${us},${others}`) : us
+}
+const XfromS = (tracestate, traceparent) => {
+  const regExp = new RegExp(`${orgId}=[0-9a-f]{16}-0[0-1]{1}`)
+  const matches = regExp.exec(tracestate)
+
+  // traceparent delimited parts
+  const parts = traceparent.split('-')
+
+  // transform to xtrace
+  // https://github.com/librato/trace/tree/master/docs/specs
+
+  // from traceparent
+  const taskId = matches ? `${parts[1]}${padding}`.toUpperCase() : ''
+
+  // from tracestate
+  const opId = matches ? matches[0].split('=')[1].split('-')[0].toUpperCase() : ''
+  const flags = matches ? matches[0].split('=')[1].split('-')[1] : ''
+
+  return matches ? `2B${taskId}${opId}${flags}` : ''
+}
+
+const reqType = (dirty = {}) => {
+  const { traceparent, tracestate, xtrace } = validate(filterObject(dirty, ['traceparent', 'tracestate', 'x-trace']))
+
   // TODO: revisit
-  // allow x-trace header to ensure compatibility with older agents
-  const xtrace = validateXtrace(dirty['x-trace']) ? dirty['x-trace'] : ''
+  // allow x-trace header only option to ensure compatibility with older agents
+  if (xtrace && !traceparent) return 'Flow'
+
+  if (!traceparent && !xtrace) return 'Source'
+  if (!XfromS(tracestate, traceparent) && traceparent) return 'Downstream'
+  if (XfromS(tracestate, traceparent) === PtoX(traceparent)) return 'Flow'
+  if (XfromS(tracestate, traceparent) !== PtoX(traceparent)) return 'Continuation'
+}
+
+const prepHeaders = (data = {}) => {
+  const { xtrace, tracestate } = data
 
   return {
-    traceparent: getTraceparent(traceparent, xtrace),
-    tracestate: getTracestate(tracestate, traceparent, xtrace),
-    xtrace: getXtrace(xtrace, traceparent, tracestate),
-    info: {
-      type: getType(xtrace, traceparent, tracestate),
-      spanId: extractSpanIdFromTraceParent(traceparent),
-      savedSpanId: extractSpanIdFromTracestate(tracestate),
-      savedFlags: extractFlagsFromTracestate(tracestate)
-    }
+    xtrace: xtrace,
+    traceparent: XtoP(xtrace),
+    tracestate: mutS(tracestate, xtrace)
   }
 }
 
-const fromData = (dirty = {}) => {
-  const { xtrace, tracestate } = validate(filterObject(dirty, ['xtrace', 'tracestate']))
+const fromHeaders = (dirty = {}) => {
+  const { traceparent, tracestate, xtrace } = validate(filterObject(dirty, ['traceparent', 'tracestate', 'x-trace']))
 
+  // TODO: revisit
+  // allow x-trace header only option to ensure compatibility with older agents
   return {
-    traceparent: getTraceparent('', xtrace),
-    tracestate: getTracestate(tracestate, '', xtrace),
-    xtrace: getXtrace(xtrace, '', tracestate),
-    info: {
-      // TODO: need any?
-    }
+    xtrace: XfromS(tracestate, traceparent) || PtoX(traceparent) || xtrace,
+    tracestate,
+    savedSpanId: extractSpanIdFromTracestate(tracestate)
   }
 }
 
 module.exports = {
-  fromHeaders,
-  fromData,
   orgId,
-  padding
+  padding,
+  prepHeaders,
+  fromHeaders,
+  reqType
 }

--- a/lib/w3c-trace-context.js
+++ b/lib/w3c-trace-context.js
@@ -1,0 +1,246 @@
+'use strict'
+
+/* utility */
+
+// based on classic from: https://stackoverflow.com/a/38750895
+const filterObject = (unfiltered, allowed = []) => {
+  return Object.keys(unfiltered)
+    .filter(key => allowed.includes(key))
+    .reduce((obj, key) => {
+      obj[key] = unfiltered[key]
+      return obj
+    }, {})
+}
+
+/* validation */
+
+const validateXtrace = (xtrace) => {
+  // https://github.com/librato/trace/tree/master/docs/specs
+  const regExp = /\b2B[0-9A-F]{40}[0-9A-F]{16}[0-1]{2}\b/
+  const matches = regExp.exec(xtrace)
+
+  return matches ? matches[0] : ''
+}
+
+const validateTraceparent = (traceparent) => {
+  // https://www.w3.org/TR/trace-context/
+  const regExp = /\b00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}\b/
+  const matches = regExp.exec(traceparent)
+
+  return matches ? matches[0] : ''
+}
+
+const validateTracestate = (tracestate) => {
+  // TODO
+  return tracestate || ''
+}
+
+const validate = (filtered) => {
+  return {
+    traceparent: validateTraceparent(filtered.traceparent),
+    tracestate: validateTracestate(filtered.tracestate),
+    xtrace: validateXtrace(filtered.xtrace)
+  }
+}
+
+/* extraction */
+
+const extractSpanIdFromTraceParent = (traceparent = '') => {
+  const regExp = /00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}/
+  const matches = regExp.exec(traceparent)
+
+  return matches ? matches[0].split('-')[2] : ''
+}
+
+const extractOrgPartFromTracestate = (tracestate) => {
+  // TODO: discuss format
+  const regExp = new RegExp(`${orgId}=[0-9a-f]{16}-[0-9]{2}`)
+  const matches = regExp.exec(tracestate)
+
+  return matches ? matches[0] : ''
+}
+
+const extractOthersFromTracestate = (tracestate) => {
+  const orgPart = extractOrgPartFromTracestate(tracestate)
+  const others = tracestate.split(',').filter(item => item !== orgPart).toString()
+
+  return others
+}
+
+const extractSpanIdFromTracestate = (tracestate) => {
+  const orgPart = extractOrgPartFromTracestate(tracestate)
+
+  return orgPart ? orgPart.slice(3, -3) : ''
+}
+
+const extractFlagsFromTracestate = (tracestate) => {
+  const orgPart = extractOrgPartFromTracestate(tracestate)
+
+  return orgPart ? orgPart.slice(-2) : ''
+}
+
+/* conversion */
+
+// note: all inputs considered validated
+const xtraceFromtraceparent = (traceparent) => {
+  if (!traceparent) return ''
+
+  // traceparent delimited parts
+  const parts = traceparent.split('-')
+
+  // transform to xtrace
+  // https://github.com/librato/trace/tree/master/docs/specs
+  const taskId = `${parts[1]}${padding}`.toUpperCase()
+  const opId = parts[2].toUpperCase()
+  const flags = parts[3]
+
+  return `2B${taskId}${opId}${flags}`
+}
+
+const xtraceFromTracestate = (traceparent, tracestate) => {
+  const parts = traceparent.split('-')
+
+  // transform to xtrace
+  // https://github.com/librato/trace/tree/master/docs/specs
+  const taskId = `${parts[1]}${padding}`.toUpperCase()
+  const opId = extractSpanIdFromTracestate(tracestate).toUpperCase()
+  const flags = extractFlagsFromTracestate(tracestate).toUpperCase()
+
+  return `2B${taskId}${opId}${flags}`
+}
+
+const traceparentFromXtrace = (xtrace) => {
+  if (!xtrace) return ''
+
+  // xtrace parts
+  // https://github.com/librato/trace/tree/master/docs/specs
+  const taskId = xtrace.slice(2, -18)
+  const opId = xtrace.slice(-18, -2)
+  const flags = xtrace.slice(-2)
+
+  // transform to traceparent
+  // https://www.w3.org/TR/trace-context/
+  const traceId = taskId.toLowerCase().slice(0, -8)
+  const spanId = opId.toLowerCase()
+
+  return `00-${traceId}-${spanId}-${flags}`
+}
+
+const tracestatefromXtrace = (xtrace) => {
+  if (!xtrace) return ''
+
+  // https://github.com/librato/trace/tree/master/docs/specs
+  const opId = xtrace.slice(-18, -2)
+  const flags = xtrace.slice(-2)
+
+  // transform to trace parent
+  // https://www.w3.org/TR/trace-context/
+  const spanId = opId.toLowerCase()
+
+  return `${orgId}=${spanId}-${flags}`
+}
+
+/* logic */
+
+const detectContinuation = (traceparent, tracestate) => {
+  const tracestateSpanId = extractSpanIdFromTracestate(tracestate)
+  const traceparentSpanId = extractSpanIdFromTraceParent(traceparent)
+
+  // Continuation is when:
+  // there is a valid span id from traceparent
+  // there is a valid org span id in tracestate
+  // 1 and 2 DO NOT atch
+  return !!traceparentSpanId && !!tracestateSpanId && (tracestateSpanId !== traceparentSpanId)
+}
+
+const detectFlow = (traceparent, tracestate) => {
+  const tracestateSpanId = extractSpanIdFromTracestate(tracestate)
+  const traceparentSpanId = extractSpanIdFromTraceParent(traceparent)
+
+  // Flow is when:
+  // there is a valid span id from traceparent
+  // there is a valid org span id in tracestate
+  // 1 and 2 match
+  return traceparentSpanId && tracestateSpanId && (tracestateSpanId === traceparentSpanId)
+}
+
+const getType = (xtrace, traceparent, tracestate) => {
+  // TODO: revisit
+  // allow x-trace header to ensure compatibility with older agents
+  if (xtrace && !traceparent) return 'Flow'
+
+  // when the request chain was AppOptics to this
+  if (detectFlow(traceparent || '', tracestate || '')) return 'Flow'
+  // when the request chain was AppOptics to OTel to this
+  if (detectContinuation(traceparent || '', tracestate || '')) return 'Continuation'
+  // when the request chain chain is OTel to this
+  if (traceparent) return 'Downstream'
+  // else
+  return 'Source'
+}
+
+const getTraceparent = (traceparent, xtrace) => {
+  return traceparent || traceparentFromXtrace(xtrace)
+}
+
+const getXtrace = (xtrace, traceparent, tracestate) => {
+  // in Continuation - the opId in xtrace is taken from tracestate
+  if (detectContinuation(traceparent, tracestate)) return xtraceFromTracestate(traceparent, tracestate)
+
+  return xtrace || xtraceFromtraceparent(traceparent)
+}
+
+// note: incoming values may be either from headers (server patch) OR from data object (client patch)
+// function encapsulates both use cases
+const getTracestate = (tracestate, traceparent, xtrace) => {
+  if (traceparent) return tracestate || ''
+
+  // passing xtrace and no traceparent means either legacy or generation from xtrace
+  const others = extractOthersFromTracestate(tracestate)
+
+  return xtrace && others ? `${tracestatefromXtrace(xtrace)},${others}` : tracestatefromXtrace(xtrace)
+}
+
+/* exportable */
+
+const orgId = 'sw'
+const padding = '99998888'
+
+const fromHeaders = (dirty = {}) => {
+  const { traceparent, tracestate } = validate(filterObject(dirty, ['traceparent', 'tracestate']))
+  // TODO: revisit
+  // allow x-trace header to ensure compatibility with older agents
+  const xtrace = validateXtrace(dirty['x-trace']) ? dirty['x-trace'] : ''
+
+  return {
+    traceparent: getTraceparent(traceparent, xtrace),
+    tracestate: getTracestate(tracestate, traceparent, xtrace),
+    xtrace: getXtrace(xtrace, traceparent, tracestate),
+    info: {
+      type: getType(xtrace, traceparent, tracestate),
+      spanId: extractSpanIdFromTraceParent(traceparent),
+      savedSpanId: extractSpanIdFromTracestate(tracestate),
+      savedFlags: extractFlagsFromTracestate(tracestate)
+    }
+  }
+}
+
+const fromData = (dirty = {}) => {
+  const { xtrace, tracestate } = validate(filterObject(dirty, ['xtrace', 'tracestate']))
+
+  return {
+    traceparent: getTraceparent('', xtrace),
+    tracestate: getTracestate(tracestate, '', xtrace),
+    xtrace: getXtrace(xtrace, '', tracestate),
+    info: {
+      // Todo: need any?
+    }
+  }
+}
+
+module.exports = {
+  fromHeaders,
+  fromData,
+  orgId,
+  padding
+}

--- a/lib/w3c-trace-context.js
+++ b/lib/w3c-trace-context.js
@@ -31,8 +31,18 @@ const validateTraceparent = (traceparent) => {
 }
 
 const validateTracestate = (tracestate) => {
-  // TODO
-  return tracestate || ''
+  // https://www.w3.org/TR/trace-context/#tracestate-header-field-values
+  // limit to 32 members in list
+  // additional validations as decided internally
+  // remove trailing/leading comma
+  // filter any entry that is not key=value
+  return tracestate
+    ? tracestate.split(',')
+      .filter(item => item !== '')
+      .filter(item => item.split('=')[1])
+      .slice(0, 32)
+      .join(',')
+    : ''
 }
 
 const validate = (filtered) => {
@@ -77,6 +87,31 @@ const extractFlagsFromTracestate = (tracestate) => {
   const orgPart = extractOrgPartFromTracestate(tracestate)
 
   return orgPart ? orgPart.slice(-2) : ''
+}
+
+/* manipulation */
+
+// https://www.w3.org/TR/trace-context/#tracestate-limits
+// decided internally not to send out anything over 512
+const truncateTracestate = (tracestate) => {
+  let t = tracestate
+
+  // only if too long
+  if (t.length > 512) {
+    // find the last (right) entry that is over 128 chars (if any) and filter it out
+    // repeat as long as too long and there are any such entries
+    while (t.length > 512 && t.split(',').reverse().find(item => item.length > 128)) {
+      t = t.split(',').filter(item => item !== t.split(',').reverse().find(item => item.length > 128)).join(',')
+    }
+
+    // while still too long, remove last (right) entry
+    // repeat as long as too long
+    while (t.length > 512) {
+      t = t.split(',').slice(0, -1).join(',')
+    }
+  }
+
+  return t
 }
 
 /* conversion */
@@ -194,17 +229,19 @@ const getXtrace = (xtrace, traceparent, tracestate) => {
 // function encapsulates both use cases
 const getTracestate = (tracestate, traceparent, xtrace) => {
   if (traceparent) return tracestate || ''
+  if (!xtrace) return ''
 
   // passing xtrace and no traceparent means either legacy or generation from xtrace
   const others = extractOthersFromTracestate(tracestate)
+  const us = tracestatefromXtrace(xtrace)
 
-  return xtrace && others ? `${tracestatefromXtrace(xtrace)},${others}` : tracestatefromXtrace(xtrace)
+  return others ? truncateTracestate(`${us},${others}`) : us
 }
 
 /* exportable */
 
 const orgId = 'sw'
-const padding = '99998888'
+const padding = '00000000'
 
 const fromHeaders = (dirty = {}) => {
   const { traceparent, tracestate } = validate(filterObject(dirty, ['traceparent', 'tracestate']))
@@ -233,7 +270,7 @@ const fromData = (dirty = {}) => {
     tracestate: getTracestate(tracestate, '', xtrace),
     xtrace: getXtrace(xtrace, '', tracestate),
     info: {
-      // Todo: need any?
+      // TODO: need any?
     }
   }
 }

--- a/lib/w3c-trace-context.js
+++ b/lib/w3c-trace-context.js
@@ -24,7 +24,7 @@ const validateXtrace = (xtrace) => {
 
 const validateTraceparent = (traceparent) => {
   // https://www.w3.org/TR/trace-context/
-  const regExp = /\b00-[0-9a-f]{32}-[0-9a-f]{16}-0[0-1]{1}\b/
+  const regExp = /\b00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}\b/
   const matches = regExp.exec(traceparent)
 
   return matches ? traceparent : ''

--- a/lib/w3c-trace-context.js
+++ b/lib/w3c-trace-context.js
@@ -16,7 +16,7 @@ const filterObject = (unfiltered, allowed = []) => {
 
 const validateXtrace = (xtrace) => {
   // https://github.com/librato/trace/tree/master/docs/specs
-  const regExp = /\b2B[0-9A-F]{40}[0-9A-F]{16}[0-1]{2}\b/
+  const regExp = /\b2B[0-9A-F]{40}[0-9A-F]{16}0[0-1]{1}\b/
   const matches = regExp.exec(xtrace)
 
   return matches ? matches[0] : ''
@@ -24,7 +24,7 @@ const validateXtrace = (xtrace) => {
 
 const validateTraceparent = (traceparent) => {
   // https://www.w3.org/TR/trace-context/
-  const regExp = /\b00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}\b/
+  const regExp = /\b00-[0-9a-f]{32}-[0-9a-f]{16}-0[0-1]{1}\b/
   const matches = regExp.exec(traceparent)
 
   return matches ? matches[0] : ''
@@ -56,23 +56,22 @@ const validate = (filtered) => {
 /* extraction */
 
 const extractSpanIdFromTraceParent = (traceparent = '') => {
-  const regExp = /00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}/
+  const regExp = /00-[0-9a-f]{32}-[0-9a-f]{16}-[0-1]{2}/
   const matches = regExp.exec(traceparent)
 
   return matches ? matches[0].split('-')[2] : ''
 }
 
 const extractOrgPartFromTracestate = (tracestate) => {
-  // TODO: discuss format
-  const regExp = new RegExp(`${orgId}=[0-9a-f]{16}-[0-9]{2}`)
+  const regExp = new RegExp(`${orgId}=[0-9a-f]{16}-0[0-9]{1}`)
   const matches = regExp.exec(tracestate)
 
   return matches ? matches[0] : ''
 }
 
 const extractOthersFromTracestate = (tracestate) => {
-  const orgPart = extractOrgPartFromTracestate(tracestate)
-  const others = tracestate.split(',').filter(item => item !== orgPart).toString()
+  // anything that has sw= as key is "not others" and is thus filtered out
+  const others = tracestate.split(',').filter(item => item.split('=')[0] !== orgId).join(',')
 
   return others
 }
@@ -184,7 +183,7 @@ const detectContinuation = (traceparent, tracestate) => {
   // Continuation is when:
   // there is a valid span id from traceparent
   // there is a valid org span id in tracestate
-  // 1 and 2 DO NOT atch
+  // 1 and 2 DO NOT match
   return !!traceparentSpanId && !!tracestateSpanId && (tracestateSpanId !== traceparentSpanId)
 }
 
@@ -196,7 +195,7 @@ const detectFlow = (traceparent, tracestate) => {
   // there is a valid span id from traceparent
   // there is a valid org span id in tracestate
   // 1 and 2 match
-  return traceparentSpanId && tracestateSpanId && (tracestateSpanId === traceparentSpanId)
+  return !!traceparentSpanId && !!tracestateSpanId && (tracestateSpanId === traceparentSpanId)
 }
 
 const getType = (xtrace, traceparent, tracestate) => {
@@ -228,10 +227,13 @@ const getXtrace = (xtrace, traceparent, tracestate) => {
 // note: incoming values may be either from headers (server patch) OR from data object (client patch)
 // function encapsulates both use cases
 const getTracestate = (tracestate, traceparent, xtrace) => {
+  // transparent in - alway tracparent and tracestate out. tracestate as is or defined empty.
   if (traceparent) return tracestate || ''
+  // neither traceparent nor xtrace in - thus tracestate should also be empty
   if (!xtrace) return ''
 
-  // passing xtrace and no traceparent means either legacy or generation from xtrace
+  // xtrace and no traceparent in - means either legacy or generation from xtrace
+  // build proper tracestate
   const others = extractOthersFromTracestate(tracestate)
   const us = tracestatefromXtrace(xtrace)
 

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -185,7 +185,6 @@ describe(`probes.${p}`, function () {
           expect(msg).property('Port', port)
           expect(msg).property('URL', '/foo?bar=baz')
           expect(msg).property('ClientIP')
-          expect(msg).property('W3C_type')
         },
         function (msg) {
           check.server.exit(msg)
@@ -222,7 +221,6 @@ describe(`probes.${p}`, function () {
         function (msg) {
           check.server.entry(msg)
           expect(msg).not.have.property('Edge')
-          expect(msg).property('W3C_type').equal('Source')
 
           xtrace = msg['X-Trace']
         },
@@ -258,7 +256,6 @@ describe(`probes.${p}`, function () {
         function (msg) {
           check.server.entry(msg)
           expect(msg).not.have.property('Edge')
-          expect(msg).property('W3C_type').equal('Downstream')
 
           xtrace = msg['X-Trace']
         },
@@ -295,7 +292,6 @@ describe(`probes.${p}`, function () {
       helper.doChecks(emitter, [
         function (msg) {
           expect(msg).property('Edge', baseTracestateSpanId.toUpperCase())
-          expect(msg).property('W3C_type').equal('Flow')
 
           xtrace = msg['X-Trace']
         },
@@ -334,11 +330,8 @@ describe(`probes.${p}`, function () {
         function (msg) {
           // the edge in "Continuation" is from trace parent.
           expect(msg).property('Edge', otherTracestateOrgPart.slice(3).split('-')[0].toUpperCase())
-          expect(msg).property('W3C_type').equal('Continuation')
-          expect(msg).property('W3C_savedSpanId')
-          expect(msg).property('W3C_savedFlags')
-          expect(msg).property('W3C_spanId')
-          expect(msg).property('W3C_tracestate')
+          expect(msg).property('sw.parent_id')
+          expect(msg).property('sw.w3c.tracestate')
 
           xtrace = msg['X-Trace']
         },
@@ -381,7 +374,6 @@ describe(`probes.${p}`, function () {
         function (msg) {
           check.server.entry(msg)
           expect(msg).property('Edge', origin.opId)
-          expect(msg).property('W3C_type').equal('Flow')
         },
         function (msg) {
           check.server.exit(msg)
@@ -858,8 +850,6 @@ describe(`probes.${p}`, function () {
             expect(msg).property('Spec', 'rsc')
             expect(msg).property('IsService', 'yes')
             expect(msg).property('RemoteURL', ctx.data.url)
-            expect(msg).property('W3C_traceparent').exists
-            expect(msg).property('W3C_tracestate').exists
           },
           function (msg) {
             check.server.entry(msg)

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -185,7 +185,6 @@ describe(`probes.${p}`, function () {
           expect(msg).property('Port', port)
           expect(msg).property('URL', '/foo?bar=baz')
           expect(msg).property('ClientIP')
-          expect(msg).property('sw.trace_context')
         },
         function (msg) {
           check.server.exit(msg)

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -185,6 +185,7 @@ describe(`probes.${p}`, function () {
           expect(msg).property('Port', port)
           expect(msg).property('URL', '/foo?bar=baz')
           expect(msg).property('ClientIP')
+          expect(msg).property('sw.trace_context')
         },
         function (msg) {
           check.server.exit(msg)

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -44,6 +44,15 @@ const httpsOptions = {
   cert: '-----BEGIN CERTIFICATE-----\nMIICWDCCAcGgAwIBAgIJAPIHj8StWrbJMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTQwODI3MjM1MzUwWhcNMTQwOTI2MjM1MzUwWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB\ngQCsJU2dO/K3oQEh9wo60VC2ajCZjIudc8cqHl9kKNKwc9lP4Rw9KWso/+vHhkp6\nCmx6Cshm6Hs00rPgZo9HmY//gcj0zHmNbagpmdvAmOudK8l5NpzdQwNROKN8EPoK\njlFEBMnZj136gF5YAgEN9ydcLtS2TeLmUG1Y3RR6ADjgaQIDAQABo1AwTjAdBgNV\nHQ4EFgQUTqL/t/yOtpAxKuC9zVm3PnFdRqAwHwYDVR0jBBgwFoAUTqL/t/yOtpAx\nKuC9zVm3PnFdRqAwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOBgQBn1XAm\nAsVdXKr3aiZIgOmw5q+F1lKNl/CHtAPCqwjgntPGhW08WG1ojhCQcNaCp1yfPzpm\niaUwFrgiz+JD+KvxvaBn4pb95A6A3yObADAaAE/ZfbEA397z0RxwTSVU+RFKxzvW\nyICDpugdtxRjkb7I715EjO9R7LkSe5WGzYDp/g==\n-----END CERTIFICATE-----'
 }
 
+const baseTracestateSpanId = '7a71b110e5e3588d'
+const baseTracestateFlags = '01'
+const baseTracestateTraceId = '0123456789abcdef0123456789abcdef'
+
+const baseTraceparent = ['00', baseTracestateTraceId, baseTracestateSpanId, baseTracestateFlags].join('-')
+const baseTracestateOrgPart = 'sw=' + [baseTracestateSpanId, baseTracestateFlags].join('-')
+
+const otherTracestateOrgPart = 'sw=9999888855667788-01'
+
 const options = p === 'https' ? httpsOptions : {}
 
 describe(`probes.${p}`, function () {
@@ -161,9 +170,6 @@ describe(`probes.${p}`, function () {
       ], done)
     })
 
-    //
-    // Test a simple res.end() call in an http server
-    //
     it(`should send traces for ${p} routing and response spans`, function (done) {
       let port
       const server = createServer(options, function (req, res) {
@@ -179,6 +185,7 @@ describe(`probes.${p}`, function () {
           expect(msg).property('Port', port)
           expect(msg).property('URL', '/foo?bar=baz')
           expect(msg).property('ClientIP')
+          expect(msg).property('W3C_type')
         },
         function (msg) {
           check.server.exit(msg)
@@ -201,9 +208,168 @@ describe(`probes.${p}`, function () {
     })
 
     //
+    // Verify w3c trace context
+    //
+
+    it('should start a "Source" trace when receiving no w3c headers', function (done) {
+      const server = createServer(options, function (req, res) {
+        res.end('done')
+      })
+
+      let xtrace = ''
+
+      helper.doChecks(emitter, [
+        function (msg) {
+          check.server.entry(msg)
+          expect(msg).not.have.property('Edge')
+          expect(msg).property('W3C_type').equal('Source')
+
+          xtrace = msg['X-Trace']
+        },
+        function (msg) {
+          check.server.exit(msg)
+        }
+      ], function () {
+        server.close(done)
+      })
+
+      server.listen(function () {
+        const port = server.address().port
+        request({
+          url: `${p}://localhost:${port}`,
+          headers: {}
+        },
+        function (error, response, body) {
+          expect(response.headers).exist
+          expect(response.headers).property('x-trace')
+          expect(xtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
+        })
+      })
+    })
+
+    it('should start a "Downstream" trace when receiving a traceparent only', function (done) {
+      const server = createServer(options, function (req, res) {
+        res.end('done')
+      })
+
+      let xtrace = ''
+
+      helper.doChecks(emitter, [
+        function (msg) {
+          check.server.entry(msg)
+          expect(msg).not.have.property('Edge')
+          expect(msg).property('W3C_type').equal('Downstream')
+
+          xtrace = msg['X-Trace']
+        },
+        function (msg) {
+          check.server.exit(msg)
+        }
+      ], function () {
+        server.close(done)
+      })
+
+      server.listen(function () {
+        const port = server.address().port
+        request({
+          url: `${p}://localhost:${port}`,
+          headers: {
+            traceparent: baseTraceparent
+          }
+        },
+        function (error, response, body) {
+          expect(response.headers).exist
+          expect(response.headers).property('x-trace')
+          expect(xtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
+        })
+      })
+    })
+
+    it('should continue "Flow" tracing when receiving a traceparent and tracestate that match', function (done) {
+      const server = createServer(options, function (req, res) {
+        res.end('done')
+      })
+
+      let xtrace = ''
+
+      helper.doChecks(emitter, [
+        function (msg) {
+          expect(msg).property('Edge', baseTracestateSpanId.toUpperCase())
+          expect(msg).property('W3C_type').equal('Flow')
+
+          xtrace = msg['X-Trace']
+        },
+        function (msg) {
+          check.server.exit(msg)
+        }
+      ], function () {
+        server.close(done)
+      })
+
+      server.listen(function () {
+        const port = server.address().port
+        request({
+          url: `${p}://localhost:${port}`,
+          headers: {
+            traceparent: baseTraceparent,
+            tracestate: baseTracestateOrgPart
+          }
+        },
+        function (error, response, body) {
+          expect(response.headers).exist
+          expect(response.headers).property('x-trace')
+          expect(xtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
+        })
+      })
+    })
+
+    it('should continue "Continuation" tracing when receiving a traceparent and tracestate that do not match in header', function (done) {
+      const server = createServer(options, function (req, res) {
+        res.end('done')
+      })
+
+      let xtrace = ''
+
+      helper.doChecks(emitter, [
+        function (msg) {
+          // the edge in "Continuation" is from trace parent.
+          expect(msg).property('Edge', otherTracestateOrgPart.slice(3).split('-')[0].toUpperCase())
+          expect(msg).property('W3C_type').equal('Continuation')
+          expect(msg).property('W3C_savedSpanId')
+          expect(msg).property('W3C_savedFlags')
+          expect(msg).property('W3C_spanId')
+          expect(msg).property('W3C_tracestate')
+
+          xtrace = msg['X-Trace']
+        },
+        function (msg) {
+          check.server.exit(msg)
+        }
+      ], function () {
+        server.close(done)
+      })
+
+      server.listen(function () {
+        const port = server.address().port
+        request({
+          url: `${p}://localhost:${port}`,
+          headers: {
+            traceparent: baseTraceparent,
+            tracestate: otherTracestateOrgPart
+          }
+        },
+        function (error, response, body) {
+          expect(response.headers).exist
+          expect(response.headers).property('x-trace')
+          expect(xtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
+        })
+      })
+    })
+
+    //
     // Verify X-Trace header results in a continued trace
     //
-    it('should continue tracing when receiving an xtrace id header', function (done) {
+    it('should continue tracing when receiving a legacy x-trace in header', function (done) {
       const server = createServer(options, function (req, res) {
         res.end('done')
       })
@@ -215,6 +381,7 @@ describe(`probes.${p}`, function () {
         function (msg) {
           check.server.entry(msg)
           expect(msg).property('Edge', origin.opId)
+          expect(msg).property('W3C_type').equal('Flow')
         },
         function (msg) {
           check.server.exit(msg)
@@ -688,8 +855,11 @@ describe(`probes.${p}`, function () {
         helper.test(emitter, testFunction, [
           function (msg) {
             check.client.entry(msg)
-            expect(msg).property('RemoteURL', ctx.data.url)
+            expect(msg).property('Spec', 'rsc')
             expect(msg).property('IsService', 'yes')
+            expect(msg).property('RemoteURL', ctx.data.url)
+            expect(msg).property('W3C_traceparent').exists
+            expect(msg).property('W3C_tracestate').exists
           },
           function (msg) {
             check.server.entry(msg)

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -233,7 +233,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request({
+        axios({
           url: `${p}://localhost:${port}`,
           headers: {}
         },
@@ -268,7 +268,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request({
+        axios({
           url: `${p}://localhost:${port}`,
           headers: {
             traceparent: baseTraceparent
@@ -304,7 +304,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request({
+        axios({
           url: `${p}://localhost:${port}`,
           headers: {
             traceparent: baseTraceparent,
@@ -344,7 +344,7 @@ describe(`probes.${p}`, function () {
 
       server.listen(function () {
         const port = server.address().port
-        request({
+        axios({
           url: `${p}://localhost:${port}`,
           headers: {
             traceparent: baseTraceparent,

--- a/test/w3c-trace-context.test.js
+++ b/test/w3c-trace-context.test.js
@@ -5,8 +5,13 @@ const w3cTraceContext = require('../lib/w3c-trace-context')
 
 const baseTraceparent = '00-0123456789abcdef0123456789abcdef-7a71b110e5e3588d-01'
 const baseXtrace = '2B0123456789ABCDEF0123456789ABCDEF999988887A71B110E5E3588D01'
-const baseTraceState = 'sw=7a71b110e5e3588d-01'
-const otherXtrace = '2B0123456789ABCDEF0123456789FFFFFF999988881B11B110E5E3588D01'
+
+const baseTracestateSpanId = '7a71b110e5e3588d'
+const baseTracestateFlags = '01'
+const baseTracestateOrgPart = 'sw=' + baseTracestateSpanId + '-' + baseTracestateFlags
+
+const otherXtrace = '2B0123456789ABCDEF0123456789ABCDEF99998888999988885566778801'
+const otherTracestateOrgPart = 'sw=9999888855667788-01'
 
 const expectEmptyObject = (w3c) => {
   expect(w3c).to.be.an('object')
@@ -91,7 +96,7 @@ describe('w3cTraceContext', function () {
     it('should create an object from traceparent and sw tracestate', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: baseTraceState
+        tracestate: baseTracestateOrgPart
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
@@ -99,21 +104,21 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTraceState)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
     })
 
     it('should create an object from traceparent and tracestate that do not match', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788-01'
+        tracestate: otherTracestateOrgPart
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-      expect(w3c.xtrace).to.be.equal('2B0123456789ABCDEF0123456789ABCDEF99998888999988885566778801')
+      expect(w3c.xtrace).to.be.equal(otherXtrace)
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('sw=9999888855667788-01')
+      expect(w3c.tracestate).to.be.equal(otherTracestateOrgPart)
     })
 
     it('should create an object from traceparent with other vendor tracestate', function () {
@@ -133,15 +138,15 @@ describe('w3cTraceContext', function () {
     it('should create an object from traceparent and tracestate with other vendor tracestate', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before'
+        tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before'
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-      expect(w3c.xtrace).to.be.equal('2B0123456789ABCDEF0123456789ABCDEF99998888999988885566778801')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before')
+      expect(w3c.tracestate).to.be.equal('a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before')
     })
 
     it('should create an empty object from invalid traceparent only (bad version)', function () {
@@ -182,7 +187,7 @@ describe('w3cTraceContext', function () {
 
     it('should create an empty object from tracestate only (bad data)', function () {
       const myHeaders = {
-        tracestate: baseTraceState + ',a1=bad,a2=game'
+        tracestate: baseTracestateOrgPart + ',a1=bad,a2=game'
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
@@ -192,7 +197,7 @@ describe('w3cTraceContext', function () {
     it('should create an empty object from tracestate and invalid traceparent (bad data)', function () {
       const myHeaders = {
         traceparent: baseTraceparent.replace('a', 'A'),
-        tracestate: baseTraceState
+        tracestate: baseTracestateOrgPart
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
@@ -213,7 +218,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTraceState)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 
@@ -228,14 +233,14 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTraceState + ',oh=other')
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',oh=other')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 
     it('should create an object from xtrace and tracestate when there is an existing sw value', function () {
       const data = {
         xtrace: baseXtrace,
-        tracestate: 'oh=other,sw=7a71b110e5e30000-01'
+        tracestate: 'oh=other,' + baseTracestateOrgPart
       }
       const w3c = w3cTraceContext.fromData(data)
 
@@ -243,14 +248,14 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTraceState + ',oh=other')
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',oh=other')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 
     it('should create an object from xtrace and tracestate when there is an existing sw value on left', function () {
       const data = {
         xtrace: baseXtrace,
-        tracestate: 'sw=7a71b110e5e30000-01,oh=other'
+        tracestate: baseTracestateOrgPart + ',oh=other'
       }
       const w3c = w3cTraceContext.fromData(data)
 
@@ -258,7 +263,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTraceState + ',oh=other')
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',oh=other')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 
@@ -303,7 +308,7 @@ describe('w3cTraceContext', function () {
     it('should be Continuation when traceparent and tracestate do not match', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788-01'
+        tracestate: otherTracestateOrgPart
       }
       const type = w3cTraceContext.fromHeaders(myHeaders).info.type
 
@@ -313,7 +318,7 @@ describe('w3cTraceContext', function () {
     it('should be Flow when traceparent and tracestate match', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: baseTraceState
+        tracestate: baseTracestateOrgPart
       }
       const type = w3cTraceContext.fromHeaders(myHeaders).info.type
 
@@ -331,7 +336,7 @@ describe('w3cTraceContext', function () {
 
     it('should be Source when there is no traceparent just tracestate (malformed)', function () {
       const myHeaders = {
-        tracestate: '7a71b110e5e3588d-01'
+        tracestate: baseTracestateOrgPart
       }
       const type = w3cTraceContext.fromHeaders(myHeaders).info.type
 
@@ -351,21 +356,21 @@ describe('w3cTraceContext', function () {
     it('should be valid when traceparent and tracestate do not match', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788-01'
+        tracestate: otherTracestateOrgPart
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
 
-      expect(id).to.be.equal('7a71b110e5e3588d')
+      expect(id).to.be.equal(baseTracestateSpanId)
     })
 
     it('should be valid when traceparent and tracestate match', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: baseTraceState
+        tracestate: baseTracestateOrgPart
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
 
-      expect(id).to.be.equal('7a71b110e5e3588d')
+      expect(id).to.be.equal(baseTracestateSpanId)
     })
 
     it('should be empty when traceparent is malformed (too long)', function () {
@@ -377,7 +382,7 @@ describe('w3cTraceContext', function () {
       expect(id).to.be.equal('')
     })
 
-    it('should be empty when traceparentis malformed (too short)', function () {
+    it('should be empty when traceparent is malformed (too short)', function () {
       const myHeaders = {
         traceparent: baseTraceparent.slice(0, 10) + baseTraceparent.slice(11)
       }
@@ -426,7 +431,7 @@ describe('w3cTraceContext', function () {
     it('should be valid when traceparent and tracestate do not match', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788-01'
+        tracestate: otherTracestateOrgPart
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
 
@@ -436,7 +441,7 @@ describe('w3cTraceContext', function () {
     it('should be empty when tracestate is malformed (too long)', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=999988885566778899-01'
+        tracestate: baseTracestateOrgPart.slice(0, 2) + '1' + baseTracestateOrgPart.slice(2)
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
 
@@ -446,7 +451,7 @@ describe('w3cTraceContext', function () {
     it('should be empty when tracestate is malformed (too short)', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=799998888556677-01'
+        tracestate: baseTracestateOrgPart.slice(0, 6) + baseTracestateOrgPart.slice(7)
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
 
@@ -456,7 +461,7 @@ describe('w3cTraceContext', function () {
     it('should be empty when tracestate is malformed (no dash)', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788_01'
+        tracestate: baseTracestateOrgPart.replace('-', '_')
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
 
@@ -466,7 +471,7 @@ describe('w3cTraceContext', function () {
     it('should be empty when tracestate is malformed (not hex)', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=99998888556677zz-01'
+        tracestate: baseTracestateOrgPart.replace('a', 'z')
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
 
@@ -476,31 +481,31 @@ describe('w3cTraceContext', function () {
     it('should be valid when tracestate is with other vendor and own data', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before'
+        tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before'
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
 
-      expect(id).to.be.equal('9999888855667788')
+      expect(id).to.be.equal(baseTracestateSpanId)
     })
 
     it('should be first valid when tracestate is malformed and contains own twice', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788-01,sw=77771111aaaa0011-01'
+        tracestate: baseTracestateOrgPart + ',sw=77771111aaaa0011-01'
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
 
-      expect(id).to.be.equal('9999888855667788')
+      expect(id).to.be.equal(baseTracestateSpanId)
     })
 
     it('should be first when tracestate is with other vendor and own data twice', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before,sw=77771111aaaa0011-01'
+        tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before,sw=77771111aaaa0011-01'
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
 
-      expect(id).to.be.equal('9999888855667788')
+      expect(id).to.be.equal(baseTracestateSpanId)
     })
 
     it('should be empty when tracestate is with other vendor data only', function () {
@@ -528,7 +533,7 @@ describe('w3cTraceContext', function () {
     it('should be valid when traceparent and tracestate do not match', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788-01'
+        tracestate: otherTracestateOrgPart
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
 
@@ -538,7 +543,7 @@ describe('w3cTraceContext', function () {
     it('should be empty when tracestate is malformed (too long)', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=999988885566778899-01'
+        tracestate: baseTracestateOrgPart.slice(0, 2) + '1' + baseTracestateOrgPart.slice(2)
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
 
@@ -548,7 +553,7 @@ describe('w3cTraceContext', function () {
     it('should be empty when tracestate is malformed (too short)', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=77771111aaaa00-01'
+        tracestate: baseTracestateOrgPart.slice(0, 6) + baseTracestateOrgPart.slice(7)
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
 
@@ -558,7 +563,7 @@ describe('w3cTraceContext', function () {
     it('should be empty when tracestate is malformed (no dash)', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788_01'
+        tracestate: baseTracestateOrgPart.replace('-', '_')
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
 
@@ -568,7 +573,7 @@ describe('w3cTraceContext', function () {
     it('should be empty when tracestate is malformed (not hex)', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=77771111aaaa000z-01'
+        tracestate: baseTracestateOrgPart.replace('a', 'z')
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
 
@@ -578,7 +583,7 @@ describe('w3cTraceContext', function () {
     it('should be valid when tracestate is with other vendor and own data', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before'
+        tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before'
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
 
@@ -588,7 +593,7 @@ describe('w3cTraceContext', function () {
     it('should be valid when tracestate is malformed and contains own twice', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788-01,sw=77771111aaaa0011-01'
+        tracestate: baseTracestateOrgPart + ',sw=77771111aaaa0011-01'
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
 
@@ -598,7 +603,7 @@ describe('w3cTraceContext', function () {
     it('should be valid when tracestate is with other vendor and own data twice', function () {
       const myHeaders = {
         traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before,sw=77771111aaaa0011-01'
+        tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before,sw=77771111aaaa0011-01'
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
 
@@ -662,7 +667,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTraceState)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 
@@ -677,7 +682,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTraceState)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 
@@ -714,7 +719,7 @@ describe('w3cTraceContext', function () {
       const myHeaders = {
         'x-trace': baseXtrace,
         traceparent: baseTraceparent,
-        tracestate: 'sw=9999888855667788-01'
+        tracestate: otherTracestateOrgPart
       }
       const type = w3cTraceContext.fromHeaders(myHeaders).info.type
 

--- a/test/w3c-trace-context.test.js
+++ b/test/w3c-trace-context.test.js
@@ -224,6 +224,20 @@ describe('w3cTraceContext', function () {
       expect(w3c.tracestate).to.be.equal('oh=other,some=things')
     })
 
+    it('should create an object from traceparent and tracestate when tracestate key includes malicious/malformed org part (bad data validated)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=no!'
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal('sw=no!')
+    })
+
     it('should create an empty object from invalid traceparent only (bad version)', function () {
       const myHeaders = {
         traceparent: '01' + baseTraceparent.slice(2)
@@ -422,6 +436,21 @@ describe('w3cTraceContext', function () {
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + longTracestate.split(',').filter(item => item !== longItem).slice(0, -2).join(','))
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+    })
+
+    it('should create an object from xtrace and tracestate when there is an existing sw value that is malformed/melicious', function () {
+      const data = {
+        xtrace: baseXtrace,
+        tracestate: 'oh=other,sw=no!'
+      }
+      const w3c = w3cTraceContext.fromData(data)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',oh=other')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 

--- a/test/w3c-trace-context.test.js
+++ b/test/w3c-trace-context.test.js
@@ -13,14 +13,6 @@ const baseTracestateOrgPart = 'sw=' + baseTracestateSpanId + '-' + baseTracestat
 const otherXtrace = '2B0123456789ABCDEF0123456789ABCDEF00000000999988885566778801'
 const otherTracestateOrgPart = 'sw=9999888855667788-01'
 
-const expectEmptyObject = (w3c) => {
-  expect(w3c).to.be.an('object')
-  expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-  expect(w3c.xtrace).to.be.equal('')
-  expect(w3c.traceparent).to.be.equal('')
-  expect(w3c.tracestate).to.be.equal('')
-}
-
 describe('w3cTraceContext', function () {
   describe('w3cTraceContext.fromHeaders object creation from w3c request headers', function () {
     it('should create an object from empty headers', function () {
@@ -28,10 +20,8 @@ describe('w3cTraceContext', function () {
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal('')
-      expect(w3c.traceparent).to.be.equal('')
-      expect(w3c.tracestate).to.be.equal('')
     })
 
     it('should create an object omitting unseeded header keys', function () {
@@ -49,35 +39,35 @@ describe('w3cTraceContext', function () {
       const w3c = w3cTraceContext.fromHeaders(1)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
     })
 
     it('should create an object from wrong input (string)', function () {
       const w3c = w3cTraceContext.fromHeaders('wow')
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
     })
 
     it('should create an object from wrong input (boolean)', function () {
       const w3c = w3cTraceContext.fromHeaders(true)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
     })
 
     it('should create an object from wrong input (empty)', function () {
       const w3c = w3cTraceContext.fromHeaders()
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
     })
 
     it('should create an object from wrong input (undefined)', function () {
       const w3c = w3cTraceContext.fromHeaders(undefined)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
     })
 
     it('should create an object from traceparent only', function () {
@@ -87,10 +77,8 @@ describe('w3cTraceContext', function () {
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('')
     })
 
     it('should create an object from traceparent and sw tracestate', function () {
@@ -101,10 +89,8 @@ describe('w3cTraceContext', function () {
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
     })
 
     it('should create an object from traceparent and tracestate that do not match', function () {
@@ -115,10 +101,8 @@ describe('w3cTraceContext', function () {
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(otherXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(otherTracestateOrgPart)
     })
 
     it('should create an object from traceparent with other vendor tracestate', function () {
@@ -129,10 +113,8 @@ describe('w3cTraceContext', function () {
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('oh=different')
     })
 
     it('should create an object from traceparent and tracestate with other vendor tracestate', function () {
@@ -143,99 +125,8 @@ describe('w3cTraceContext', function () {
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before')
-    })
-
-    it('should create an object from traceparent and tracestate with other vendor tracestate truncated to 32 entries (bad data validated)', function () {
-      const longTracestate = new Array(34).fill(null).map((_, index) => {
-        const c = String.fromCharCode(65 + index).toLowerCase()
-        return `${c}${c}=${new Array(12).fill(c).join('')}`
-      }).join(',') // 543 chars ok, 34 entries not ok
-
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: baseTracestateOrgPart + ',' + longTracestate
-      }
-      const w3c = w3cTraceContext.fromHeaders(myHeaders)
-
-      expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-      expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + longTracestate.split(',').slice(0, 31).join(','))
-    })
-
-    it('should create an object from traceparent and tracestate when tracestate key has leading delimiter , (bad data validated)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: ',woo=hoo'
-      }
-      const w3c = w3cTraceContext.fromHeaders(myHeaders)
-
-      expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-      expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('woo=hoo')
-    })
-
-    it('should create an object from traceparent and tracestate when tracestate key has trailing delimiter , (bad data validated)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: 'woo=hoo,'
-      }
-      const w3c = w3cTraceContext.fromHeaders(myHeaders)
-
-      expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-      expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('woo=hoo')
-    })
-
-    it('should create an object from traceparent and tracestate when tracestate key with empty value (bad data validated)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: 'oh=other,woo=,some=things'
-      }
-      const w3c = w3cTraceContext.fromHeaders(myHeaders)
-
-      expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-      expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('oh=other,some=things')
-    })
-
-    it('should create an object from traceparent and tracestate when tracestate key without value (bad data validated)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: 'oh=other,woo,some=things'
-      }
-      const w3c = w3cTraceContext.fromHeaders(myHeaders)
-
-      expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-      expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('oh=other,some=things')
-    })
-
-    it('should create an object from traceparent and tracestate when tracestate key includes malicious/malformed org part (bad data validated)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: 'sw=no!'
-      }
-      const w3c = w3cTraceContext.fromHeaders(myHeaders)
-
-      expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-      expect(w3c.xtrace).to.be.equal(baseXtrace)
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal('sw=no!')
     })
 
     it('should create an empty object from invalid traceparent only (bad version)', function () {
@@ -244,7 +135,9 @@ describe('w3cTraceContext', function () {
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
+      expect(w3c.xtrace).to.be.equal('')
     })
 
     it('should create an empty object from invalid traceparent only (bad traceId part)', function () {
@@ -253,7 +146,9 @@ describe('w3cTraceContext', function () {
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
+      expect(w3c.xtrace).to.be.equal('')
     })
 
     it('should create an empty object from invalid traceparent only (bad spanId part)', function () {
@@ -262,7 +157,9 @@ describe('w3cTraceContext', function () {
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
+      expect(w3c.xtrace).to.be.equal('')
     })
 
     it('should create an empty object from invalid traceparent only (bad flags part)', function () {
@@ -271,7 +168,9 @@ describe('w3cTraceContext', function () {
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
+      expect(w3c.xtrace).to.be.equal('')
     })
 
     it('should create an empty object from tracestate only (bad data)', function () {
@@ -280,7 +179,9 @@ describe('w3cTraceContext', function () {
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
+      expect(w3c.xtrace).to.be.equal('')
     })
 
     it('should create an empty object from tracestate and invalid traceparent (bad data)', function () {
@@ -290,19 +191,21 @@ describe('w3cTraceContext', function () {
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
+      expect(w3c.xtrace).to.be.equal('')
     })
   })
 
-  describe('w3cTraceContext.fromData object creation from xtrace, stored tracestate input', function () {
+  describe('w3cTraceContext.prepHeaders object creation from xtrace, stored tracestate input', function () {
     it('should create an object from xtrace', function () {
       const data = {
         xtrace: baseXtrace
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
@@ -314,10 +217,10 @@ describe('w3cTraceContext', function () {
         xtrace: baseXtrace,
         tracestate: 'oh=other'
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',oh=other')
@@ -329,10 +232,10 @@ describe('w3cTraceContext', function () {
         xtrace: baseXtrace,
         tracestate: 'oh=other,' + baseTracestateOrgPart
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',oh=other')
@@ -344,10 +247,10 @@ describe('w3cTraceContext', function () {
         xtrace: baseXtrace,
         tracestate: baseTracestateOrgPart + ',oh=other'
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',oh=other')
@@ -363,10 +266,10 @@ describe('w3cTraceContext', function () {
         xtrace: baseXtrace,
         tracestate: baseTracestateOrgPart + ',' + longTracestate
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + longTracestate.split(',').slice(0, -2).join(','))
@@ -385,10 +288,10 @@ describe('w3cTraceContext', function () {
         xtrace: baseXtrace,
         tracestate: baseTracestateOrgPart + ',' + longTracestate
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + longTracestate.split(',').filter(item => item !== longItem).join(','))
@@ -407,10 +310,10 @@ describe('w3cTraceContext', function () {
         xtrace: baseXtrace,
         tracestate: baseTracestateOrgPart + ',' + longTracestate
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + longTracestate.split(',').filter(item => item !== longItem).join(','))
@@ -429,10 +332,10 @@ describe('w3cTraceContext', function () {
         xtrace: baseXtrace,
         tracestate: baseTracestateOrgPart + ',' + longTracestate
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + longTracestate.split(',').filter(item => item !== longItem).slice(0, -2).join(','))
@@ -444,50 +347,103 @@ describe('w3cTraceContext', function () {
         xtrace: baseXtrace,
         tracestate: 'oh=other,sw=no!'
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate')
 
       expect(w3c.traceparent).to.be.equal(baseTraceparent)
       expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',oh=other')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 
-    it('should create an empty from invalid xtrace (bad prefix)', function () {
-      const data = {
-        xtrace: 'AA' + baseXtrace.slice(2)
-      }
-      const w3c = w3cTraceContext.fromData(data)
+    it('should create an object from traceparent and tracestate with other vendor tracestate truncated to 32 entries', function () {
+      const longTracestate = new Array(34).fill(null).map((_, index) => {
+        const c = String.fromCharCode(65 + index).toLowerCase()
+        return `${c}${c}=${new Array(10).fill(c).join('')}`
+      }).join(',') // 33 entries not ok
 
-      expectEmptyObject(w3c)
+      const data = {
+        xtrace: baseXtrace,
+        tracestate: baseTracestateOrgPart + ',' + longTracestate
+      }
+      const w3c = w3cTraceContext.prepHeaders(data)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('traceparent', 'tracestate', 'xtrace')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + longTracestate.split(',').slice(0, 31).join(','))
     })
 
-    it('should create an empty from invalid xtrace (bad traceId)', function () {
+    it('should create an object from traceparent and tracestate when tracestate key has leading delimiter , (bad data validated)', function () {
       const data = {
-        xtrace: baseXtrace.slice(0, -16) + baseTraceparent.slice(-16)
+        xtrace: baseXtrace,
+        tracestate: ',woo=hoo'
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('traceparent', 'tracestate', 'xtrace')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + 'woo=hoo')
     })
 
-    it('should create an empty from invalid xtrace (bad opId)', function () {
+    it('should create an object from traceparent and tracestate when tracestate key has trailing delimiter , (bad data)', function () {
       const data = {
-        xtrace: baseXtrace.slice(0, -6) + baseTraceparent.slice(-5)
+        xtrace: baseXtrace,
+        tracestate: 'woo=hoo,'
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('traceparent', 'tracestate', 'xtrace')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + 'woo=hoo')
     })
 
-    it('should create an empty from invalid xtrace (bad flags)', function () {
+    it('should create an object from traceparent and tracestate when tracestate key with empty value (bad data)', function () {
       const data = {
-        xtrace: baseXtrace.slice(-1) + 'a'
+        xtrace: baseXtrace,
+        tracestate: 'oh=other,woo=,some=things'
       }
-      const w3c = w3cTraceContext.fromData(data)
+      const w3c = w3cTraceContext.prepHeaders(data)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('traceparent', 'tracestate', 'xtrace')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + 'oh=other,some=things')
+    })
+
+    it('should create an object from traceparent and tracestate when tracestate key without value (bad data)', function () {
+      const data = {
+        xtrace: baseXtrace,
+        tracestate: 'oh=other,woo,some=things'
+      }
+      const w3c = w3cTraceContext.prepHeaders(data)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('traceparent', 'tracestate', 'xtrace')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart + ',' + 'oh=other,some=things')
+    })
+
+    it('should create an object from traceparent and tracestate when tracestate key includes malicious/malformed org part (bad data)', function () {
+      const myHeaders = {
+        xtrace: baseXtrace,
+        tracestate: 'sw=no!'
+      }
+      const w3c = w3cTraceContext.prepHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('traceparent', 'tracestate', 'xtrace')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
     })
   })
 
@@ -497,7 +453,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: otherTracestateOrgPart
       }
-      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+      const type = w3cTraceContext.reqType(myHeaders)
 
       expect(type).to.be.equal('Continuation')
     })
@@ -507,7 +463,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: baseTracestateOrgPart
       }
-      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+      const type = w3cTraceContext.reqType(myHeaders)
 
       expect(type).to.be.equal('Flow')
     })
@@ -516,7 +472,7 @@ describe('w3cTraceContext', function () {
       const myHeaders = {
         traceparent: baseTraceparent
       }
-      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+      const type = w3cTraceContext.reqType(myHeaders)
 
       expect(type).to.be.equal('Downstream')
     })
@@ -525,7 +481,7 @@ describe('w3cTraceContext', function () {
       const myHeaders = {
         tracestate: baseTracestateOrgPart
       }
-      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+      const type = w3cTraceContext.reqType(myHeaders)
 
       expect(type).to.be.equal('Source')
     })
@@ -533,84 +489,9 @@ describe('w3cTraceContext', function () {
     it('should be Source when there are no headers', function () {
       const myHeaders = {
       }
-      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+      const type = w3cTraceContext.reqType(myHeaders)
 
       expect(type).to.be.equal('Source')
-    })
-  })
-
-  describe('w3cTraceContext.fromHeaders info spanId', function () {
-    it('should be valid when traceparent and tracestate do not match', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: otherTracestateOrgPart
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
-
-      expect(id).to.be.equal(baseTracestateSpanId)
-    })
-
-    it('should be valid when traceparent and tracestate match', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: baseTracestateOrgPart
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
-
-      expect(id).to.be.equal(baseTracestateSpanId)
-    })
-
-    it('should be empty when traceparent is malformed (too long)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent + '1'
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be empty when traceparent is malformed (too short)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent.slice(0, 10) + baseTraceparent.slice(11)
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be empty when tracestate is malformed (no dash)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent.replace('-', '_')
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be empty when tracestate is malformed (not hex)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent.replace('a', 'z')
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be empty when tracestate is malformed (not lowercase hex)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent.replace('a', 'A')
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be empty when there is no traceparent', function () {
-      const myHeaders = {
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
-
-      expect(id).to.be.equal('')
     })
   })
 
@@ -620,7 +501,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: otherTracestateOrgPart
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal('9999888855667788')
     })
@@ -630,7 +511,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: baseTracestateOrgPart.slice(0, 2) + '1' + baseTracestateOrgPart.slice(2)
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal('')
     })
@@ -640,7 +521,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: baseTracestateOrgPart.slice(0, 6) + baseTracestateOrgPart.slice(7)
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal('')
     })
@@ -650,7 +531,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: baseTracestateOrgPart.replace('-', '_')
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal('')
     })
@@ -660,7 +541,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: baseTracestateOrgPart.replace('a', 'z')
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal('')
     })
@@ -670,7 +551,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before'
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal(baseTracestateSpanId)
     })
@@ -680,7 +561,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: baseTracestateOrgPart + ',sw=77771111aaaa0011-01'
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal(baseTracestateSpanId)
     })
@@ -690,7 +571,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before,sw=77771111aaaa0011-01'
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal(baseTracestateSpanId)
     })
@@ -700,7 +581,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: 'a1=continue_from_me,a2=i_was_before'
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal('')
     })
@@ -710,108 +591,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: 'a1=continue_from_me,a2=i_was_before'
       }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
-
-      expect(id).to.be.equal('')
-    })
-  })
-
-  describe('w3cTraceContext.fromHeaders info savedFlags', function () {
-    it('should be valid when traceparent and tracestate do not match', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: otherTracestateOrgPart
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
-
-      expect(id).to.be.equal('01')
-    })
-
-    it('should be empty when tracestate is malformed (too long)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: baseTracestateOrgPart.slice(0, 2) + '1' + baseTracestateOrgPart.slice(2)
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be empty when tracestate is malformed (too short)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: baseTracestateOrgPart.slice(0, 6) + baseTracestateOrgPart.slice(7)
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be empty when tracestate is malformed (no dash)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: baseTracestateOrgPart.replace('-', '_')
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be empty when tracestate is malformed (not hex)', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: baseTracestateOrgPart.replace('a', 'z')
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be valid when tracestate is with other vendor and own data', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before'
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
-
-      expect(id).to.be.equal('01')
-    })
-
-    it('should be valid when tracestate is malformed and contains own twice', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: baseTracestateOrgPart + ',sw=77771111aaaa0011-01'
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
-
-      expect(id).to.be.equal('01')
-    })
-
-    it('should be valid when tracestate is with other vendor and own data twice', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before,sw=77771111aaaa0011-01'
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
-
-      expect(id).to.be.equal('01')
-    })
-
-    it('should be empty when tracestate is with other vendor data only', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,a2=i_was_before'
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
-
-      expect(id).to.be.equal('')
-    })
-
-    it('should be empty when there is no tracestate', function () {
-      const myHeaders = {
-        traceparent: baseTraceparent
-      }
-      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+      const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
       expect(id).to.be.equal('')
     })
@@ -851,10 +631,7 @@ describe('w3cTraceContext', function () {
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 
@@ -866,10 +643,7 @@ describe('w3cTraceContext', function () {
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
       expect(w3c).to.be.an('object')
-      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
-
-      expect(w3c.traceparent).to.be.equal(baseTraceparent)
-      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
     })
 
@@ -879,7 +653,8 @@ describe('w3cTraceContext', function () {
       }
       const w3c = w3cTraceContext.fromHeaders(myHeaders)
 
-      expectEmptyObject(w3c)
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
     })
   })
 
@@ -888,7 +663,7 @@ describe('w3cTraceContext', function () {
       const myHeaders = {
         'x-trace': baseXtrace
       }
-      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+      const type = w3cTraceContext.reqType(myHeaders)
 
       expect(type).to.be.equal('Flow')
     })
@@ -897,7 +672,7 @@ describe('w3cTraceContext', function () {
       const myHeaders = {
         xtrace: baseXtrace
       }
-      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+      const type = w3cTraceContext.reqType(myHeaders)
 
       expect(type).to.be.equal('Source')
     })
@@ -908,7 +683,7 @@ describe('w3cTraceContext', function () {
         traceparent: baseTraceparent,
         tracestate: otherTracestateOrgPart
       }
-      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+      const type = w3cTraceContext.reqType(myHeaders)
 
       expect(type).to.be.equal('Continuation')
     })
@@ -917,7 +692,7 @@ describe('w3cTraceContext', function () {
       const myHeaders = {
         'x-trace': baseXtrace + 'A'
       }
-      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+      const type = w3cTraceContext.reqType(myHeaders)
 
       expect(type).to.be.equal('Source')
     })

--- a/test/w3c-trace-context.test.js
+++ b/test/w3c-trace-context.test.js
@@ -79,6 +79,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.tracestate).to.be.equal('')
     })
 
     it('should create an object from traceparent and sw tracestate', function () {
@@ -91,6 +92,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.tracestate).to.be.equal(baseTracestateOrgPart)
     })
 
     it('should create an object from traceparent and tracestate that do not match', function () {
@@ -103,6 +105,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(otherXtrace)
+      expect(w3c.tracestate).to.be.equal(otherTracestateOrgPart)
     })
 
     it('should create an object from traceparent with other vendor tracestate', function () {
@@ -115,6 +118,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.tracestate).to.be.equal('oh=different')
     })
 
     it('should create an object from traceparent and tracestate with other vendor tracestate', function () {
@@ -127,6 +131,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.tracestate).to.be.equal('a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before')
     })
 
     it('should create an empty object from invalid traceparent only (bad version)', function () {
@@ -138,6 +143,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal('')
+      expect(w3c.tracestate).to.be.equal('')
     })
 
     it('should create an empty object from invalid traceparent only (bad traceId part)', function () {
@@ -149,6 +155,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal('')
+      expect(w3c.tracestate).to.be.equal('')
     })
 
     it('should create an empty object from invalid traceparent only (bad spanId part)', function () {
@@ -160,6 +167,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal('')
+      expect(w3c.tracestate).to.be.equal('')
     })
 
     it('should create an empty object from invalid traceparent only (bad flags part)', function () {
@@ -171,6 +179,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal('')
+      expect(w3c.tracestate).to.be.equal('')
     })
 
     it('should create an empty object from tracestate only (bad data)', function () {
@@ -182,6 +191,7 @@ describe('w3cTraceContext', function () {
       expect(w3c).to.be.an('object')
       expect(w3c).to.have.all.keys('xtrace', 'tracestate', 'savedSpanId')
       expect(w3c.xtrace).to.be.equal('')
+      expect(w3c.tracestate).to.be.equal('')
     })
 
     it('should create an empty object from tracestate and invalid traceparent (bad data)', function () {
@@ -447,7 +457,7 @@ describe('w3cTraceContext', function () {
     })
   })
 
-  describe('w3cTraceContext.fromHeaders info type', function () {
+  describe('w3cTraceContext.reqType', function () {
     it('should be Continuation when traceparent and tracestate do not match', function () {
       const myHeaders = {
         traceparent: baseTraceparent,

--- a/test/w3c-trace-context.test.js
+++ b/test/w3c-trace-context.test.js
@@ -1,0 +1,733 @@
+/* global it, describe */
+'use strict'
+const expect = require('chai').expect
+const w3cTraceContext = require('../lib/w3c-trace-context')
+
+const baseTraceparent = '00-0123456789abcdef0123456789abcdef-7a71b110e5e3588d-01'
+const baseXtrace = '2B0123456789ABCDEF0123456789ABCDEF999988887A71B110E5E3588D01'
+const baseTraceState = 'sw=7a71b110e5e3588d-01'
+const otherXtrace = '2B0123456789ABCDEF0123456789FFFFFF999988881B11B110E5E3588D01'
+
+const expectEmptyObject = (w3c) => {
+  expect(w3c).to.be.an('object')
+  expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+  expect(w3c.xtrace).to.be.equal('')
+  expect(w3c.traceparent).to.be.equal('')
+  expect(w3c.tracestate).to.be.equal('')
+}
+
+describe('w3cTraceContext', function () {
+  describe('w3cTraceContext.fromHeaders object creation from w3c request headers', function () {
+    it('should create an object from empty headers', function () {
+      const myHeaders = {}
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c.xtrace).to.be.equal('')
+      expect(w3c.traceparent).to.be.equal('')
+      expect(w3c.tracestate).to.be.equal('')
+    })
+
+    it('should create an object omitting unseeded header keys', function () {
+      const myHeaders = {
+        'x-some': 'thing',
+        other: 'also thing'
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.not.have.any.keys('x-some', 'other')
+    })
+
+    it('should create an object from wrong input (number)', function () {
+      const w3c = w3cTraceContext.fromHeaders(1)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+    })
+
+    it('should create an object from wrong input (string)', function () {
+      const w3c = w3cTraceContext.fromHeaders('wow')
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+    })
+
+    it('should create an object from wrong input (boolean)', function () {
+      const w3c = w3cTraceContext.fromHeaders(true)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+    })
+
+    it('should create an object from wrong input (empty)', function () {
+      const w3c = w3cTraceContext.fromHeaders()
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+    })
+
+    it('should create an object from wrong input (undefined)', function () {
+      const w3c = w3cTraceContext.fromHeaders(undefined)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+    })
+
+    it('should create an object from traceparent only', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal('')
+    })
+
+    it('should create an object from traceparent and sw tracestate', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: baseTraceState
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTraceState)
+    })
+
+    it('should create an object from traceparent and tracestate that do not match', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788-01'
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c.xtrace).to.be.equal('2B0123456789ABCDEF0123456789ABCDEF99998888999988885566778801')
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal('sw=9999888855667788-01')
+    })
+
+    it('should create an object from traceparent with other vendor tracestate', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'oh=different'
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal('oh=different')
+    })
+
+    it('should create an object from traceparent and tracestate with other vendor tracestate', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before'
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+      expect(w3c.xtrace).to.be.equal('2B0123456789ABCDEF0123456789ABCDEF99998888999988885566778801')
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal('a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before')
+    })
+
+    it('should create an empty object from invalid traceparent only (bad version)', function () {
+      const myHeaders = {
+        traceparent: '01' + baseTraceparent.slice(2)
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expectEmptyObject(w3c)
+    })
+
+    it('should create an empty object from invalid traceparent only (bad traceId part)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent.slice(0, -30) + baseTraceparent.slice(-29)
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expectEmptyObject(w3c)
+    })
+
+    it('should create an empty object from invalid traceparent only (bad spanId part)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent.slice(0, -6) + baseTraceparent.slice(-5)
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expectEmptyObject(w3c)
+    })
+
+    it('should create an empty object from invalid traceparent only (bad flags part)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent.slice(-1) + 'a'
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expectEmptyObject(w3c)
+    })
+
+    it('should create an empty object from tracestate only (bad data)', function () {
+      const myHeaders = {
+        tracestate: baseTraceState + ',a1=bad,a2=game'
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expectEmptyObject(w3c)
+    })
+
+    it('should create an empty object from tracestate and invalid traceparent (bad data)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent.replace('a', 'A'),
+        tracestate: baseTraceState
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expectEmptyObject(w3c)
+    })
+
+    // TODO: do we want to validate the traceparent?
+  })
+
+  describe('w3cTraceContext.fromData object creation from xtrace, stored tracestate input', function () {
+    it('should create an object from xtrace', function () {
+      const data = {
+        xtrace: baseXtrace
+      }
+      const w3c = w3cTraceContext.fromData(data)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTraceState)
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+    })
+
+    it('should create an object from xtrace and tracestate when there are other vendors', function () {
+      const data = {
+        xtrace: baseXtrace,
+        tracestate: 'oh=other'
+      }
+      const w3c = w3cTraceContext.fromData(data)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTraceState + ',oh=other')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+    })
+
+    it('should create an object from xtrace and tracestate when there is an existing sw value', function () {
+      const data = {
+        xtrace: baseXtrace,
+        tracestate: 'oh=other,sw=7a71b110e5e30000-01'
+      }
+      const w3c = w3cTraceContext.fromData(data)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTraceState + ',oh=other')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+    })
+
+    it('should create an object from xtrace and tracestate when there is an existing sw value on left', function () {
+      const data = {
+        xtrace: baseXtrace,
+        tracestate: 'sw=7a71b110e5e30000-01,oh=other'
+      }
+      const w3c = w3cTraceContext.fromData(data)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTraceState + ',oh=other')
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+    })
+
+    it('should create an empty from invalid xtrace (bad prefix)', function () {
+      const data = {
+        xtrace: 'AA' + baseXtrace.slice(2)
+      }
+      const w3c = w3cTraceContext.fromData(data)
+
+      expectEmptyObject(w3c)
+    })
+
+    it('should create an empty from invalid xtrace (bad traceId)', function () {
+      const data = {
+        xtrace: baseXtrace.slice(0, -16) + baseTraceparent.slice(-16)
+      }
+      const w3c = w3cTraceContext.fromData(data)
+
+      expectEmptyObject(w3c)
+    })
+
+    it('should create an empty from invalid xtrace (bad opId)', function () {
+      const data = {
+        xtrace: baseXtrace.slice(0, -6) + baseTraceparent.slice(-5)
+      }
+      const w3c = w3cTraceContext.fromData(data)
+
+      expectEmptyObject(w3c)
+    })
+
+    it('should create an empty from invalid xtrace (bad flags)', function () {
+      const data = {
+        xtrace: baseXtrace.slice(-1) + 'a'
+      }
+      const w3c = w3cTraceContext.fromData(data)
+
+      expectEmptyObject(w3c)
+    })
+  })
+
+  describe('w3cTraceContext.fromHeaders info type', function () {
+    it('should be Continuation when traceparent and tracestate do not match', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788-01'
+      }
+      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+
+      expect(type).to.be.equal('Continuation')
+    })
+
+    it('should be Flow when traceparent and tracestate match', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: baseTraceState
+      }
+      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+
+      expect(type).to.be.equal('Flow')
+    })
+
+    it('should be Downstream when there is only traceparent', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent
+      }
+      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+
+      expect(type).to.be.equal('Downstream')
+    })
+
+    it('should be Source when there is no traceparent just tracestate (malformed)', function () {
+      const myHeaders = {
+        tracestate: '7a71b110e5e3588d-01'
+      }
+      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+
+      expect(type).to.be.equal('Source')
+    })
+
+    it('should be Source when there are no headers', function () {
+      const myHeaders = {
+      }
+      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+
+      expect(type).to.be.equal('Source')
+    })
+  })
+
+  describe('w3cTraceContext.fromHeaders info spanId', function () {
+    it('should be valid when traceparent and tracestate do not match', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
+
+      expect(id).to.be.equal('7a71b110e5e3588d')
+    })
+
+    it('should be valid when traceparent and tracestate match', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: baseTraceState
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
+
+      expect(id).to.be.equal('7a71b110e5e3588d')
+    })
+
+    it('should be empty when traceparent is malformed (too long)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent + '1'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when traceparentis malformed (too short)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent.slice(0, 10) + baseTraceparent.slice(11)
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (no dash)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent.replace('-', '_')
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (not hex)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent.replace('a', 'z')
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (not lowercase hex)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent.replace('a', 'A')
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when there is no traceparent', function () {
+      const myHeaders = {
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.spanId
+
+      expect(id).to.be.equal('')
+    })
+  })
+
+  describe('w3cTraceContext.fromHeaders info savedSpanId', function () {
+    it('should be valid when traceparent and tracestate do not match', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('9999888855667788')
+    })
+
+    it('should be empty when tracestate is malformed (too long)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=999988885566778899-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (too short)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=799998888556677-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (no dash)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788_01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (not hex)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=99998888556677zz-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be valid when tracestate is with other vendor and own data', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('9999888855667788')
+    })
+
+    it('should be first valid when tracestate is malformed and contains own twice', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788-01,sw=77771111aaaa0011-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('9999888855667788')
+    })
+
+    it('should be first when tracestate is with other vendor and own data twice', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before,sw=77771111aaaa0011-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('9999888855667788')
+    })
+
+    it('should be empty when tracestate is with other vendor data only', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,a2=i_was_before'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when there is no tracestate', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,a2=i_was_before'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedSpanId
+
+      expect(id).to.be.equal('')
+    })
+  })
+
+  describe('w3cTraceContext.fromHeaders info savedFlags', function () {
+    it('should be valid when traceparent and tracestate do not match', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('01')
+    })
+
+    it('should be empty when tracestate is malformed (too long)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=999988885566778899-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (too short)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=77771111aaaa00-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (no dash)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788_01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (not hex)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=77771111aaaa000z-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be valid when tracestate is with other vendor and own data', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('01')
+    })
+
+    it('should be valid when tracestate is malformed and contains own twice', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788-01,sw=77771111aaaa0011-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('01')
+    })
+
+    it('should be valid when tracestate is with other vendor and own data twice', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,sw=9999888855667788-01,a2=i_was_before,sw=77771111aaaa0011-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('01')
+    })
+
+    it('should be empty when tracestate is with other vendor data only', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,a2=i_was_before'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when there is no tracestate', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).info.savedFlags
+
+      expect(id).to.be.equal('')
+    })
+  })
+
+  describe('w3cTraceContext.padding', function () {
+    it('should have a default value of 99998888', function () {
+      expect(w3cTraceContext.padding).to.be.equal('99998888')
+    })
+
+    it('should be setable', function () {
+      w3cTraceContext.padding = '12345678'
+
+      expect(w3cTraceContext.padding).to.be.equal('12345678')
+    })
+  })
+
+  describe('w3cTraceContext.orgId', function () {
+    it('should have a default value of sw', function () {
+      expect(w3cTraceContext.orgId).to.be.equal('sw')
+    })
+
+    it('should be setable', function () {
+      w3cTraceContext.orgId = 'no'
+
+      expect(w3cTraceContext.orgId).to.be.equal('no')
+    })
+  })
+
+  // TODO: revisit
+  // allows x-trace header to ensure comparability with older agents
+  describe('w3cTraceContext.fromHeaders object creation from legacy x-trace input', function () {
+    it('should create an object from x-trace', function () {
+      const myHeaders = {
+        'x-trace': baseXtrace
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTraceState)
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+    })
+
+    it('should create an object from x-trace even overriding xtrace if specified', function () {
+      const myHeaders = {
+        xtrace: otherXtrace,
+        'x-trace': baseXtrace
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expect(w3c).to.be.an('object')
+      expect(w3c).to.have.all.keys('xtrace', 'traceparent', 'tracestate', 'info')
+
+      expect(w3c.traceparent).to.be.equal(baseTraceparent)
+      expect(w3c.tracestate).to.be.equal(baseTraceState)
+      expect(w3c.xtrace).to.be.equal(baseXtrace)
+    })
+
+    it('should create an empty object from invalid x-trace', function () {
+      const myHeaders = {
+        'x-trace': baseXtrace + 'A'
+      }
+      const w3c = w3cTraceContext.fromHeaders(myHeaders)
+
+      expectEmptyObject(w3c)
+    })
+  })
+
+  describe('w3cTraceContext.fromHeaders info type from legacy x-trace input', function () {
+    it('should be Flow when there is only x-trace', function () {
+      const myHeaders = {
+        'x-trace': baseXtrace
+      }
+      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+
+      expect(type).to.be.equal('Flow')
+    })
+
+    it('should be Source when using xtrace (bad data)', function () {
+      const myHeaders = {
+        xtrace: baseXtrace
+      }
+      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+
+      expect(type).to.be.equal('Source')
+    })
+
+    it('should be Flow if x-trace present even when traceparent and tracestate do not match', function () {
+      const myHeaders = {
+        'x-trace': baseXtrace,
+        traceparent: baseTraceparent,
+        tracestate: 'sw=9999888855667788-01'
+      }
+      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+
+      expect(type).to.be.equal('Continuation')
+    })
+
+    it('should be Source when there is only x-trace that is invalid', function () {
+      const myHeaders = {
+        'x-trace': baseXtrace + 'A'
+      }
+      const type = w3cTraceContext.fromHeaders(myHeaders).info.type
+
+      expect(type).to.be.equal('Source')
+    })
+  })
+})


### PR DESCRIPTION
## Overview 

This Pull request adds [W3C Trace Context](https://www.w3.org/TR/trace-context/) support to the AppOptics APM Node Agent. 

This *non-breaking change* allows the agent to handle distributed tracing scenarios that cross boundaries between AppOptics and [Open Telemetry](https://opentelemetry.io/) Instrumented services.

A Proof-of-Concept server setup is available at https://github.com/appoptics/node-w3c-poc. For trace samples see <a href="#poc">Proof-of-Concept</a> below.

## Availability

To use with existing apps: `npm install git://github.com/appoptics/appoptics-apm-node.git#W3C-Trace-Context --save`

## Problem

AppOptics Agents can follow a distributed trace as long as the request chain is made up solely of AppOptics instrumented Services (notation: AAA). Open Telemetry Instrumented services can follow a distributed trace as long as the request chain is made up solely of Open Telemetry instrumented services (notation: OOO).

When the chain of instrumented services is a mix of AppOptics and Open Telemetry services (notation: AOA, OAO), the chain is "broken" and each part of the chain is considered a standalone trace.

### Valid - AAA and OOO

```
     ───── https://my.solarwinds.cloud/ ─────                  
          ▲             ▲             ▲                           
     ┌──────────┐  ┌──────────┐  ┌──────────┐                 ┌──────────┐  ┌──────────┐  ┌──────────┐
     │  AO App  │  │  AO App  │  │  AO App  │                 │          │  │          │  │          │
   ─►│          ├─►│          ├─►│          │               ─►│          ├─►│          ├─►│          │
     │          │  │          │  │          │                 │ OTel App │  │ OTel App │  │ OTel App │
     └──────────┘  └──────────┘  └──────────┘                 └──────────┘  └──────────┘  └──────────┘
                                                                   ▼             ▼             ▼
                                                              ──── http://localhost:9411/zipkin/ ─────
```

### Broken - AOA and OAO
```
     ───── https://my.solarwinds.cloud/ ─────                 ───── https://my.solarwinds.cloud/ ─────   
          ▲                           ▲                                          ▲ 
     ┌──────────┐  ┌──────────┐  ┌──────────┐                 ┌──────────┐  ┌──────────┐  ┌──────────┐
     │  AO App  │  │          │  │  AO App  │                 │          │  │  AO App  │  │          │
   ─►│          ├x │          ├x │          │               ─►│          ├x │          ├x │          │
     │          │  │ OTel App │  │          │                 │ OTel App │  │          │  │ OTel App │
     └──────────┘  └──────────┘  └──────────┘                 └──────────┘  └──────────┘  └──────────┘
                        ▼                                           ▼                           ▼
     ──── http://localhost:9411/zipkin/ ─────                  ──── http://localhost:9411/zipkin/ ─────
```

## Solution 

With the changes in the pull request, requests that cross boundaries are correctly traced and context is maintained as per the W3C Trace Context specification recommendation. 

An AOA chain will create two linked traces at AppOptics backend recognizing a "continuation". An OAO chain will create a single trace at the AppOptics backend recognizing that the AppOptics instrumented service is "downstream". Obviously more complex chains are also supported (see <a href="#poc">Proof-of-Concept</a> below.).

### Maintain Trace Context Across Boundaries - AOA, OAO
```
     ───── https://my.solarwinds.cloud/ ─────                 ───── https://my.solarwinds.cloud/ ─────   
          ▲                           ▲                                          ▲ 
     ┌──────────┐  ┌──────────┐  ┌──────────┐                 ┌──────────┐  ┌──────────┐  ┌──────────┐
     │  AO App  │  │          │  │  AO App  │                 │          │  │  AO App  │  │          │
   ─►│          ├─►│          ├─►│          │               ─►│          ├─►│          ├─►│          │
     │          │  │ OTel App │  │          │                 │ OTel App │  │          │  │ OTel App │
     └──────────┘  └──────────┘  └──────────┘                 └──────────┘  └──────────┘  └──────────┘
                       ▼                                           ▼                           ▼
     ──── http://localhost:9411/zipkin/ ─────                  ──── http://localhost:9411/zipkin/ ─────
```


## Implementation Overview

Changes are contained within the `http` probe alone without breaking any API barrier.

A new module, `w3c-trace-context`, is introduced. It handles conversion between AppOptics `xtrace` (for internal proccesing) and w3c `tracestate` and `traceparent` (for http communication). It also provides legacy support for the `x-trace` header.

Module exposes two methods `fromHeaders` and `prepHeaders`. `fromHeaders` accepts a headers object and returns an object with the data required for internal processing (`xtrace`, `tracestate` and `savedSpanId` extracted from tracestate and reported as KV). `prepHeaders` accepts `xtrace` and `tracestate` and returns the trio of header values (`xtrace`, `tracestate`, `traceparent`).

Integration with `http` probe is done via the two methods. `fromHeaders` is used in the server patch to extract incoming headers and `prepHeaders` is used in the client patch to generate outgoing headers.

All logic regarding headers required by the W3C Trace Context specification recommendation is encapsulated inside the module.
```
                                                              ─┐
                            ┌───────┐                          │
                            │Backend│                          │
                            └───────┘                          │
                                ▲                              │
                                │                              │
                                │                              │
                             network                           │
                                │                              │
                                │                              │
                                ▼                              │  Here
                            ┌───────┐                          │  Be
                            │liboboe│                          │  Dragons
                            └───────┘                          │
                                ▼                              │
                               api                             │
                                ▲                              │
                         ┌─────────────┐                       │
                         │Node Bindings│                       │
                         └─────────────┘                       │
                                ▼                              │
        repo boundary ──────── api ───────────────             │
                                ▲                              │
                          ┌──────────┐                         │
                          │Node Agent│                         │
                          └──────────┘                         │
                                ▼                              │
                               api                            ─┘
                                ▲
                  ┌───────────────────────────┐               ─┐
    incoming ───► │        http probe         │ ──► outgoing   │
    request       │server               client│     request    │
                  │patch                patch │                │
                  └───────────────────────────┘                │
                                                               │  W3C Trace
                                                               │  Context
                fromHeaders              prepHeaders           │
                                                               │
                    ┌───────────────────────┐                  │
                    │w3 Trace Context Module│                  │
                    └───────────────────────┘                 ─┘

```

## Implementation Details & Notes

### xtrace Padding

Since the trace id part of `xtrace` is longer than the trace id part of `traceparnet`, conversion between `xtrace` and `traceparent` uses a constant "padding" string. This implementation uses '00000000' as will all future SolarWinds Agents.

### Backwards Compatibility

This is a *non-breaking change* that is fully backwards compatible.

With this pull request merged, any AppOptics instrumented service that does not support W3C Trace Context headers becomes "Legacy" for W3C Trace Context.

This implementation correctly traces request chains that pass through a "legacy" AppOptics instrumented service (notation: ALA) and those originate in one (notation: LAL) (see <a href="#poc">Proof-of-Concept</a> below.).

### Org part of tracestate

This implementation uses `sw` org id in `tracestate` and sets its value to span id and flags with dash separator (e.g. `sw=7a71b110e5e3588d-01`).

### Request Type

In the context of request chains, each incoming http request can be classified as being one of four types: *Source*, *Flow*, *Downstream* or *Continuation*. 
  * A *Source* request is the first request in the chain. Source request have no valid headers.
  * A *Flow* request is one that is directly downstream from an AppOptics instrumented app. It has valid `x-trace`, `traceparent` and `tracestate` headers. Org <u>is in</u> `tracestate`. The span id part of `traceparent` (and `x-trace`) <u>match</u> the span id part in `tracestate`. 
  * A Continuation request is one that comes directly downstream form an Open Telemetry instrumented service, but has passed through an AppOptics instrumented service in the past. It has valid `traceparent` and `tracestate` headers. Org <u>is in</u> `tracestate`. The span id part of `traceparent` (and `x-trace`) <u>does not match</u> the span id part in `tracestate`.
  * A Downstream request is one that comes directly form an Open Telemetry instrumented service. It originated in that service, or any other upstream, but has never went through an AppOptics instrumented service. It has a valid `traceparent` header (and no `x-trace`). Org is <u>not in</u> `tracestate`.

Any request chain can be mapped to request type chain. AAA maps to SFF. AOA to SC , OAAA to DFF
and something complex like AOAAOAAAOOOAAAOAAOA maps to SDFDFFDFFDFD. Thus Request Type is as an abstraction of the data in the request headers. It can be derived from `traceparent` and `tracestate`.

It is returned from `reqType` method of the new `w3c-trace-context` module and is used in the integration with `http`.

For testing purposes request type was reported to backend as `W3C_type` key value pair and was used in conjunction with the `Color_by` filter of the undocumented `/graph` view in AppOptics UI (see <a href="#poc">Proof-of-Concept</a> below.). This feature is out of current spec and was removed from final version of this pull request.

### Trace Decisions

The core logic of trace decisions is unchanged.

* *Continuation* requests should always be treated as *Flow* requests since their `xtrace` is generated from the the span id and flags stored in the org part of `tracestate`.
* This implementation treats *Downstream* requests as if they were *Source* requests, ignoring the tracing decision flags of the upstream vendor and making a new one instead.

### Span Parenting

In a *Continuation* request, the span id part of `traceparent` belongs to an upstream service and is unrecognized. In such a case, this implementation generates an `xtrace` based on the span id stored in the org part of `tracestate` resulting in correct parenting, a continued trace and usable UI view.

### Span Edge

In a *Downstream* request the span id part of `traceparent` belongs to an upstream service and is unrecognized. In such a case this implementation generates and event ignoring the `xtrace` (plugging the data from `traceparent` after instantiation) which results in a new top level span and thus resulting in a usable UI view.

### Key Value Pairs

The following key value pairs were added as per updated spec:

#### Client patch (outgoing request)
None.

#### Server patch (incoming request)

For *Continuation* only: 
`sw.parent_id`
`sw.w3c.tracestate`

### Response Headers

This implementation does not change server response headers.

### tracestate Passthrough

Incoming `tracestate` string is only examined to match the org key value.

Outgoing `tracestate` string is:
- cleaned of any entry that does not contain a valid `key=value` pair
- limits number of entries to 32
- truncated to be no longer than 512 characters by removing:
  - entries longer than 128 characters; and then
  - entries from the end of the list

## Tests

All [tests pass](https://github.com/appoptics/appoptics-apm-node/actions/runs/1414519040) for Node versions 10, 12, 14 and 16, 17.

* W3C Trace Context Module unit tests are included in this pull request.
* Updated `http` probe  tests are included in this pull request.
* As this is a *non-breaking change*, no other changes had to be made to existing test suite. 

Extensive integration testing done using [PoC server setup](https://github.com/appoptics/node-w3c-poc). Additional spot testing with higher level frameworks (Express, Nest.js) shows tracing works as expected.

## <h3 id="poc">Proof-of-Concept</h3>

### AOAAOAAAOOOAAAOAAOA - Originate at AppOptics, Cross Otel

Trace "Source" is at AppOptics instrumented service . Open Telemetry instrumented service is "Downstream".
 
<img width="1728" alt="Screen Shot 2021-11-02 at 3 57 08 PM" src="https://user-images.githubusercontent.com/891105/139964034-104f4c6e-1d48-489c-b01f-40f84d8220e8.png">

[Trace](https://my-stg.appoptics.com/apm/225844/services/w3c-poc/traces/41BAAD2A40EB27D3DF5387D0660F60C000000000)

<img width="1723" alt="Screen Shot 2021-11-02 at 4 00 52 PM" src="https://user-images.githubusercontent.com/891105/139964153-4b8a3f01-936e-432b-98bc-1ff199d773db.png">

Note: Zipkin "knows" there are 14 spans and depth of 6 but fails to display them. Pending further invastigation.

### OAOOAAOAAOAA - Originate ate Otel, Cross Otel

Trace "Source" is at an Open Telemetry instrumented service AppOptics instrumented service is "Downstream".

<img width="1733" alt="Screen Shot 2021-11-02 at 3 59 05 PM" src="https://user-images.githubusercontent.com/891105/139964328-3edfa340-ae40-4dd0-9859-072a3c3f8ab1.png">

[Trace](https://my-stg.appoptics.com/apm/225844/services/w3c-poc/traces/018739905C0275EF2EDD24E62C5570BD00000000)

<img width="1737" alt="Screen Shot 2021-11-02 at 3 59 58 PM" src="https://user-images.githubusercontent.com/891105/139964376-6259df28-613e-4ea4-8e71-cd74b6bccd16.png">

### AOALAOA - Originate at AppOptics, Cross Otel, Connect Legacy

Trace "Source" is at AppOptics instrumented service. Legacy instrumented service is "Downstream".

<img width="1722" alt="Screen Shot 2021-11-02 at 4 02 23 PM" src="https://user-images.githubusercontent.com/891105/139964455-54b9a287-7f16-4f1f-87f5-a48c4d66a3aa.png">

[Trace](https://my-stg.appoptics.com/apm/225844/services/w3c-poc/traces/27A5FFC5BA95784E71943D32F55D188500000000)

### LAALLAA - Originate at Legacy, Connect AppOptics

Trace "Source" is at Legacy instrumented service. AppOptics instrumented service is "Downstream".

<img width="1737" alt="Screen Shot 2021-11-02 at 4 06 47 PM" src="https://user-images.githubusercontent.com/891105/139964490-85c7408c-11b3-4701-9b39-20acc91ae8a2.png">

[Trace](https://my-stg.appoptics.com/apm/225844/services/w3c-poc/traces/C8CE64DD0228D30257C1C57546DF9916D7C95CB7)

### OAOAA Request Type Graph View (experimental)

<img width="1731" alt="Screen Shot 2021-10-05 at 6 53 03 PM" src="https://user-images.githubusercontent.com/891105/136128381-dbec2725-c5ac-417f-bcd8-ae835562c7bb.png">

[Trace](https://my-stg.appoptics.com/apm/225844/services/ao-node-test/traces/47EE5FC5D0BEE10BF87626DE893B954399998888/graph)