### PR TITLE
NH-5414-Update-Dependencies-devDependencies-1

### DIFF
--- a/lib/probes/express.js
+++ b/lib/probes/express.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const flatten = require('array-flatten')
 const shimmer = require('shimmer')
 const methods = require('methods')
 const semver = require('semver')
@@ -134,7 +133,7 @@ function patchRoutes (express, version) {
         return
       }
       shimmer.wrap(proto, method, method => function (...args) {
-        return method.apply(this, flatten(args).map(expressRoute))
+        return method.apply(this, args.flat().map(expressRoute))
       })
     })
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "ace-context": "^1.0.1",
-    "array-flatten": "^2.1.2",
     "cls-hooked": "^4.2.2",
     "debug-custom": "^1.1.0",
     "eslint-plugin-json": "^3.1.0",


### PR DESCRIPTION
 ### Overview:

This pull request removes `array-flatten` from dependencies.

`array-flatten` was added as dependency in https://github.com/appoptics/appoptics-apm-node/commit/9b2a6a058260350ed7091ea12673d0c352f8587c. 

### Status:

No longer needed. Array.prototype.flat() is available in [node versions 11+](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#browser_compatibility).

### Notes:
- Pull Request merges into `nh-main`. Agent built from `master` will maintain dependency`.