### PR TITLE
NH-5414-Update-Dependencies-devDependencies-2

### DIFF
--- a/lib/probes/express.js
+++ b/lib/probes/express.js
@@ -131,7 +131,7 @@ function patchRoutes (express, version) {
     }
     http.METHODS.concat('all').forEach(method => {
       if (typeof proto[method.toLowerCase()] !== 'function') {
-        logMissing(`v4 Route.${method.toLowerCase().to}()`)
+        logMissing(`v4 Route.${method.toLowerCase()}()`)
         return
       }
       shimmer.wrap(proto, method.toLowerCase(), m => function (...args) {

--- a/lib/probes/express.js
+++ b/lib/probes/express.js
@@ -2,9 +2,10 @@
 
 const flatten = require('array-flatten')
 const shimmer = require('shimmer')
-const methods = require('methods')
+const http = require('http')
 const semver = require('semver')
 const utility = require('../utility')
+
 const ao = require('..')
 const log = ao.loggers
 const conf = ao.probes.express
@@ -128,13 +129,13 @@ function patchRoutes (express, version) {
       logMissing('v4 Route.prototype')
       return
     }
-    methods.concat('all').forEach(method => {
-      if (typeof proto[method] !== 'function') {
-        logMissing(`v4 Route.${method}()`)
+    http.METHODS.concat('all').forEach(method => {
+      if (typeof proto[method.toLowerCase()] !== 'function') {
+        logMissing(`v4 Route.${method.toLowerCase().to}()`)
         return
       }
-      shimmer.wrap(proto, method, method => function (...args) {
-        return method.apply(this, flatten(args).map(expressRoute))
+      shimmer.wrap(proto, method.toLowerCase(), m => function (...args) {
+        return m.apply(this, flatten(args).map(expressRoute))
       })
     })
   }

--- a/lib/probes/koa-route.js
+++ b/lib/probes/koa-route.js
@@ -1,12 +1,11 @@
 'use strict'
 
 const shimmer = require('shimmer')
-const methods = require('methods')
+const http = require('http')
 const semver = require('semver')
-
-const ao = require('../')
 const utility = require('../utility')
 
+const ao = require('../')
 const conf = ao.probes['koa-route']
 
 module.exports = function (route, info) {
@@ -17,10 +16,10 @@ module.exports = function (route, info) {
     patcher = patchGeneratorHandler
   }
 
-  methods.concat('del')
+  http.METHODS.concat('del')
     // The method might not exist at all
-    .filter(method => typeof route[method] === 'function')
-    .forEach(method => patchRoute(route, method, patcher))
+    .filter(method => typeof route[method.toLowerCase()] === 'function')
+    .forEach(method => patchRoute(route, method.toLowerCase(), patcher))
 
   return route
 }

--- a/lib/probes/koa-router.js
+++ b/lib/probes/koa-router.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const shimmer = require('shimmer')
-const methods = require('methods')
+const http = require('http')
 const semver = require('semver')
-
 const utility = require('../utility')
+
 const ao = require('../')
 const conf = ao.probes['koa-router']
 
@@ -17,8 +17,8 @@ module.exports = function (_router, info) {
     return function () {
       const router = new _router(...arguments)
 
-      methods.concat('del', 'all').forEach(method => {
-        patchAsyncMethod(router, method)
+      http.METHODS.concat('del', 'all').forEach(method => {
+        patchAsyncMethod(router, method.toLowerCase())
       })
       return router
     }
@@ -36,8 +36,8 @@ module.exports = function (_router, info) {
       return router
     }
 
-    methods.concat('del').forEach(method => {
-      patchGeneratorFunction(target, method)
+    http.METHODS.concat('del').forEach(method => {
+      patchGeneratorFunction(target, method.toLowerCase())
     })
     return router
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-yaml": "^0.5.0",
     "glob": "^7.0.3",
-    "methods": "~1.1.0",
     "minimist": "^1.2.3",
     "save-dev": "0.0.1-security",
     "semver": "^7.3.2",


### PR DESCRIPTION
### Overview:

This pull request removes `methods` from dependencies.

`methods` was added as dependency in https://github.com/appoptics/appoptics-apm-node/commit/a04fafd78ea8a8d9e8ef1a6672a634c02b6b35e2

### Status:

Package [does little](https://www.npmjs.com/package/methods) and can be replaced with native `http.METHODS`.

### Notes:
- Pull Request merges into `nh-main`. Agent built from `master` will maintain dependency`.