### PR TITLE
NH-8430-Auto-Instrument-Node-DNS

### DIFF
--- a/lib/probe-defaults.js
+++ b/lib/probe-defaults.js
@@ -23,6 +23,11 @@ module.exports = {
     collectBacktraces: true
   },
 
+  dns: {
+    enabled: true,
+    collectBacktraces: true
+  },
+
   fs: {
     enabled: true,
     registered: true, // to completely disable all and any probe functionality change to "false". probe wil not be patched.

--- a/lib/probes/dns.js
+++ b/lib/probes/dns.js
@@ -5,56 +5,6 @@ const ao = require('..')
 const conf = ao.probes.dns
 const log = ao.loggers
 
-function patchAsyncMethod (dns, method) {
-  if (typeof dns[method] === 'function') {
-    shimmer.wrap(dns, method, fn => function (...args) {
-      const cb = args.pop()
-      return ao.instrument(
-        () => {
-          const kvpairs = {
-            Spec: 'dns',
-            Operation: method,
-            Args: args[0] || ''
-          }
-
-          return {
-            name: 'dns',
-            kvpairs
-          }
-        },
-        cb => fn.apply(this, args.concat(cb)),
-        conf,
-        cb
-      )
-    })
-  } else {
-    log.patching('dns.%s not a function', method)
-  }
-}
-
-function patchAsyncMethods (dns) {
-  const methods = [
-    'lookup',
-    'lookupService',
-    'reverse',
-    'resolve',
-    'resolve6',
-    'resolve4',
-    'resolveAny',
-    'resolveCaa',
-    'resolveCname',
-    'resolveMx',
-    'resolveNaptr',
-    'resolveNs',
-    'resolvePtr',
-    'resolveSoa',
-    'resolveSrv',
-    'resolveTxt'
-  ]
-
-  methods.forEach(method => patchAsyncMethod(dns, method))
-}
-
 function patchSyncMethod (dns, method) {
   if (typeof dns[method] === 'function') {
     shimmer.wrap(dns, method, fn => function (...args) {
@@ -90,10 +40,111 @@ function patchSyncMethods (dns) {
   methods.forEach(method => patchSyncMethod(dns, method))
 }
 
+function patchAsyncCallbackMethod (dns, method) {
+  if (typeof dns[method] === 'function') {
+    shimmer.wrap(dns, method, fn => function (...args) {
+      const cb = args.pop()
+      return ao.instrument(
+        () => {
+          const kvpairs = {
+            Spec: 'dns',
+            Operation: method,
+            Flavor: 'callback',
+            Args: args[0] || ''
+          }
+
+          return {
+            name: 'dns',
+            kvpairs
+          }
+        },
+        cb => fn.apply(this, args.concat(cb)),
+        conf,
+        cb
+      )
+    })
+  } else {
+    log.patching('dns.%s not a function', method)
+  }
+}
+
+function patchAsyncCallbackMethods (dns) {
+  const methods = [
+    'lookup',
+    'lookupService',
+    'reverse',
+    'resolve',
+    'resolve6',
+    'resolve4',
+    'resolveAny',
+    'resolveCaa',
+    'resolveCname',
+    'resolveMx',
+    'resolveNaptr',
+    'resolveNs',
+    'resolvePtr',
+    'resolveSoa',
+    'resolveSrv',
+    'resolveTxt'
+  ]
+
+  methods.forEach(method => patchAsyncCallbackMethod(dns, method))
+}
+
+function patchAsyncPromiseMethod (dns, method) {
+  if (typeof dns[method] === 'function') {
+    shimmer.wrap(dns, method, fn => function (...args) {
+      return ao.pInstrument(
+        () => {
+          const kvpairs = {
+            Spec: 'dns',
+            Flavor: 'promise',
+            Operation: method,
+            Args: args[0] || ''
+          }
+
+          return {
+            name: 'dns',
+            kvpairs
+          }
+        },
+        () => fn.apply(this, args),
+        conf
+      )
+    })
+  } else {
+    log.patching('dns.%s not a function', method)
+  }
+}
+
+function patchAsyncPromiseMethods (dns) {
+  const methods = [
+    'lookup',
+    'lookupService',
+    'reverse',
+    'resolve',
+    'resolve6',
+    'resolve4',
+    'resolveAny',
+    'resolveCaa',
+    'resolveCname',
+    'resolveMx',
+    'resolveNaptr',
+    'resolveNs',
+    'resolvePtr',
+    'resolveSoa',
+    'resolveSrv',
+    'resolveTxt'
+  ]
+
+  methods.forEach(method => patchAsyncPromiseMethod(dns, method))
+}
+
 // instrumentation based on https://nodejs.org/api/dns.html
 
 module.exports = function (dns, options) {
+  patchAsyncCallbackMethods(dns)
+  patchAsyncPromiseMethods(dns.promises)
   patchSyncMethods(dns)
-  patchAsyncMethods(dns)
   return dns
 }

--- a/lib/probes/dns.js
+++ b/lib/probes/dns.js
@@ -1,0 +1,99 @@
+'use strict'
+
+const shimmer = require('shimmer')
+const ao = require('..')
+const conf = ao.probes.dns
+const log = ao.loggers
+
+function patchAsyncMethod (dns, method) {
+  if (typeof dns[method] === 'function') {
+    shimmer.wrap(dns, method, fn => function (...args) {
+      const cb = args.pop()
+      return ao.instrument(
+        () => {
+          const kvpairs = {
+            Spec: 'dns',
+            Operation: method,
+            Args: args[0] || ''
+          }
+
+          return {
+            name: 'dns',
+            kvpairs
+          }
+        },
+        cb => fn.apply(this, args.concat(cb)),
+        conf,
+        cb
+      )
+    })
+  } else {
+    log.patching('dns.%s not a function', method)
+  }
+}
+
+function patchAsyncMethods (dns) {
+  const methods = [
+    'lookup',
+    'lookupService',
+    'reverse',
+    'resolve',
+    'resolve6',
+    'resolve4',
+    'resolveAny',
+    'resolveCaa',
+    'resolveCname',
+    'resolveMx',
+    'resolveNaptr',
+    'resolveNs',
+    'resolvePtr',
+    'resolveSoa',
+    'resolveSrv',
+    'resolveTxt'
+  ]
+
+  methods.forEach(method => patchAsyncMethod(dns, method))
+}
+
+function patchSyncMethod (dns, method) {
+  if (typeof dns[method] === 'function') {
+    shimmer.wrap(dns, method, fn => function (...args) {
+      return ao.instrument(
+        () => {
+          const kvpairs = {
+            Spec: 'dns',
+            Operation: method,
+            Args: JSON.stringify(args[0]) || ''
+          }
+
+          return {
+            name: 'dns',
+            kvpairs
+          }
+        },
+        () => fn.apply(this, args),
+        conf
+      )
+    })
+  } else {
+    log.patching('dns.%s not a function', method)
+  }
+}
+
+function patchSyncMethods (dns) {
+  const methods = [
+    'getServers',
+    'setDefaultResultOrder',
+    'setServers'
+  ]
+
+  methods.forEach(method => patchSyncMethod(dns, method))
+}
+
+// instrumentation based on https://nodejs.org/api/dns.html
+
+module.exports = function (dns, options) {
+  patchSyncMethods(dns)
+  patchAsyncMethods(dns)
+  return dns
+}

--- a/lib/probes/dns.js
+++ b/lib/probes/dns.js
@@ -13,7 +13,7 @@ function patchSyncMethod (dns, method) {
           const kvpairs = {
             Spec: 'dns',
             Operation: method,
-            Args: JSON.stringify(args[0]) || ''
+            Args: args.join(', ')
           }
 
           return {
@@ -50,7 +50,7 @@ function patchAsyncCallbackMethod (dns, method) {
             Spec: 'dns',
             Operation: method,
             Flavor: 'callback',
-            Args: args[0] || ''
+            Args: args.join(', ')
           }
 
           return {
@@ -68,7 +68,33 @@ function patchAsyncCallbackMethod (dns, method) {
   }
 }
 
-function patchAsyncCallbackMethods (dns) {
+function patchAsyncPromiseMethod (dns, method) {
+  if (typeof dns[method] === 'function') {
+    shimmer.wrap(dns, method, fn => function (...args) {
+      return ao.pInstrument(
+        () => {
+          const kvpairs = {
+            Spec: 'dns',
+            Flavor: 'promise',
+            Operation: method,
+            Args: args.join(', ')
+          }
+
+          return {
+            name: 'dns',
+            kvpairs
+          }
+        },
+        () => fn.apply(this, args),
+        conf
+      )
+    })
+  } else {
+    log.patching('dns.%s not a function', method)
+  }
+}
+
+function patchAsyncMethods (dns) {
   const methods = [
     'lookup',
     'lookupService',
@@ -89,62 +115,13 @@ function patchAsyncCallbackMethods (dns) {
   ]
 
   methods.forEach(method => patchAsyncCallbackMethod(dns, method))
-}
-
-function patchAsyncPromiseMethod (dns, method) {
-  if (typeof dns[method] === 'function') {
-    shimmer.wrap(dns, method, fn => function (...args) {
-      return ao.pInstrument(
-        () => {
-          const kvpairs = {
-            Spec: 'dns',
-            Flavor: 'promise',
-            Operation: method,
-            Args: args[0] || ''
-          }
-
-          return {
-            name: 'dns',
-            kvpairs
-          }
-        },
-        () => fn.apply(this, args),
-        conf
-      )
-    })
-  } else {
-    log.patching('dns.%s not a function', method)
-  }
-}
-
-function patchAsyncPromiseMethods (dns) {
-  const methods = [
-    'lookup',
-    'lookupService',
-    'reverse',
-    'resolve',
-    'resolve6',
-    'resolve4',
-    'resolveAny',
-    'resolveCaa',
-    'resolveCname',
-    'resolveMx',
-    'resolveNaptr',
-    'resolveNs',
-    'resolvePtr',
-    'resolveSoa',
-    'resolveSrv',
-    'resolveTxt'
-  ]
-
-  methods.forEach(method => patchAsyncPromiseMethod(dns, method))
+  methods.forEach(method => patchAsyncPromiseMethod(dns.promises, method))
 }
 
 // instrumentation based on https://nodejs.org/api/dns.html
 
 module.exports = function (dns, options) {
-  patchAsyncCallbackMethods(dns)
-  patchAsyncPromiseMethods(dns.promises)
+  patchAsyncMethods(dns)
   patchSyncMethods(dns)
   return dns
 }

--- a/test/probes/dns.test.js
+++ b/test/probes/dns.test.js
@@ -90,6 +90,7 @@ describe('probes.dns', function () {
           checks.entry(msg)
           msg.should.have.property('Operation', 'lookup')
           msg.should.have.property('Flavor', 'callback')
+          msg.should.have.property('Args', `${tld}`)
         },
         function (msg) {
           checks.exit(msg)
@@ -109,6 +110,7 @@ describe('probes.dns', function () {
           checks.entry(msg)
           msg.should.have.property('Operation', 'lookupService')
           msg.should.have.property('Flavor', 'callback')
+          msg.should.have.property('Args', '127.0.0.1, 22')
         },
         function (msg) {
           checks.exit(msg)
@@ -128,6 +130,7 @@ describe('probes.dns', function () {
           checks.entry(msg)
           msg.should.have.property('Operation', 'reverse')
           msg.should.have.property('Flavor', 'callback')
+          msg.should.have.property('Args', '8.8.8.8')
         },
         function (msg) {
           checks.exit(msg)
@@ -172,6 +175,7 @@ describe('probes.dns', function () {
           checks.entry(msg)
           msg.should.have.property('Operation', 'lookup')
           msg.should.have.property('Flavor', 'promise')
+          msg.should.have.property('Args', `${tld}`)
         },
         function (msg) {
           checks.exit(msg)
@@ -191,6 +195,7 @@ describe('probes.dns', function () {
           checks.entry(msg)
           msg.should.have.property('Operation', 'lookupService')
           msg.should.have.property('Flavor', 'promise')
+          msg.should.have.property('Args', '127.0.0.1, 22')
         },
         function (msg) {
           checks.exit(msg)
@@ -210,6 +215,7 @@ describe('probes.dns', function () {
           checks.entry(msg)
           msg.should.have.property('Operation', 'reverse')
           msg.should.have.property('Flavor', 'promise')
+          msg.should.have.property('Args', '8.8.8.8')
         },
         function (msg) {
           checks.exit(msg)
@@ -252,6 +258,7 @@ describe('probes.dns', function () {
         function (msg) {
           checks.entry(msg)
           msg.should.have.property('Operation', 'getServers')
+          msg.should.have.property('Args', '')
         },
         function (msg) {
           checks.exit(msg)
@@ -269,6 +276,7 @@ describe('probes.dns', function () {
         function (msg) {
           checks.entry(msg)
           msg.should.have.property('Operation', 'setDefaultResultOrder')
+          msg.should.have.property('Args', 'verbatim')
         },
         function (msg) {
           checks.exit(msg)
@@ -285,15 +293,18 @@ describe('probes.dns', function () {
         helper.test(emitter, function (done) {
           try {
             dns.setServers([
-              '8.8.8.8'
+              '4.4.4.4',
+              '2001:4860:4860::8888',
+              '4.4.4.4:1053',
+              '[2001:4860:4860::8888]:1053'
             ])
-
             done()
           } catch (e) {}
         }, [
           function (msg) {
             checks.entry(msg)
             msg.should.have.property('Operation', 'setServers')
+            msg.should.have.property('Args', '4.4.4.4,2001:4860:4860::8888,4.4.4.4:1053,[2001:4860:4860::8888]:1053')
           },
           function (msg) {
             checks.exit(msg)

--- a/test/probes/dns.test.js
+++ b/test/probes/dns.test.js
@@ -5,7 +5,6 @@ const helper = require('../helper')
 const { ao } = require('../1.test-common')
 
 const dns = require('dns')
-const dnsPromises = require('dns').promises
 
 describe('probes.dns', function () {
   let emitter
@@ -165,7 +164,7 @@ describe('probes.dns', function () {
   describe('async promise methods', function () {
     it('should support promise lookup', function (done) {
       helper.test(emitter, function (done) {
-        dnsPromises.lookup(tld).then((result) => {
+        dns.promises.lookup(tld).then((result) => {
           done()
         }).catch(e => {
           done()
@@ -185,7 +184,7 @@ describe('probes.dns', function () {
 
     it('should support promise lookupService', function (done) {
       helper.test(emitter, function (done) {
-        dnsPromises.lookupService('127.0.0.1', 22).then((result) => {
+        dns.promises.lookupService('127.0.0.1', 22).then((result) => {
           done()
         }).catch(e => {
           done()
@@ -205,7 +204,7 @@ describe('probes.dns', function () {
 
     it('should support promise reverse', function (done) {
       helper.test(emitter, function (done) {
-        dnsPromises.reverse('8.8.8.8').then((hostnames) => {
+        dns.promises.reverse('8.8.8.8').then((hostnames) => {
           done()
         }).catch(e => {
           done()
@@ -224,11 +223,11 @@ describe('probes.dns', function () {
     })
 
     resolveMethods.forEach(function (method) {
-      if (!dnsPromises[method]) return
+      if (!dns.promises[method]) return
 
       it('should support promise ' + method, function (done) {
         helper.test(emitter, function (done) {
-          dnsPromises[method](tld).then((addresses) => {
+          dns.promises[method](tld).then((addresses) => {
             done()
           }).catch(e => {
             done()

--- a/test/probes/dns.test.js
+++ b/test/probes/dns.test.js
@@ -1,0 +1,214 @@
+/* global it, describe, before, beforeEach, after */
+'use strict'
+
+const helper = require('../helper')
+const { ao } = require('../1.test-common')
+
+const dns = require('dns')
+
+describe('probes.dns', function () {
+  let emitter
+
+  beforeEach(function (done) {
+    setTimeout(function () {
+      done()
+    }, 100)
+  })
+
+  //
+  // Define some general message checks
+  //
+  const checks = {
+    entry: function (msg) {
+      msg.should.have.property('Layer', 'dns')
+      msg.should.have.property('Label', 'entry')
+    },
+    exit: function (msg) {
+      msg.should.have.property('Layer', 'dns')
+      msg.should.have.property('Label', 'exit')
+    }
+  }
+
+  //
+  // Intercept appoptics messages for analysis
+  //
+  before(function (done) {
+    emitter = helper.appoptics(done)
+    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
+    ao.traceMode = 'always'
+    ao.g.testing(__filename)
+  })
+  after(function (done) {
+    emitter.close(done)
+  })
+
+  // this test exists only to fix a problem with oboe not reporting a UDP
+  // send failure.
+  it('UDP might lose a message', function (done) {
+    helper.test(emitter, function (done) {
+      ao.instrument('fake', function () { })
+      done()
+    }, [
+      function (msg) {
+        msg.should.have.property('Label').oneOf('entry', 'exit')
+        msg.should.have.property('Layer', 'fake')
+      }
+    ], done)
+  })
+
+  //
+  // Define tests
+  //
+  const tld = 'example.com'
+
+  it('should support getServers', function (done) {
+    helper.test(emitter, function (done) {
+      try {
+        dns.getServers()
+        done()
+      } catch (e) {}
+    }, [
+      function (msg) {
+        checks.entry(msg)
+        msg.should.have.property('Operation', 'getServers')
+      },
+      function (msg) {
+        checks.exit(msg)
+      }
+    ], done)
+  })
+
+  it('should support setDefaultResultOrder', function (done) {
+    helper.test(emitter, function (done) {
+      try {
+        dns.setDefaultResultOrder('verbatim')
+        done()
+      } catch (e) {}
+    }, [
+      function (msg) {
+        checks.entry(msg)
+        msg.should.have.property('Operation', 'setDefaultResultOrder')
+      },
+      function (msg) {
+        checks.exit(msg)
+      }
+    ], done)
+  })
+
+  it('should support lookup', function (done) {
+    helper.test(emitter, function (done) {
+      try {
+        dns.lookup(tld, (err, address, family) => {
+          done()
+        })
+      } catch (e) {}
+    }, [
+      function (msg) {
+        checks.entry(msg)
+        msg.should.have.property('Operation', 'lookup')
+      },
+      function (msg) {
+        checks.exit(msg)
+      }
+    ], done)
+  })
+
+  it('should support lookupService', function (done) {
+    helper.test(emitter, function (done) {
+      try {
+        dns.lookupService('127.0.0.1', 22, (err, hostname, service) => {
+          done()
+        })
+      } catch (e) {}
+    }, [
+      function (msg) {
+        checks.entry(msg)
+        msg.should.have.property('Operation', 'lookupService')
+      },
+      function (msg) {
+        checks.exit(msg)
+      }
+    ], done)
+  })
+
+  it('should support reverse', function (done) {
+    helper.test(emitter, function (done) {
+      try {
+        dns.reverse('8.8.8.8', (err, hostnames) => {
+          done()
+        })
+      } catch (e) {}
+    }, [
+      function (msg) {
+        checks.entry(msg)
+        msg.should.have.property('Operation', 'reverse')
+      },
+      function (msg) {
+        checks.exit(msg)
+      }
+    ], done)
+  })
+
+  const resolveMethods = [
+    'resolve',
+    'resolve6',
+    'resolve4',
+    'resolveAny',
+    'resolveCaa',
+    'resolveCname',
+    'resolveMx',
+    // 'resolveNaptr', // does not return
+    'resolveNs',
+    // 'resolvePtr', // does not return
+    'resolveSoa',
+    'resolveSrv',
+    'resolveTxt'
+  ]
+
+  resolveMethods.forEach(function (method) {
+    if (!dns[method]) return
+
+    it('should support ' + method, function (done) {
+      helper.test(emitter, function (done) {
+        try {
+          dns[method](tld, (err, addresses) => {
+            done()
+          })
+        } catch (e) {}
+      }, [
+        function (msg) {
+          checks.entry(msg)
+          msg.should.have.property('Operation', method)
+        },
+        function (msg) {
+          checks.exit(msg)
+        }
+      ], done)
+    })
+  })
+
+  it('should support setServers', function (done) {
+    // The dns.setServers() method must not be called while a DNS query is in progress.
+    // The dns.setServers() method affects only dns.resolve(), dns.resolve*() and dns.reverse() (and specifically not dns.lookup()).
+    // hence the test helper is encapsulated inside the dns call.
+    dns.resolve(tld, (err, addresses) => {
+      helper.test(emitter, function (done) {
+        try {
+          dns.setServers([
+            '8.8.8.8'
+          ])
+
+          done()
+        } catch (e) {}
+      }, [
+        function (msg) {
+          checks.entry(msg)
+          msg.should.have.property('Operation', 'setServers')
+        },
+        function (msg) {
+          checks.exit(msg)
+        }
+      ], done)
+    })
+  })
+})

--- a/test/probes/mongoose.test.js
+++ b/test/probes/mongoose.test.js
@@ -60,6 +60,7 @@ describe(`probes/mongoose ${pkg.version} using ${moduleName}`, function () {
     // and don't let file IO complicate the results
     fsenabled = ao.probes.fs.enabled
     ao.probes.fs.enabled = false
+    ao.probes.dns.enabled = false
   })
   after(function (done) {
     ao.probes.fs.enabled = fsenabled

--- a/test/probes/pg.test.js
+++ b/test/probes/pg.test.js
@@ -57,6 +57,7 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
     ao.probes.fs.enabled = false
+    ao.probes.dns.enabled = false
   })
   after(function (done) {
     emitter.close(done)

--- a/test/probes/tedious.test.js
+++ b/test/probes/tedious.test.js
@@ -31,14 +31,14 @@ describe(`probes.tedious ${pkg.version}`, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.probes.fs.enabled = false
     emitter = helper.appoptics(done)
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
     ao.g.testing(__filename)
+    ao.probes.fs.enabled = false
+    ao.probes.dns.enabled = false
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
     emitter.close(done)
   })
 


### PR DESCRIPTION
## Overview 

This pull request adds auto instrumentation of Node's native [`DNS` module](https://nodejs.org/api/dns.html) to the agent.

## Implementation

A new probe named `dns` has been added. Instrumentation covers both the standard [callback api](https://nodejs.org/api/dns.html#dns) as well the [promise api](https://nodejs.org/api/dns.html#dns-promises-api).

### Configuration 

Probe has basic configuration values that are set in a manner similar to all other probes.

 ```enabled: true```
 ```collectBacktraces: true```

### Key Value Pairs

The following KVs are reported.

`Spec` - string, required - **dns**
`Operation` - string, required - name of operation being performed.
`Args` - string, required - arguments passed to the operation.
`Flavor` - string, optional - the API used. Options are `callback` or `promise`. Not added for synchronous operations. 

[Spec](https://github.com/librato/trace/tree/master/docs/specs/KV) will be updated after this pull request is merged.

### Tests

Tests added for probe.

As side-effect of instrumenting dns operations, some tests had to be modified as to explicitly disable the dns probe so that additional spans are not created during test run (see: 8eb333211cdf95256cbe4cdfb6080cd83fbcc43e).

All [tests pass](https://github.com/appoptics/appoptics-apm-node/actions/runs/1854549082).

Integration testing is done using a [simple app](https://github.com/appoptics/node-instrumented/tree/main/dns) that performs all module functions.

<img width="802" alt="Screen Shot 2022-02-16 at 9 30 18 AM" src="https://user-images.githubusercontent.com/891105/154331004-6360f587-e17e-4962-ba6b-6ffbd069d262.png">
<img width="803" alt="Screen Shot 2022-02-16 at 9 32 20 AM" src="https://user-images.githubusercontent.com/891105/154331018-347d6c07-a2b9-4674-bd73-0939034c678f.png">

<img width="803" alt="Screen Shot 2022-02-16 at 9 33 50 AM" src="https://user-images.githubusercontent.com/891105/154331068-0fbbabcd-3a50-4119-96ae-7323285e70d2.png">

<img width="837" alt="Screen Shot 2022-02-16 at 10 20 36 AM" src="https://user-images.githubusercontent.com/891105/154331076-1021e12d-1796-44bb-a835-98cbf1bca765.png">

### Notes:
- Pull Request merges into `nh-main` branch. Agent built from `master` will stay unchanged.
