### PR TITLE
NH-8801-Auto-Instrument-Node-fs.promises-Interface

### DIFF
--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -63,6 +63,9 @@ function patchFdMethods (fs) {
 }
 
 function patchFdMethod (fs, method) {
+  // note these methods are not exposed by the promise interface.
+  // thus - no instrumentation of promises.
+
   if (typeof fs[method] === 'function') {
     shimmer.wrap(fs, method, fn => function (...args) {
       const cb = args.pop()
@@ -164,6 +167,48 @@ function patchPathMethod (fs, method) {
     log.patching('fs.%s not a function', method)
   }
 
+  if (typeof fs.promises[method] === 'function') {
+    shimmer.wrap(fs.promises, method, fn => {
+      const f = function (...args) {
+        let span
+        return ao.pInstrument(
+          () => {
+            return {
+              name: 'fs',
+              kvpairs: {
+                Spec: 'filesystem',
+                Operation: method,
+                FilePath: args[0]
+              },
+              finalize (createdSpan) {
+                span = createdSpan
+                if (conf.ignoreErrors && method in conf.ignoreErrors) {
+                  span.setIgnoreErrorFn(function (err) {
+                    // if looking at operation and/or path in the future:
+                    // span.events.entry.kv.Operation === 'open' ditto.FilePath
+                    return err.code in conf.ignoreErrors[method]
+                  })
+                }
+              }
+            }
+          },
+          () => fn.apply(this, args).then((fileHandle) => { // only when resolves successfully (no error)
+            if (span && method === 'open') {
+              span.events.exit.set({ FileDescriptor: fileHandle.fd })
+            }
+          }),
+          conf
+        )
+      }
+      if (method === 'realpath') {
+        f.native = fn.native
+      }
+      return f
+    })
+  } else {
+    log.patching('fsPromises.%s not a function', method)
+  }
+
   const syncMethod = method + 'Sync'
   if (typeof fs[syncMethod] === 'function') {
     shimmer.wrap(fs, syncMethod, fn => {
@@ -240,6 +285,28 @@ function patchLinkMethod (fs, method) {
     })
   } else {
     log.patching('fs.%s not a function', method)
+  }
+
+  if (typeof fs.promises[method] === 'function') {
+    shimmer.wrap(fs.promises, method, fn => function (...args) {
+      return ao.pInstrument(
+        () => {
+          return {
+            name: 'fs',
+            kvpairs: {
+              Spec: 'filesystem',
+              Operation: method,
+              FilePath: args[0],
+              NewFilePath: args[1]
+            }
+          }
+        },
+        () => fn.apply(this, args),
+        conf
+      )
+    })
+  } else {
+    log.patching('fsPromises.%s not a function', method)
   }
 
   const syncMethod = method + 'Sync'

--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -26,6 +26,11 @@ function fdSpan (method, fd) {
       FileDescriptor: fd
     }
 
+    // fd methods are not exposed by the promise interface
+    if (method.indexOf('Sync') === -1) {
+      kvpairs.Flavor = 'callback'
+    }
+
     return {
       name: 'fs',
       kvpairs,
@@ -133,7 +138,8 @@ function patchPathMethod (fs, method) {
               kvpairs: {
                 Spec: 'filesystem',
                 Operation: method,
-                FilePath: args[0]
+                FilePath: args[0],
+                Flavor: 'callback'
               },
               finalize (createdSpan) {
                 span = createdSpan
@@ -178,7 +184,8 @@ function patchPathMethod (fs, method) {
               kvpairs: {
                 Spec: 'filesystem',
                 Operation: method,
-                FilePath: args[0]
+                FilePath: args[0],
+                Flavor: 'promise'
               },
               finalize (createdSpan) {
                 span = createdSpan
@@ -274,7 +281,8 @@ function patchLinkMethod (fs, method) {
               Spec: 'filesystem',
               Operation: method,
               FilePath: args[0],
-              NewFilePath: args[1]
+              NewFilePath: args[1],
+              Flavor: 'callback'
             }
           }
         },
@@ -297,7 +305,8 @@ function patchLinkMethod (fs, method) {
               Spec: 'filesystem',
               Operation: method,
               FilePath: args[0],
-              NewFilePath: args[1]
+              NewFilePath: args[1],
+              Flavor: 'promise'
             }
           }
         },

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -369,6 +369,7 @@ describe('probes.fs', function () {
           function (msg) {
             checks.entry(msg)
             expect(msg).property('Operation', call.name)
+            expect(msg).property('Flavor', 'promise')
             if (call.type === 'path') {
               expect(msg).property('FilePath', args[0])
             } else if (call.type === 'fd') {
@@ -426,6 +427,7 @@ describe('probes.fs', function () {
           function (msg) {
             checks.entry(msg)
             expect(msg).property('Operation', call.name)
+            expect(msg).property('Flavor', 'callback')
             if (call.type === 'path') {
               expect(msg).property('FilePath', args[0])
             } else if (call.type === 'fd') {
@@ -492,6 +494,7 @@ describe('probes.fs', function () {
           function (msg) {
             checks.entry(msg)
             expect(msg).property('Operation', name)
+            expect(msg).to.not.have.property('Flavor')
             switch (call.type) {
               case 'path':
                 expect(msg).property('FilePath', args[0])


### PR DESCRIPTION
## Overview 

This pull request adds auto instrumentation to the [promise interface](https://nodejs.org/api/fs.html#promises-api) of Node's native [`fs` module](https://nodejs.org/api/fs.html).

## Implementation

Instrumentation covering the promise api was added to existing probe. 
### Key Value Pairs

A kv pair was added for async operations:

- `Flavor` - string, optional - the API used. Options are `callback` or `promise`. Not added for synchronous operations. 

[Spec](https://github.com/librato/trace/tree/master/docs/specs/KV) will be updated after this pull request is merged.

### Notes
 - The Promise API exposes a smaller set of methods when compared to the Callback and Sync APIs and thus instrumentation for promises is less extensive.
 - When using Sync and Callback API's some operations generate sub spans. For example `appendFileSync` will result in four additional sub spans: `writeFileSync`, `openSync`, `writeSync`, `closeSync`. The promise API instrumentation will only generate the operation span without sub spans.
 
## Tests

Tests added for newly instrumented methods. The tests suite was refactored (a little) to (mildly) simplify test setup.

All [tests pass](https://github.com/appoptics/appoptics-apm-node/actions/runs/1867856782) for Node versions 14 and 16, 17.

Integration testing is done using a [simple app](https://github.com/appoptics/node-instrumented/tree/main/fs) that performs all promise functions (as well callbacks and sync).

<img width="809" alt="Screen Shot 2022-02-18 at 9 01 15 PM" src="https://user-images.githubusercontent.com/891105/154786963-12c57598-943c-4f54-8cae-23eb230ec329.png">

<img width="834" alt="Screen Shot 2022-02-18 at 9 01 31 PM" src="https://user-images.githubusercontent.com/891105/154786979-a28f4ec6-3e2c-4e2f-9ce4-d66297d23171.png">

Trace: https://my-stg.appoptics.com/apm/225844/services/ao-node-test/traces/D77E348CBB8BA91CD37BAC3707BEB69D00000000

### Notes:
- Pull Request merges into `nh-main` branch. Agent built from `master` will stay unchanged.