### PR TITLE
NH-5772-Trace-Context-in-Queries

### DIFF
--- a/lib/probe-defaults.js
+++ b/lib/probe-defaults.js
@@ -11,9 +11,11 @@ module.exports = {
   // NOTE: Disabling backtraces may improve performance, but will make data
   // presented in the dashboard less useful for correlating code locations.
   //
-  // SQL database modules also include a sanitizeSql setting to prevent
-  // potentially sensitive data from being reported to AppOptics.
-  //
+  // SQL database modules also include:
+  //  - a sanitizeSql setting to prevent potentially sensitive data from being
+  //    reported to AppOptics (default: true).
+  //  - a tagSql setting to inject a traceparent value a comment into SQL
+  //    statements sent to database (default: false).
 
   //
   // node-native modules
@@ -78,7 +80,8 @@ module.exports = {
   'cassandra-driver': {
     enabled: true,
     collectBacktraces: true,
-    sanitizeSql: true
+    sanitizeSql: true,
+    tagSql: false
   },
 
   // https://npmjs.org/package/co-render
@@ -157,28 +160,32 @@ module.exports = {
   mysql: {
     enabled: true,
     collectBacktraces: true,
-    sanitizeSql: true
+    sanitizeSql: true,
+    tagSql: false
   },
 
   // https://npmjs.org/package/node-cassandra-cql
   'node-cassandra-cql': {
     enabled: true,
     collectBacktraces: true,
-    sanitizeSql: true
+    sanitizeSql: true,
+    tagSql: false
   },
 
   // https://npmjs.org/package/oracledb
   oracledb: {
     enabled: true,
     collectBacktraces: true,
-    sanitizeSql: true
+    sanitizeSql: true,
+    tagSql: false
   },
 
   // https://npmjs.org/package/pg
   pg: {
     enabled: true,
     collectBacktraces: true,
-    sanitizeSql: true
+    sanitizeSql: true,
+    tagSql: false
   },
 
   // https://npmjs.org/package/raw-body
@@ -203,7 +210,8 @@ module.exports = {
   tedious: {
     enabled: true,
     collectBacktraces: true,
-    sanitizeSql: true
+    sanitizeSql: true,
+    tagSql: false
   },
 
   // https://npmjs.org/package/vision

--- a/lib/probes/mysql.js
+++ b/lib/probes/mysql.js
@@ -2,6 +2,7 @@
 
 const shimmer = require('shimmer')
 const ao = require('..')
+const sqlTraceContext = require('../sql-trace-context')
 
 const conf = ao.probes.mysql
 const logMissing = ao.makeLogMissing('mysql')
@@ -75,7 +76,7 @@ function patchConnection (proto, Query) {
     return
   }
   shimmer.wrap(proto, 'connect', fn => function (...args) {
-    if (ao.lastEvent) {
+    if (ao.tracing) {
       if (args.length) {
         args.push(ao.bind(args.pop()))
       }
@@ -95,6 +96,9 @@ function patchClient (proto, Query) {
 
     const queryStatment = typeof query === 'object' ? query.sql : query
     const queryArgs = typeof values !== 'function' ? values : query.values
+
+    // trace context injection decision
+    const injectSql = conf.enabled && conf.tagSql && ao.tracing && ao.sampling(ao.lastEvent)
 
     /* callback */
     let cb = noop
@@ -137,7 +141,14 @@ function patchClient (proto, Query) {
 
         return {
           name: 'mysql',
-          kvpairs
+          kvpairs,
+          finalize (span) {
+            if (injectSql) {
+              // once we know what the newly created span id is: set it into the QueryTag
+              const tag = sqlTraceContext.tag(span.events.entry.toString())
+              span.events.entry.set({ QueryTag: tag })
+            }
+          }
         }
       },
       done => {
@@ -150,6 +161,12 @@ function patchClient (proto, Query) {
           args.push(done)
         }
 
+        // note: this is an SQL injection
+        if (injectSql) {
+          const tag = sqlTraceContext.tag(ao.traceId)
+          if (typeof query === 'object') { args[0].sql = `${tag} ${queryStatment}` }
+          if (typeof query === 'string') { args[0] = `${tag} ${queryStatment}` }
+        }
         const ret = fn.apply(this, args)
 
         // Event-style

--- a/lib/probes/oracledb.js
+++ b/lib/probes/oracledb.js
@@ -2,6 +2,7 @@
 
 const shimmer = require('shimmer')
 const ao = require('..')
+const sqlTraceContext = require('../sql-trace-context')
 
 const conf = ao.probes.oracledb
 const logMissing = ao.makeLogMissing('oracledb')
@@ -37,7 +38,7 @@ function patchCreatePool (proto, oracledb) {
     // args[0] is a connection object
     // args[1] the query. it is optional.
     // if not provided there will be no instrumentation
-    if (ao.lastEvent && typeof args[1] === 'function') {
+    if (ao.tracing && typeof args[1] === 'function') {
       // Retain continuation, if we are in one
       const cb = ao.bind(args.pop())
 
@@ -79,7 +80,7 @@ function patchGetConnection (proto, oracledb, options) {
     // args[0] is a connection object
     // args[1] the query. it is optional.
     // if not provided there will be no instrumentation
-    if (ao.lastEvent && typeof args[1] === 'function') {
+    if (ao.tracing && typeof args[1] === 'function') {
       // Retain continuation, if we are in one
       const cb = ao.bind(args.pop())
 
@@ -136,6 +137,9 @@ function patchMethod (conn, method, oracledb, options) {
     /* query and arguments */
     const [queryStatment, queryArgs] = args
 
+    // trace context injection decision
+    const injectSql = conf.enabled && conf.tagSql && ao.tracing && ao.sampling(ao.lastEvent)
+
     /* callback */
     const cb = args.pop()
 
@@ -174,10 +178,23 @@ function patchMethod (conn, method, oracledb, options) {
 
         return {
           name: 'oracle',
-          kvpairs
+          kvpairs,
+          finalize (span) {
+            if (injectSql) {
+              // once we know what the newly created span id is: set it into the QueryTag
+              const tag = sqlTraceContext.tag(span.events.entry.toString())
+              span.events.entry.set({ QueryTag: tag })
+            }
+          }
         }
       },
       done => {
+        // note: this is an SQL injection
+        if (injectSql) {
+          const tag = sqlTraceContext.tag(ao.traceId)
+          args[0] = `${tag} ${queryStatment}`
+        }
+
         fn.apply(this, args.concat(done))
       },
       conf,

--- a/lib/probes/pg.js
+++ b/lib/probes/pg.js
@@ -2,6 +2,7 @@
 
 const shimmer = require('shimmer')
 const ao = require('..')
+const sqlTraceContext = require('../sql-trace-context')
 
 const conf = ao.probes.pg
 const logMissing = ao.makeLogMissing('pg')
@@ -57,7 +58,7 @@ function patchPool (postgres) {
     if (typeof p.connect === 'function') {
       const maybeBind = fn => ao.lastEvent ? ao.bind(fn) : fn
       shimmer.wrap(p, 'connect', connect => maybeBind(function (...args) {
-        if (ao.lastEvent && typeof args[0] === 'function') {
+        if (ao.tracing && typeof args[0] === 'function') {
           args[0] = ao.bind(args[0])
         }
         return connect.apply(this, args)
@@ -82,7 +83,7 @@ function patchClientConnect (client) {
 
   shimmer.wrap(client, fn, connect => function (...args) {
     // if context is present and there is a callback bind it
-    if (ao.lastEvent && typeof args[0] === 'function') {
+    if (ao.tracing && typeof args[0] === 'function') {
       args.push(ao.bind(args.pop()))
     }
     return connect.apply(this, args)
@@ -98,6 +99,11 @@ function patchClientQuery (client) {
     /* query and arguments */
     const [query, queryArgs] = args
     const queryStatment = typeof query === 'object' ? getPreparedStatement(this, query) : query
+
+    // trace context injection decision
+    // when type is object - it is a prepared statement
+    // do not inject into prepared statements
+    const injectSql = conf.enabled && conf.tagSql && ao.tracing && ao.sampling(ao.lastEvent) && typeof query === 'string'
 
     /* callback */
     const cb = getCallback(args)
@@ -135,12 +141,25 @@ function patchClientQuery (client) {
 
         return {
           name: 'postgres',
-          kvpairs
+          kvpairs,
+          finalize (span) {
+            if (injectSql) {
+              // once we know what the newly created span id is: set it into the QueryTag
+              const tag = sqlTraceContext.tag(span.events.entry.toString())
+              span.events.entry.set({ QueryTag: tag })
+            }
+          }
         }
       },
       done => {
         if (cb) {
           setCallback(args, done)
+        }
+
+        // note: this is an SQL injection
+        if (injectSql) {
+          const tag = sqlTraceContext.tag(ao.traceId)
+          args[0] = `${tag} ${queryStatment}`
         }
 
         const ret = fn.apply(this, args)

--- a/lib/probes/tedious.js
+++ b/lib/probes/tedious.js
@@ -2,6 +2,7 @@
 
 const shimmer = require('shimmer')
 const ao = require('..')
+const sqlTraceContext = require('../sql-trace-context')
 
 const conf = ao.probes.tedious
 const logMissing = ao.makeLogMissing('tedious')
@@ -40,7 +41,7 @@ function patchDefaultConfig (connection) {
   }
 
   shimmer.wrap(connection, f, fn => function () {
-    if (ao.lastEvent) {
+    if (ao.tracing) {
       ao.bindEmitter(this)
     }
     return fn.apply(this, arguments)
@@ -59,6 +60,9 @@ function patchMakeRequest (connection) {
     // api changed at that specific version...
     const queryStatment = semver.gte(version, '11.0.10') ? request.sqlTextOrProcedure : request.parametersByName.statement.value
     const queryArgs = getQueryArgs(semver.gte(version, '11.0.10') ? request.parameters : request.originalParameters)
+
+    // trace context injection decision
+    const injectSql = conf.enabled && conf.tagSql && ao.tracing && ao.sampling(ao.lastEvent)
 
     /* callback */
     const cb = request.userCallback
@@ -96,10 +100,23 @@ function patchMakeRequest (connection) {
 
         return {
           name: 'mssql',
-          kvpairs
+          kvpairs,
+          finalize (span) {
+            if (injectSql) {
+              // once we know what the newly created span id is: set it into the QueryTag
+              const tag = sqlTraceContext.tag(span.events.entry.toString())
+              span.events.entry.set({ QueryTag: tag })
+            }
+          }
         }
       },
       done => {
+        // note: this is an SQL injection
+        if (injectSql) {
+          const tag = sqlTraceContext.tag(ao.traceId)
+          args[0].sqlTextOrProcedure = `${tag} ${queryStatment}`
+        }
+
         args[0].userCallback = done
 
         return fn.apply(this, args)

--- a/lib/sql-trace-context.js
+++ b/lib/sql-trace-context.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/* validation */
+
+const validTraceparent = (traceparent) => {
+  if (typeof traceparent !== 'string') return ''
+
+  // https://www.w3.org/TR/trace-context/
+  const regExp = /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/
+  const matches = regExp.exec(traceparent)
+
+  return matches
+}
+
+/* exportable */
+
+const tag = (traceparent) => {
+  return validTraceparent(traceparent) ? `/* traceparent='${traceparent}' */` : ''
+}
+
+module.exports = {
+  tag
+}

--- a/lib/sql-trace-context.js
+++ b/lib/sql-trace-context.js
@@ -15,7 +15,7 @@ const validTraceparent = (traceparent) => {
 /* exportable */
 
 const tag = (traceparent) => {
-  return validTraceparent(traceparent) ? `/* traceparent='${traceparent}' */` : ''
+  return validTraceparent(traceparent) ? `/*traceparent='${traceparent}'*/` : ''
 }
 
 module.exports = {

--- a/test/probes/mysql.test.js
+++ b/test/probes/mysql.test.js
@@ -375,7 +375,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
     }, [
       function (msg) {
         checks.entry(msg)
-        msg.should.have.property('QueryTag', `/* traceparent='${msg['sw.trace_context']}' */`)
+        msg.should.have.property('QueryTag', `/*traceparent='${msg['sw.trace_context']}'*/`)
         msg.should.have.property('Query', 'SELECT 1')
       },
       function (msg) {

--- a/test/probes/mysql.test.js
+++ b/test/probes/mysql.test.js
@@ -192,6 +192,10 @@ describe(`probes.mysql ${pkg.version}`, function () {
     ao.probes.mysql.sanitizeSql = false
   })
 
+  it('should be configured to not tag SQL by default', function () {
+    ao.probes.mysql.should.have.property('tagSql', false)
+  })
+
   it('should trace a basic query', test_basic)
   it('should trace a query with a value list', test_values)
   it('should trace a query with a value object', test_object)
@@ -200,6 +204,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
   it('should trace a cluster pooled query', test_clustered_pool)
   it('should sanitize a query', test_sanitize)
   it('should truncate long queries', test_long_query)
+  it('should tag queries when feature is enabled', test_tag)
   it('should skip when disabled', test_disabled)
 
   //
@@ -213,6 +218,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
       function (msg) {
         checks.entry(msg)
         msg.should.have.property('Query', 'SELECT 1')
+        msg.should.not.have.property('QueryTag')
       },
       function (msg) {
         checks.exit(msg)
@@ -358,6 +364,26 @@ describe(`probes.mysql ${pkg.version}`, function () {
       }
     ], function (err) {
       done(err)
+    })
+  }
+
+  function test_tag (done) {
+    ao.probes.mysql.tagSql = true
+    helper.test(emitter, function (done) {
+      const query = 'SELECT 1'
+      ctx.mysql.query(query, done)
+    }, [
+      function (msg) {
+        checks.entry(msg)
+        msg.should.have.property('QueryTag', `/* traceparent='${msg['sw.trace_context']}' */`)
+        msg.should.have.property('Query', 'SELECT 1')
+      },
+      function (msg) {
+        checks.exit(msg)
+      }
+    ], () => {
+      ao.probes.mysql.tagSql = false
+      done()
     })
   }
 

--- a/test/probes/oracledb.test.js
+++ b/test/probes/oracledb.test.js
@@ -179,7 +179,7 @@ describe(`probes.oracledb ${pkg.version}`, function () {
     }, [
       function (msg) {
         checks['oracle-entry'](msg)
-        msg.should.have.property('QueryTag', `/* traceparent='${msg['sw.trace_context']}' */`)
+        msg.should.have.property('QueryTag', `/*traceparent='${msg['sw.trace_context']}'*/`)
         msg.should.have.property('Query', 'SELECT 1 FROM DUAL')
       },
       function (msg) {

--- a/test/probes/pg.test.js
+++ b/test/probes/pg.test.js
@@ -44,6 +44,10 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
     ao.probes.pg.sanitizeSql = false
   })
 
+  it('should be configured to not tag SQL by default', function () {
+    ao.probes.pg.should.have.property('tagSql', false)
+  })
+
   //
   // Intercept appoptics messages for analysis
   //

--- a/test/probes/pg/subtests.js
+++ b/test/probes/pg/subtests.js
@@ -227,7 +227,7 @@ module.exports = function (ao, ctx) {
       checks.entry(msg)
       msg.should.have.property('Query', 'SELECT $1::int AS number')
       msg.should.have.property('QueryArgs', '["1"]')
-      msg.should.have.property('QueryTag', `/* traceparent='${msg['sw.trace_context']}' */`)
+      msg.should.have.property('QueryTag', `/*traceparent='${msg['sw.trace_context']}'*/`)
     },
     function (msg) {
       checks.exit(msg)

--- a/test/probes/tedious.test.js
+++ b/test/probes/tedious.test.js
@@ -220,7 +220,7 @@ describe(`probes.tedious ${pkg.version}`, function () {
     }, [
       function (msg) {
         checks['mssql-entry'](msg)
-        msg.should.have.property('QueryTag', `/* traceparent='${msg['sw.trace_context']}' */`)
+        msg.should.have.property('QueryTag', `/*traceparent='${msg['sw.trace_context']}'*/`)
         msg.should.have.property('Query', "select 42, 'hello world'")
       },
       function (msg) {

--- a/test/sql-trace-context.test.js
+++ b/test/sql-trace-context.test.js
@@ -11,7 +11,7 @@ describe('sqlTraceContext', function () {
       const traceparent = baseTraceparent
       const tag = sqlTraceContext.tag(traceparent)
 
-      expect(tag).to.be.equal(`/* traceparent='${traceparent}' */`)
+      expect(tag).to.be.equal(`/*traceparent='${traceparent}'*/`)
     })
   })
 

--- a/test/sql-trace-context.test.js
+++ b/test/sql-trace-context.test.js
@@ -1,0 +1,107 @@
+/* global it, describe */
+'use strict'
+const expect = require('chai').expect
+const sqlTraceContext = require('../lib/sql-trace-context')
+
+const baseTraceparent = '00-0123456789abcdef0123456789abcdef-7a71b110e5e3588d-01'
+
+describe('sqlTraceContext', function () {
+  describe('sqlTraceContext.tag good input', function () {
+    it('should inject when receiving traceparent that is valid', function () {
+      const traceparent = baseTraceparent
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal(`/* traceparent='${traceparent}' */`)
+    })
+  })
+
+  describe('sqlTraceContext.tag bad traceparent input type', function () {
+    it('should return empty string when receiving traceparent that is an empty string', function () {
+      const traceparent = ''
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent that is a number', function () {
+      const traceparent = 42
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent that is an object', function () {
+      const traceparent = { key: 'value' }
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent that is an array', function () {
+      const traceparent = [1, 2, '3']
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent that is null', function () {
+      const traceparent = null
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent that is undefined', function () {
+      const traceparent = undefined
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent that is a Buffer', function () {
+      const traceparent = Buffer.from(baseTraceparent)
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+  })
+
+  describe('sqlTraceContext.tag invalid traceparent input', function () {
+    it('should return empty string when receiving traceparent with appended Bobby Tables', function () {
+      const traceparent = baseTraceparent + 'Robert\'); DROP TABLE students;--'
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent with appended comment closer */', function () {
+      const traceparent = baseTraceparent + '*/'
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent with appended valid chars', function () {
+      const traceparent = baseTraceparent + 'a'
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent with appended missing chars', function () {
+      const traceparent = baseTraceparent.slice(0, -1)
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent with appended space', function () {
+      const traceparent = baseTraceparent + ' '
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent with appended linefeed', function () {
+      const traceparent = baseTraceparent + '\n'
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+    it('should return empty string when receiving traceparent with appended tab', function () {
+      const traceparent = baseTraceparent + '\t'
+      const tag = sqlTraceContext.tag(traceparent)
+
+      expect(tag).to.be.equal('')
+    })
+  })
+})


### PR DESCRIPTION
## Overview 

This pull request adds injection of Trace Context into database queries. The functionality is meant to allow integration with [SolarWinds DPM](https://docs.vividcortex.com/) using [Query Tags](https://docs.vividcortex.com/general-reference/query-tags/). Tags used are similar to those inserted by [sqlcommenter](https://github.com/open-telemetry/opentelemetry-sqlcommenter).

## Implementation

Changes are contained within the `mysql`, `pg`, `oracledb` and `tedious` probes without breaking any API barrier.

### Configuration 

A new configuration value is introduced to each of the probes: `sqlTag`. It defaults to `false`.

### Tagging Decision

For all probes tagging is done when the probe is *registered* and *enabled* and `sqlTag` is set to `true`, we are *tracing* and we are *sampling*.

Additionally, for the `pg` probe only, named prepared statement are not tagged.

### Tag (SQL comment) Creation

A new module, `sql-trace-context` is introduced. It handles creation of an SQL comment string in the desired format.

Module exposes a single method `tag` which accepts a string and returns either a comment which contains a `traceparent` key and a single-quoted value that matches open telemetry [traceparent format](https://www.w3.org/TR/trace-context/), or, if input not valid, an empty string. 

Integration with probes is done via this method.

### Tagging

Comment injection is done by string concatenation at the runner function. The traceparent string is obtained from the api (a global method accessing key on global object), validated using the above module and prepended to the SQL statement provided in the arguments passed to the instrumented function.

### Key Value Pairs

A key `QueryTag` is added. It contains the tag (SQL comment) injected into the SQL. It is generated by a call to the callback function of the Span generating function. Note that `QueryTag` and the injected comment itself are generated by the same mechanism and using the same value but they do not refer to the same string.

## Tests

All [tests pass](https://github.com/appoptics/appoptics-apm-node/runs/5070747451?check_suite_focus=true) for Node versions 14 and 16, 17.

Integration testing is done using a [simple app](https://github.com/appoptics/node-instrumented) that performs CRUD operations on all four dbs.

<img width="1677" alt="Screen Shot 2022-02-04 at 10 01 59 AM" src="https://user-images.githubusercontent.com/891105/152580517-da2407bf-a0a0-47ca-847d-f91f4f549fda.png">

Injection verification testing via query logging is *not* implemented at this time.

## Risk

The instrumentation in the package is based on the [shimmer package](https://www.npmjs.com/package/shimmer) which notes that: *"There are times when it's necessary to monkeypatch default behavior in JavaScript and Node. However, changing the behavior of the runtime on the fly is rarely a good idea ... "*

Given the above, the general approach to instrumentation was to *observe only*. The patched function collects the needed tracing data and then apply the original function to the user supplied arguments *as-provided*.

This feature is a departure from that concept. With this pull request merged, the agent will be **modifying user supplied arguments for mission critical database interactions**.

### Notes:
- Pull Request merges into `nh-main` branch. Agent built from `master` will stay unchanged.