### PR TITLE
NH-5315-Remove-Handle-Conflicts-Code

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -30,7 +30,6 @@ The configuration file can supply the following properties, showing their defaul
   enabled: true,
   hostnameAlias: undefined,
   domainPrefix: false,
-  ignoreConflicts: false,
   traceMode: 'enabled',
   runtimeMetrics: true,
   transactionSettings: undefined,
@@ -53,7 +52,6 @@ The configuration file can supply the following properties, showing their defaul
 |proxy||Proxy that does not require authentication: `http://proxy-server:3306`. Proxy that does require Basic Authentication: `http://user:password@proxy-server:3306`.|
 |hostnameAlias||A logical hostname that can be used to easily identify the host.|
 |domainPrefix|`false`|Prefix transaction names with the domain name.|
-|ignoreConflicts|`false`|Appoptics will disable itself when conflicting APM products are loaded unless this is set to `true`.|
 |traceMode|`'enabled'`|Mode `'enabled'` will cause Appoptics to sample as many requests as possible. Mode 'disabled' will disable sampling and metrics.|
 |runtimeMetrics|`true`|Collect runtime metrics characterizing the performance of node and v8|
 |transactionSettings|`undefined`|An array of transactions to exclude. Each array element is an object of the form `{type: 'url', string: 'pattern', tracing: trace-setting}` or `{type: 'url', regex: /regex/, tracing: trace-setting}`. When the specified type (currently only `'url'` is implemented) matches the string or regex then tracing for that url is set to trace-setting, overriding the global traceMode. N.B. if inserting a regex into a JSON configuration file you must enter the string that is expected by the `RegExp` constructor because JSON has no representation of a `RegExp` object. `trace-setting` is either `'enabled'` or `'disabled'`.|

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -33,7 +33,6 @@ function getUnifiedConfig () {
 
   const settings = {
     // end-user focused, config file only
-    ignoreConflicts: { location: 'c', type: 'b' },
     domainPrefix: { location: 'c', type: 'b' },
     insertTraceIdsIntoLogs: { location: 'c', type: 'b' },
     insertTraceIdsIntoMorgan: { location: 'c', type: 'b' },

--- a/lib/index.js
+++ b/lib/index.js
@@ -183,38 +183,6 @@ ao.makeLogMissing = function makeLogMissing (name) {
 }
 
 //
-// Disable module when conflicts are found
-//
-if (!config.ignoreConflicts) {
-  const modules = Object.keys(require.cache)
-  const possibleConflicts = [
-    'newrelic',
-    'strong-agent',
-    'appdynamics'
-  ]
-  function checkMod (conflict, mod) {
-    return (new RegExp(`/node_modules/${conflict}/`)).test(mod)
-  }
-  const conflicts = possibleConflicts.filter(conflict => {
-    return modules.filter(mod => checkMod(conflict, mod)).length > 0
-  })
-
-  function andList (list) {
-    const last = list.pop()
-    return (list.length ? list.join(', ') + ', and ' : '') + last
-  }
-
-  if (conflicts.length > 0) {
-    enabled = false
-    log.error([
-      'Users have reported that the following modules conflict',
-      `with AppOptics instrumentation: ${andList(conflicts)}.`,
-      'Please uninstall them and restart the application.'
-    ].join(' '))
-  }
-}
-
-//
 // now go through a sequence of checks and tests that can result in
 // appoptics being disabled. accumulate the errors so a summary message
 // with the enabled status can be output at the end of the checks.

--- a/test/get-unified-config.test.js
+++ b/test/get-unified-config.test.js
@@ -227,7 +227,6 @@ describe('get-unified-config', function () {
         enabled: false,
         hostnameAlias: 'bruce',
         serviceKey: 'f'.repeat(64),
-        ignoreConflicts: true,
         domainPrefix: false
       }
       writeConfigJSON(config)
@@ -407,7 +406,6 @@ describe('get-unified-config', function () {
         enabled: false,
         hostnameAlias: 'bruce',
         serviceKey: 'f'.repeat(64),
-        ignoreConflicts: true,
         domainPrefix: false,
         unifiedLogging: 'never'
       }


### PR DESCRIPTION
### Overview:

This pull request removes the code used to detect and potentially handle conflicts with `newrelic`, `strong-agent` and `appdynamics` and also removes the `ignoreConfilicts` config setting.

### Status:

The code, as implemented, checked the require cache to see if one of the ignored packages is loaded. However, since the AppOptics agent is  required, per our instructions, **before** any other packages, the agent will not be able to find anything in the required cache when the code is run.

Since this behavior is foundational, the code only checks edge-cases (AppOptics agent was not required first) of edge cases (other packages that may create conflicts were required prior). For simplification it has been removed.

### Notes:
- Pull Request merges into `nh-main` branch. Agent built from `master` will stay unchanged.