### PR TITLE
NH-7586-Change-Webserver-KV-to-HTTPMethod

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1403,9 +1403,9 @@ function sendMetrics (metrics, gopts = {}) {
  * packages or by those wishing a higher level of control.
  *
  * @method ao.insertLogObject
- * @param {object} [object] - into which an sw log object containing trace_id, span_id, trace_flages 
+ * @param {object} [object] - into which an sw log object containing trace_id, span_id, trace_flages
  * properties is inserted when conditions are met.
- * 
+ *
  * @returns {object} - the object with the an additional properties, ao, e.g.
  * object.sw === {trace_id:..., span_id: ..., trace_flages: ...}.
  *

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -364,7 +364,7 @@ function patchServer (module, options, protocol) {
           ClientIP: getClientIP(req, conf),
           'HTTP-Host': getHost(req),
           Port: getPort(req),
-          Method: req.method,
+          HTTPMethod: req.method,
           URL: getPath(req),
           Proto: protocol
         }

--- a/test/composite/axios.test.js
+++ b/test/composite/axios.test.js
@@ -104,7 +104,7 @@ describe('composite.axios', function () {
       helper.doChecks(emitter, [
         function (msg) {
           check.server.entry(msg)
-          expect(msg).property('Method', 'GET')
+          expect(msg).property('HTTPMethod', 'GET')
           expect(msg).property('Proto', 'http')
           expect(msg).property('HTTP-Host', 'localhost')
           expect(msg).property('Port', port)

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -167,7 +167,7 @@ describe(`probes.${p}`, function () {
       helper.doChecks(emitter, [
         function (msg) {
           check.server.entry(msg)
-          expect(msg).property('Method', 'GET')
+          expect(msg).property('HTTPMethod', 'GET')
           expect(msg).property('Proto', p)
           expect(msg).property('HTTP-Host', 'localhost')
           expect(msg).property('Port', port)

--- a/test/probes/http-trigger-trace.test.js
+++ b/test/probes/http-trigger-trace.test.js
@@ -376,7 +376,7 @@ describe('probes.http trigger-trace', function () {
       res.end('done')
     })
     server.listen(function () {
-      options = { url: `http://localhost:${server.address().port}` }
+      options = { url: `http://localhost:${server.address().port}/some.html?this=that` }
       p()
       done()
     })
@@ -464,12 +464,12 @@ describe('probes.http trigger-trace', function () {
               expect(msg).not.property(key)
             }
           }
-          // expect(msg).property('Method', 'GET')
-          // expect(msg).property('Proto', 'http')
-          // expect(msg).property('HTTP-Host', 'localhost')
-          // expect(msg).property('Port', port)
-          // expect(msg).property('URL', '/foo?bar=baz')
-          // expect(msg).property('ClientIP')
+          expect(msg).property('HTTPMethod', 'GET')
+          expect(msg).property('Proto', 'http')
+          expect(msg).property('HTTP-Host', 'localhost')
+          expect(msg).property('Port', server.address().port)
+          expect(msg).property('URL', '/some.html?this=that')
+          expect(msg).property('ClientIP')
         },
         function (msg) {
           testdebug('checking exit')


### PR DESCRIPTION
### Overview:
This pull request updates the `http/s` probe(s) so that the key for the HTTP method kv is `HTTPMethod` as preferred by spec.

### Notes:
- Pull Request merges into `nh-main` branch. Agent built from `master` will stay unchanged.
- Minor cleanup alos piggy backing PR.