### PR TITLE
NH-5268-Remove-semver-Conditionals-for-Outdated-Node-Versions

### DIFF
--- a/lib/probes/generic-pool.js
+++ b/lib/probes/generic-pool.js
@@ -5,14 +5,12 @@ const ao = require('..')
 const log = ao.loggers
 
 const semver = require('semver')
-const nodeVersion = semver.major(process.version)
-
 const logMissing = ao.makeLogMissing('generic-pool')
 
 module.exports = function (gp, info) {
   const version = info.version
   const majorVersion = semver.major(version)
-  if (majorVersion >= 3 && nodeVersion >= 8) {
+  if (majorVersion >= 3) {
     // version 3 is a major overhaul. only patch it if running node version 8.
     // https://github.com/coopernurse/node-pool/blob/master/CHANGELOG.md
     if (typeof gp.Pool === 'function') {

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -3,7 +3,6 @@
 const shimmer = require('shimmer')
 const url = require('url')
 const os = require('os')
-const semver = require('semver')
 
 const ao = require('..')
 const w3cTraceContext = require('../w3c-trace-context')
@@ -211,17 +210,9 @@ function patchClient (module, options, protocol) {
   // wrap request for http and https
   shimmer.wrap(module, 'request', wrapper)
 
-  // in node 8 http.get() no longer calls the exported http.request()
-  // so it must be wrapped in addition to wrapping request. in
-  // node 9.9.0 https.get() no longer calls the exported https.request()
-  // so it must also be wrapped.
   // TODO BAM - consider wrapping _http_client.ClientRequest() where all
   // client requests get created.
-  if (semver.gte(process.version, '8.0.0')) {
-    if (protocol === 'http' || semver.gte(process.version, '9.9.0')) {
-      shimmer.wrap(module, 'get', wrapper)
-    }
-  }
+  shimmer.wrap(module, 'get', wrapper)
 }
 
 //

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const semver = require('semver')
 const shimmer = require('shimmer')
 
 const ao = require('..')
@@ -10,11 +9,6 @@ const logMissing = ao.makeLogMissing('mongodb-core')
 
 module.exports = function (mongodb, options) {
   const { version } = options
-
-  // node 12 with mongodb-core prior to v3 exhibits a memory leak with cls-hooked.
-  if (semver.gte(process.version, '11.15.0') && semver.lt(version, '3.0.0')) {
-    return [mongodb, `${version} (disabled: node ${process.version})`]
-  }
 
   // Patch Server
   let proto = mongodb.Server && mongodb.Server.prototype

--- a/lib/probes/zlib.js
+++ b/lib/probes/zlib.js
@@ -2,7 +2,6 @@
 
 const { inherits } = require('util')
 const shimmer = require('shimmer')
-const semver = require('semver')
 
 const ao = require('..')
 const conf = ao.probes.zlib
@@ -11,8 +10,6 @@ const logMissing = ao.makeLogMissing('probes.zlib')
 
 // turn this on for debugging checks and output.
 const debugging = false
-
-const nodeVersionLessThan8 = semver.lt(process.version, '8.0.0')
 
 const classes = [
   'Deflate',
@@ -34,12 +31,10 @@ const methods = [
   'unzip'
 ]
 
-if (semver.gte(process.version, '11.7.0')) {
-  classes.push('BrotliCompress')
-  classes.push('BrotliDecompress')
-  methods.push('brotliCompress')
-  methods.push('brotliDecompress')
-}
+classes.push('BrotliCompress')
+classes.push('BrotliDecompress')
+methods.push('brotliCompress')
+methods.push('brotliDecompress')
 
 function makeKvPairs (name, options) {
   const kvpairs = { Operation: name }
@@ -112,22 +107,14 @@ function wrapCreator (proto, name) {
     logMissing(`zlib.prototype.${creator}()`)
     return
   }
-  if (nodeVersionLessThan8) {
-    proto[creator] = function (options) {
-      return new proto[name](options)
-    }
-  } else {
-    // zlib changed in node 8 so that the creator function object
-    // is read-only. It is still configurable. This should work for
-    // previous versions as well.
-    Object.defineProperty(proto, creator, {
-      value: function (...args) {
-        return new proto[name](...args)
-      },
-      writable: true,
-      configurable: true
-    })
-  }
+
+  Object.defineProperty(proto, creator, {
+    value: function (...args) {
+      return new proto[name](...args)
+    },
+    writable: true,
+    configurable: true
+  })
 }
 
 function wrapClass (proto, name) {

--- a/test/probes/generic-pool.test.js
+++ b/test/probes/generic-pool.test.js
@@ -20,9 +20,6 @@ const pkg = require('generic-pool/package')
 const v3 = semver.satisfies(pkg.version, '>= 3')
 const ifv3 = v3 ? it : it.skip
 const ifv2 = v3 ? it.skip : it
-const nodeVersion = semver.major(process.version)
-
-const hasAsync = nodeVersion >= 8
 
 let n = 0
 const max = 2
@@ -224,14 +221,7 @@ describe(`probes.generic-pool ${pkg.version}`, function () {
         done(e)
       })
 
-      let acquire
-      if (hasAsync) {
-        // kind of ugly, but how else to get around JavaScript  < 8 issuing a
-        // syntax error?
-        eval('acquire = (async function () {return await pool.acquire()}).bind(pool)')
-      } else {
-        acquire = pool.acquire.bind(pool)
-      }
+      const acquire = async function () { return await pool.acquire() }
 
       //
       // now get the second resource when it's available. it should be available

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -1,8 +1,4 @@
 /* global it, describe, before, beforeEach, after, afterEach */
-
-// note: expect() triggers a lint no-unused-expressions. no apparent reason
-/* eslint-disable no-unused-expressions */
-
 'use strict'
 
 //
@@ -16,7 +12,6 @@ const util = require('util')
 
 const addon = ao.addon
 
-const semver = require('semver')
 const axios = require('axios')
 
 if (process.env.AO_TEST_HTTP !== 'http' && process.env.AO_TEST_HTTP !== 'https') {
@@ -28,15 +23,8 @@ const p = process.env.AO_TEST_HTTP
 
 const driver = require(p)
 
-let createServer = function (options, requestListener) {
+const createServer = function (options, requestListener) {
   return driver.createServer(options, requestListener)
-}
-
-if (p === 'http' && semver.lte(process.version, '9.6.0')) {
-  // the options argument was added to the http module in v9.6.0
-  createServer = function (options, requestListener) {
-    return driver.createServer(requestListener)
-  }
 }
 
 const httpsOptions = {
@@ -199,7 +187,7 @@ describe(`probes.${p}`, function () {
         axios(
           `${p}://localhost:${port}/foo?bar=baz`,
           function (error, response, body) {
-            expect(response.headers).exist
+            expect(response.headers).exist()()
             expect(response.headers).property('x-trace')
           }
         )
@@ -238,7 +226,7 @@ describe(`probes.${p}`, function () {
           headers: {}
         },
         function (error, response, body) {
-          expect(response.headers).exist
+          expect(response.headers).exist()
           expect(response.headers).property('x-trace')
           expect(trasportXtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
         })
@@ -275,7 +263,7 @@ describe(`probes.${p}`, function () {
           }
         },
         function (error, response, body) {
-          expect(response.headers).exist
+          expect(response.headers).exist()
           expect(response.headers).property('x-trace')
           expect(trasportXtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
         })
@@ -312,7 +300,7 @@ describe(`probes.${p}`, function () {
           }
         },
         function (error, response, body) {
-          expect(response.headers).exist
+          expect(response.headers).exist()
           expect(response.headers).property('x-trace')
           expect(trasportXtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
         })
@@ -352,7 +340,7 @@ describe(`probes.${p}`, function () {
           }
         },
         function (error, response, body) {
-          expect(response.headers).exist
+          expect(response.headers).exist()
           expect(response.headers).property('x-trace')
           expect(trasportXtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
         })
@@ -426,7 +414,7 @@ describe(`probes.${p}`, function () {
           }
         },
         function (error, response, body) {
-          expect(response.headers).exist
+          expect(response.headers).exist()
           expect(response.headers).property('x-trace')
           expect(origin.taskId).not.equal(response.headers['x-trace'].slice(2, 42))
         })
@@ -460,7 +448,7 @@ describe(`probes.${p}`, function () {
           headers: { tracestate: baseTracestateOrgPart }
         },
         function (error, response, body) {
-          expect(response.headers).exist
+          expect(response.headers).exist()
           expect(response.headers).property('x-trace')
           expect(origin.taskId).not.equal(response.headers['x-trace'].slice(2, 42))
         })
@@ -1194,23 +1182,7 @@ describe(`probes.${p}`, function () {
       })
     })
 
-    // this fails with the following error on node v10.9.0 to v10.14.1
-    // it might fail before 10.9.0 but it succeeds with node 8. there
-    // are fixes related to errors on streams in 10.14.2, so it seems
-    // reasonable to consider the failures as related to a node bug.
-    /**
-     * Error: Parse Error
-     *  at Socket.socketOnData (_http_client.js:441:20)
-     *  at addChunk (_stream_readable.js:283:12)
-     *  at readableAddChunk (_stream_readable.js:264:11)
-     *  at Socket.Readable.push (_stream_readable.js:219:10)
-     *  at TCP.onread (net.js:639:20)
-     */
     it('should report an error when the server has a socket error', function (testDone) {
-      if (semver.satisfies(process.version, '>= 10.9.0 <= 10.14.1')) {
-        return this.skip()
-      }
-
       // disable so we don't have to look for/exclude http spans in the
       // emitted output.
       ao.probes[p].enabled = false

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -187,7 +187,7 @@ describe(`probes.${p}`, function () {
         axios(
           `${p}://localhost:${port}/foo?bar=baz`,
           function (error, response, body) {
-            expect(response.headers).exist()()
+            expect(response.headers).exist()
             expect(response.headers).property('x-trace')
           }
         )

--- a/test/probes/restify.test.js
+++ b/test/probes/restify.test.js
@@ -6,7 +6,6 @@ const helper = require('../helper')
 const { ao } = require('../1.test-common')
 
 const expect = require('chai').expect
-const semver = require('semver')
 
 const axios = require('axios')
 
@@ -15,20 +14,7 @@ const opts = {
   name: 'restify-test'
 }
 
-if (!semver.satisfies(process.version, '>=4')) {
-  describe('probes.restify', function () {
-    it.skip('not supported for node version < 4', function () {})
-  })
-  process.exit()
-}
-
 const restify = require('restify')
-
-// restify does fs IO starting in node 8
-if (semver.satisfies(process.version, '>=8.0.0')) {
-  ao.loggers.debug('turning off fs instrumentation')
-  ao.probes.fs.enabled = false
-}
 
 describe(`probes.restify ${pkg.version}`, function () {
   let emitter
@@ -192,13 +178,8 @@ describe(`probes.restify ${pkg.version}`, function () {
     })
   }
 
-  if (semver.gte(process.version, '6.0.0')) {
-    it('should forward controller/action', testControllerAction)
-    it('should create a span for each middleware', testMiddleware)
-  } else {
-    it.skip('should forward controller/action', testControllerAction)
-    it.skip('should create a span for each middleware', testMiddleware)
-  }
+  it('should forward controller/action', testControllerAction)
+  it('should create a span for each middleware', testMiddleware)
 })
 
 function interpretMetrics (metrics) {

--- a/test/probes/zlib.test.js
+++ b/test/probes/zlib.test.js
@@ -11,8 +11,6 @@ const zlib = require('zlib')
 
 const expect = require('chai').expect
 
-const semver = require('semver')
-
 const classes = [
   'Deflate',
   'Inflate',
@@ -33,12 +31,10 @@ const methods = [
   'unzip'
 ]
 
-if (semver.gte(process.version, '11.7.0')) {
-  classes.push('BrotliCompress')
-  classes.push('BrotliDecompress')
-  methods.push('brotliCompress')
-  methods.push('brotliDecompress')
-}
+classes.push('BrotliCompress')
+classes.push('BrotliDecompress')
+methods.push('brotliCompress')
+methods.push('brotliDecompress')
 
 describe('probes.zlib once', function () {
   let emitter
@@ -147,10 +143,6 @@ describe('probes.zlib', function () {
 
   // Brotli
   before(function (done) {
-    if (semver.lt(process.version, '11.7.0')) {
-      done()
-      return
-    }
     inputs.BrotliCompress = test
     outputs.BrotliDecompress = test
     zlib.brotliCompress(test, function (err, res) {

--- a/test/versions.js
+++ b/test/versions.js
@@ -32,8 +32,6 @@ test('zlib')
 test('amqplib', '>= 0.2.0 < 0.5.0 || > 0.5.0')
 
 test('bcrypt', selectone(process.version, [
-  { selector: '>= 8.0.0 < 10.0.0', targetSelector: '>= 1.0.3 < 3.0.0 || > 3.0.0' },
-  { selector: '>= 10.0.0 < 12.0.0', targetSelector: '>= 3.0.0' },
   // version 4.0.0 doesn't work on alpine
   { selector: '>= 12.0.0', targetSelector: loi.id !== 'alpine' ? '>= 3.0.6' : '>= 3.0.6 < 4.0.0 || >= 4.0.1' }
 ]))


### PR DESCRIPTION
### Overview
This pull request removes node version checks for outdated versions that will not be supported moving fwd.

The following probes are affected:
- generic-pool (972c567)
- zlib (369840e)
- mongodb-core (56a45ed)
- http (03d35d0)

### Notes:
- Pull Request merges into `nh-main`.