### PR TITLE
NH-5459-Support-Trace-ID-Insertion-for-log4js

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -54,6 +54,7 @@
     * ~~[.sendMetric(name, [options])](#ao.sendMetric) ⇒ <code>number</code>~~
     * [.sendMetrics(metrics, [gopts])](#ao.sendMetrics) ⇒ [<code>SendMetricsReturn</code>](#SendMetricsReturn)
     * [.insertLogObject([object])](#ao.insertLogObject) ⇒ <code>object</code>
+    * [.getLogString([delimiter])](#ao.getLogString) ⇒ <code>string</code>
     * [.wrapLambdaHandler([handler])](#ao.wrapLambdaHandler) ⇒ <code>function</code>
 
 <a name="ao.logLevel"></a>
@@ -643,6 +644,44 @@ logger.info(ao.insertLogObject({
     message: 'this object is being modified by insertLogObject',
     more: 'there will be an added sw property'
 }))
+```
+<a name="ao.getLogString"></a>
+
+### ao.getLogString([delimiter]) ⇒ <code>string</code>
+Return text delimited representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
+to custom tokens in log packages.
+
+**Kind**: static method of [<code>ao</code>](#ao)  
+**Returns**: <code>string</code> - - the trace log string (e.g. trace_id:... span_id: ..., trace_flages: ...)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [delimiter] | <code>string</code> | the delimiter to use |
+
+**Example**  
+```js
+log4js.configure({
+  appenders: {
+    out: {
+      type: 'stdout',
+      layout: {
+        type: 'pattern',
+        pattern: '%d %p %c %x{user} says: %m is: %x{trace} %n',
+        tokens: {
+          user: function (logEvent) {
+            return 'Jake'
+          },
+          trace: function () {
+            return typeof ao !=='undefined' ? ao.getLogString() : ''
+          }
+        }
+      }
+    }
+  },
+  categories: { default: { appenders: ['out'], level: 'info' } }
+})
+const logger = log4js.getLogger()
+loggerLayout.info('token from api')
 ```
 <a name="ao.wrapLambdaHandler"></a>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -681,7 +681,7 @@ log4js.configure({
   categories: { default: { appenders: ['out'], level: 'info' } }
 })
 const logger = log4js.getLogger()
-loggerLayout.info('token from api')
+logger.info('token from api')
 ```
 <a name="ao.wrapLambdaHandler"></a>
 

--- a/lib/api-sim.js
+++ b/lib/api-sim.js
@@ -74,6 +74,7 @@ module.exports = function (appoptics) {
     sendMetric,
     sendMetrics,
     insertLogObject,
+    getLogString,
 
     // lambda
     wrapLambdaHandler
@@ -721,6 +722,10 @@ function sendMetrics (metrics) {
  */
 function insertLogObject (o = {}) {
   return o
+}
+
+function getLogString () {
+  return ''
 }
 
 function wrapLambdaHandler (fn) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -75,6 +75,7 @@ module.exports = function (appoptics) {
     sendMetric,
     sendMetrics,
     insertLogObject,
+    getLogString,
 
     // lambda
     wrapLambdaHandler // wrap user handler
@@ -1405,7 +1406,7 @@ function sendMetrics (metrics, gopts = {}) {
  * @method ao.insertLogObject
  * @param {object} [object] - into which an sw log object containing trace_id, span_id, trace_flags
  * properties is inserted when conditions are met.
- * 
+ *
  * @returns {object} - the object with the an additional properties, ao, e.g.
  * object.sw === {trace_id:..., span_id: ..., trace_flages: ...}.
  *
@@ -1457,6 +1458,44 @@ function insertLogObject (o = {}) {
     }
   }
   return o
+}
+
+/**
+ * Return text delimited representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
+ * to custom tokens in log packages.
+ *
+ * @method ao.getLogString
+ * @param {string} [delimiter] - the delimiter to use
+ *
+ * @returns {string} - the trace log string (e.g. trace_id:... span_id: ..., trace_flages: ...)
+ *
+ * @example
+ * log4js.configure({
+ *   appenders: {
+ *     out: {
+ *       type: 'stdout',
+ *       layout: {
+ *         type: 'pattern',
+ *         pattern: '%d %p %c %x{user} says: %m is: %x{trace} %n',
+ *         tokens: {
+ *           user: function (logEvent) {
+ *             return 'Jake'
+ *           },
+ *           trace: function () {
+ *             return typeof ao !=='undefined' ? ao.getLogString() : ''
+ *           }
+ *         }
+ *       }
+ *     }
+ *   },
+ *   categories: { default: { appenders: ['out'], level: 'info' } }
+ * })
+ * const logger = log4js.getLogger()
+ * loggerLayout.info('token from api')
+ */
+function getLogString (delimiter = ' ') {
+  const obj = ao.insertLogObject()
+  return obj.sw ? Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(delimiter) : ''
 }
 
 /**

--- a/lib/api.js
+++ b/lib/api.js
@@ -1491,7 +1491,7 @@ function insertLogObject (o = {}) {
  *   categories: { default: { appenders: ['out'], level: 'info' } }
  * })
  * const logger = log4js.getLogger()
- * loggerLayout.info('token from api')
+ * logger.info('token from api')
  */
 function getLogString (delimiter = ' ') {
   const obj = ao.insertLogObject()

--- a/lib/probe-defaults.js
+++ b/lib/probe-defaults.js
@@ -249,6 +249,7 @@ module.exports = {
   // later.
   //
   bunyan: { enabled: true },
+  log4js: { enabled: true },
   morgan: { enabled: true },
   pino: { enabled: true },
   winston: { enabled: true }

--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const ao = require('..')
+const shimmer = require('shimmer')
+
+const logMissing = ao.makeLogMissing('log4js')
+
+function patchLevel (level) {
+  return function LogWithLogObject (msg) {
+    const obj = ao.insertLogObject()
+    if(typeof msg === 'string') {
+      arguments[0] = `${msg} ${Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(' ') }`
+    } else {
+      arguments[0] = {...obj, msg}
+    }
+    return level.apply(this, arguments)
+  }
+}
+
+module.exports = function (log4js, info) {
+  if (!ao.probes.log4js.enabled) {
+    return log4js
+  }
+
+  // getLogger is called on a configured log4js object
+  // wrap the logger instantiation function to get the correct configuration.
+  shimmer.wrap(log4js, 'getLogger' ,function (original) {
+    return function () {
+      // create an instance
+      const instance = original.apply(this, arguments)
+
+      // extract the defined levels (including custom ones) and patch each
+      Object.values(log4js.levels.levels)
+        .map(item => item.levelStr.toLowerCase())
+        .forEach(level => {
+          shimmer.wrap(instance, level, patchLevel)
+        })
+
+      return instance
+    }
+  })
+
+  return log4js
+}

--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -11,11 +11,19 @@ function patchLevel (level) {
     // when no insertion is needed (or possible) returned obj will not have sw key
 
     // the result is log4js layout output as string (see https://log4js-node.github.io/log4js-node/layouts.html)
-    // passThrough (second argument) is appended to msg (first argument) using a space
-    // we assume that both are strings and treat them as such.
-    // if they are not - we do not insert
-    if (obj.sw && typeof msg === 'string' && typeof passThrough === 'string') {
-      arguments[1] = `${passThrough} ${Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(' ')}`
+    // if it is supplied passThrough (second argument) is appended to msg (first argument) using a space
+
+    // we assume that msg is a string else we do not insert trace data.
+    if (obj.sw && typeof msg === 'string') {
+      const str = Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(' ')
+
+      // when passThrough exist append trace data to it so that it does not "break" message
+      // when there is none - append to original message
+      if (typeof passThrough === 'string') {
+        arguments[1] = `${passThrough} ${str}`
+      } else {
+        arguments[0] = `${msg} ${str}`
+      }
     }
 
     return level.apply(this, arguments)

--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -5,15 +5,16 @@ const shimmer = require('shimmer')
 
 const logMissing = ao.makeLogMissing('log4.js')
 
-function patchLevel (level) {
-  // the result of this function is a log4js layout output 
+function patchLog (log) {
+  // the result of this function is a log4js layout output
   // which is always a string (see https://log4js-node.github.io/log4js-node/layouts.html).
-  // passThrough (second argument) is optional.
+  // first argument received by the log method is the level object which will not be touched.
+  // third argument (passThrough) is optional.
   // when it is supplied, it is appended to msg (first argument) using a space.
-  return function LogWithLogObject (msg, passThrough) {
+  return function LogWithLogObject (_, msg, passThrough) {
     const obj = ao.insertLogObject()
     // when no insertion is needed (or not possible) - returned obj will not have sw key
-    // we also assume that msg is supplied by user as a string 
+    // we also assume that msg is supplied by user as a string
     // else we do not insert trace data.
     if (obj.sw && typeof msg === 'string') {
       const str = Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(' ')
@@ -21,13 +22,13 @@ function patchLevel (level) {
       // when passThrough exist append trace data to it so that it does not "break" message.
       // when there is none - append to original message (arguments[1] is ignored in that case)
       if (typeof passThrough === 'string') {
-        arguments[1] = `${passThrough} ${str}`
+        arguments[2] = `${passThrough} ${str}`
       } else {
-        arguments[0] = `${msg} ${str}`
+        arguments[1] = `${msg} ${str}`
       }
     }
 
-    return level.apply(this, arguments)
+    return log.apply(this, arguments)
   }
 }
 
@@ -45,14 +46,10 @@ module.exports = function (log4js, info) {
         const instance = original.apply(this, arguments)
 
         // logging is done by calling a level function (e.g logger.debug('say something'))
-        // extract the defined levels (including custom ones) and patch each
-        // if none exist (e.g. because package changed) log error.
-        const levels = Object.values(log4js.levels.levels || {})
-        if (levels.length) {
-          levels.map(item => item.levelStr.toLowerCase())
-            .forEach(level => {
-              shimmer.wrap(instance, level, patchLevel)
-            })
+        // which then calls the log function, or alternatively, by directly calling the log function.
+        // patch the lower level log function to cover all cases (including custom levels).
+        if (typeof instance.log === 'function') {
+          shimmer.wrap(instance, 'log', patchLog)
         } else {
           logMissing('levels')
         }

--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -3,16 +3,21 @@
 const ao = require('..')
 const shimmer = require('shimmer')
 
-const logMissing = ao.makeLogMissing('log4js')
+const logMissing = ao.makeLogMissing('log4.js')
 
 function patchLevel (level) {
-  return function LogWithLogObject (msg) {
+  return function LogWithLogObject (msg, passThrough) {
     const obj = ao.insertLogObject()
-    if(typeof msg === 'string') {
-      arguments[0] = `${msg} ${Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(' ') }`
-    } else {
-      arguments[0] = {...obj, msg}
+    // when no insertion is needed (or possible) returned obj will not have sw key
+
+    // the result is log4js layout output as string (see https://log4js-node.github.io/log4js-node/layouts.html)
+    // passThrough (second argument) is appended to msg (first argument) using a space
+    // we assume that both are strings and treat them as such.
+    // if they are not - we do not insert
+    if (obj.sw && typeof msg === 'string' && typeof passThrough === 'string') {
+      arguments[1] = `${passThrough} ${Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(' ')}`
     }
+
     return level.apply(this, arguments)
   }
 }
@@ -22,23 +27,33 @@ module.exports = function (log4js, info) {
     return log4js
   }
 
-  // getLogger is called on a configured log4js object
-  // wrap the logger instantiation function to get the correct configuration.
-  shimmer.wrap(log4js, 'getLogger' ,function (original) {
-    return function () {
-      // create an instance
-      const instance = original.apply(this, arguments)
+  if (typeof log4js.getLogger === 'function') {
+    // getLogger is called on a configured log4js object
+    // wrap the logger instantiation function to get the correct configuration.
+    shimmer.wrap(log4js, 'getLogger', function (original) {
+      return function () {
+        // create an instance
+        const instance = original.apply(this, arguments)
 
-      // extract the defined levels (including custom ones) and patch each
-      Object.values(log4js.levels.levels)
-        .map(item => item.levelStr.toLowerCase())
-        .forEach(level => {
-          shimmer.wrap(instance, level, patchLevel)
-        })
+        // logging is done by calling a level function (e.g logger.debug('say something'))
+        // extract the defined levels (including custom ones) and patch each
+        // if none exist (e.g. because package changed) log error.
+        const levels = Object.values(log4js.levels.levels || {})
+        if (levels.length) {
+          levels.map(item => item.levelStr.toLowerCase())
+            .forEach(level => {
+              shimmer.wrap(instance, level, patchLevel)
+            })
+        } else {
+          logMissing('levels')
+        }
 
-      return instance
-    }
-  })
+        return instance
+      }
+    })
+  } else {
+    logMissing('getLogger()')
+  }
 
   return log4js
 }

--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -6,19 +6,20 @@ const shimmer = require('shimmer')
 const logMissing = ao.makeLogMissing('log4.js')
 
 function patchLevel (level) {
+  // the result of this function is a log4js layout output 
+  // which is always a string (see https://log4js-node.github.io/log4js-node/layouts.html).
+  // passThrough (second argument) is optional.
+  // when it is supplied, it is appended to msg (first argument) using a space.
   return function LogWithLogObject (msg, passThrough) {
     const obj = ao.insertLogObject()
-    // when no insertion is needed (or possible) returned obj will not have sw key
-
-    // the result is log4js layout output as string (see https://log4js-node.github.io/log4js-node/layouts.html)
-    // if it is supplied passThrough (second argument) is appended to msg (first argument) using a space
-
-    // we assume that msg is a string else we do not insert trace data.
+    // when no insertion is needed (or not possible) - returned obj will not have sw key
+    // we also assume that msg is supplied by user as a string 
+    // else we do not insert trace data.
     if (obj.sw && typeof msg === 'string') {
       const str = Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(' ')
 
-      // when passThrough exist append trace data to it so that it does not "break" message
-      // when there is none - append to original message
+      // when passThrough exist append trace data to it so that it does not "break" message.
+      // when there is none - append to original message (arguments[1] is ignored in that case)
       if (typeof passThrough === 'string') {
         arguments[1] = `${passThrough} ${str}`
       } else {

--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -10,17 +10,17 @@ function patchLog (log) {
   // which is always a string (see https://log4js-node.github.io/log4js-node/layouts.html).
   // first argument received by the log method is the level object which will not be touched.
   // third argument (passThrough) is optional.
-  // when it is supplied, it is appended to msg (first argument) using a space.
+  // when it is supplied, it is appended to msg (second argument) using a space.
   return function LogWithLogObject (_, msg, passThrough) {
     const obj = ao.insertLogObject()
-    // when no insertion is needed (or not possible) - returned obj will not have sw key
-    // we also assume that msg is supplied by user as a string
-    // else we do not insert trace data.
+    // when no insertion is needed (or when not possible) the returned obj will not have an sw key
+    // assume that msg is supplied by user as a string
+    // else do not insert trace data.
     if (obj.sw && typeof msg === 'string') {
       const str = Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(' ')
 
-      // when passThrough exist append trace data to it so that it does not "break" message.
-      // when there is none - append to original message (arguments[1] is ignored in that case)
+      // when passThrough exist, append trace data to it so that insertion does not "break" message.
+      // when there is none, append to original message (arguments[2] is ignored in that case)
       if (typeof passThrough === 'string') {
         arguments[2] = `${passThrough} ${str}`
       } else {

--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -12,13 +12,12 @@ function patchLog (log) {
   // third argument (passThrough) is optional.
   // when it is supplied, it is appended to msg (second argument) using a space.
   return function LogWithLogObject (_, msg, passThrough) {
-    const obj = ao.insertLogObject()
-    // when no insertion is needed (or when not possible) the returned obj will not have an sw key
+    const str = ao.getLogString()
+
+    // when no insertion is needed (or when not possible) the returned str will be empty
     // assume that msg is supplied by user as a string
     // else do not insert trace data.
-    if (obj.sw && typeof msg === 'string') {
-      const str = Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(' ')
-
+    if (str && typeof msg === 'string') {
       // when passThrough exist, append trace data to it so that insertion does not "break" message.
       // when there is none, append to original message (arguments[2] is ignored in that case)
       if (typeof passThrough === 'string') {
@@ -37,6 +36,16 @@ module.exports = function (log4js, info) {
     return log4js
   }
 
+  shimmer.wrap(log4js, 'configure', function (original) {
+    return function () {
+      // save the applied configuration on the object so it can be read at instantiation time.
+      // otherwise it is not currently possible to read what config was applied.
+      // side note: can be nice addition to the log4js api.
+      this.configuration = arguments[0]
+      return original.apply(this, arguments)
+    }
+  })
+
   if (typeof log4js.getLogger === 'function') {
     // getLogger is called on a configured log4js object
     // wrap the logger instantiation function to get the correct configuration.
@@ -49,7 +58,19 @@ module.exports = function (log4js, info) {
         // which then calls the log function, or alternatively, by directly calling the log function.
         // patch the lower level log function to cover all cases (including custom levels).
         if (typeof instance.log === 'function') {
-          shimmer.wrap(instance, 'log', patchLog)
+          // when the user is using a pattern in their layout in ANY of their appenders respect their pattern (and skill)
+          // do NOT append the trace to the end of the log message.
+          // (note: inserting for patterns is available using log4js tokens and api method getLogString)
+          const appendTraceToEndOfLog = !Object.values(this.configuration.appenders).find(appender => {
+            return (
+              typeof appender.layout !== 'undefined' &&
+              'basic|colored|messagePassThrough|dummy'.indexOf(appender && appender.layout && appender.layout.type) === -1
+            )
+          })
+
+          if (appendTraceToEndOfLog) {
+            shimmer.wrap(instance, 'log', patchLog)
+          }
         } else {
           logMissing('levels')
         }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "koa-route": "^3.2.0",
     "koa-router": "^10.1.1",
     "level": "^7.0.0",
+    "log4js": "^6.4.2",
     "memcached": "^2.2.2",
     "method-override": "^2.3.10",
     "mkdirp": "^0.5.1",

--- a/test/probes/log4js.test.js
+++ b/test/probes/log4js.test.js
@@ -1,0 +1,297 @@
+/* global it, describe, before, beforeEach, afterEach */
+'use strict'
+
+const ao = require('../..')
+
+const helper = require('../helper')
+const expect = require('chai').expect
+
+const log4js = require('log4js')
+const { version } = require('log4js/package.json')
+
+const { EventEmitter } = require('events')
+
+function checkEventInfo (eventInfo, level, message, traceId) {
+  const reString = 'trace_id=[a-f0-9]{32} span_id=[a-f0-9]{16} trace_flags=0(0|1)'
+  const re = new RegExp(reString)
+  const m = eventInfo.match(re)
+
+  if (traceId) {
+    const parts = traceId.split('-')
+    expect(m[0]).equal(`trace_id=${parts[1]} span_id=${parts[2]} trace_flags=${parts[3]}`)
+  } else {
+    expect(m).equal(null)
+  }
+}
+
+const insertModes = [false, true, 'traced', 'sampledOnly', 'always']
+
+//= ================================
+// log4js tests
+//= ================================
+describe(`log4js v${version}`, function () {
+  // used by each test
+  let logger
+  let emitter
+  let counter = 0
+  let pfx
+  let spanName
+  let eventInfo
+
+  before(function () {
+    // define log4js appender.
+    // see: Custom Appenders at https://log4js-node.github.io/log4js-node/appenders.html
+    function emitAppender (layout, timezoneOffset) {
+      return (loggingEvent) => {
+        logEmitter.emit('test-log', `${layout(loggingEvent, timezoneOffset)}\n`)
+      }
+    }
+
+    // define an "inline" appender module
+    // see: Advanced configuration at https://log4js-node.github.io/log4js-node/appenders.html
+    const myAppenderModule = {
+      configure: (config, layouts) => {
+        let layout = layouts.colouredLayout
+        if (config.layout) {
+          layout = layouts.layout(config.layout.type, config.layout)
+        }
+        return emitAppender(layout, config.timezoneOffset)
+      }
+    }
+
+    // listen to our fake stream.
+    const logEmitter = new EventEmitter()
+    logEmitter.addListener('test-log', function (s) {
+      eventInfo = s
+    })
+
+    // make the logger
+    log4js.configure({
+      appenders: { custom: { type: myAppenderModule } },
+      categories: { default: { appenders: ['custom'], level: 'debug' } }
+    })
+
+    logger = log4js.getLogger()
+  })
+
+  beforeEach(function () {
+    // provide unique spans for up to 100 tests
+    pfx = ('0' + counter++).slice(-2)
+    spanName = `${pfx}-test`
+
+    // the following are global to all tests so they can use a common
+    // check function.
+    eventInfo = undefined
+  })
+
+  //
+  // Intercept appoptics messages for analysis
+  //
+  beforeEach(function (done) {
+    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
+    ao.traceMode = 'always'
+    ao.cfg.insertTraceIdsIntoLogs = true
+    ao.probes.fs.enabled = false
+
+    emitter = helper.appoptics(done)
+  })
+  afterEach(function (done) {
+    emitter.close(done)
+  })
+
+  // this test exists only to fix a problem with oboe not reporting a UDP
+  // send failure.
+  it('UDP might lose a message', function (done) {
+    helper.test(emitter, function (done) {
+      ao.instrument('fake', function () {})
+      done()
+    }, [
+      function (msg) {
+        msg.should.have.property('Label').oneOf('entry', 'exit')
+        msg.should.have.property('Layer', 'fake')
+      }
+    ], done)
+  })
+
+  insertModes.forEach(mode => {
+    const maybe = mode === false ? 'not ' : ''
+    eventInfo = undefined
+
+    it(`should ${maybe}insert in sync sampled code when mode=${mode}`, function (done) {
+      const level = 'info'
+      const message = `synchronous traced setting = ${mode}`
+      let traceId
+
+      ao.cfg.insertTraceIdsIntoLogs = mode
+
+      function localDone () {
+        checkEventInfo(eventInfo, level, message, mode === false ? undefined : traceId)
+        done()
+      }
+
+      helper.test(emitter, function (done) {
+        ao.instrument(spanName, function () {
+          traceId = ao.lastEvent.toString()
+          // log
+          logger.info(message)
+        })
+        done()
+      }, [
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'entry')
+        },
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'exit')
+        }
+      ], localDone)
+    })
+  })
+
+  insertModes.forEach(mode => {
+    const maybe = (mode === 'sampledOnly' || mode === false) ? 'not ' : ''
+
+    it(`should ${maybe}insert in sync unsampled code when mode=${mode}`, function () {
+      const level = 'info'
+      const message = `synchronous unsampled setting = ${mode}`
+      let traceId
+
+      // these are reset in beforeEach() so set in each test.
+      ao.cfg.insertTraceIdsIntoLogs = mode
+      ao.traceMode = 0
+      ao.sampleRate = 0
+
+      function test () {
+        traceId = ao.lastEvent.toString()
+        expect(traceId[traceId.length - 1] === '0', 'traceId shoud be unsampled')
+        logger.info(message)
+        return 'test-done'
+      }
+
+      const traceparent = ao.addon.Event.makeRandom(0).toString()
+      const result = ao.startOrContinueTrace(traceparent, '', spanName, test)
+
+      expect(result).equal('test-done')
+      checkEventInfo(eventInfo, level, message, maybe ? undefined : traceId)
+    })
+  })
+
+  it('mode=\'always\' should always insert a trace ID even if not tracing', function () {
+    const level = 'info'
+    const message = 'always insert'
+
+    ao.cfg.insertTraceIdsIntoLogs = 'always'
+
+    logger.info(message)
+
+    checkEventInfo(eventInfo, level, message, `00-${'0'.repeat(32)}-${'0'.repeat(16)}-${'0'.repeat(2)}`)
+  })
+
+  it('should insert trace IDs in asynchronous instrumented code', function (done) {
+    const level = 'error'
+    const message = 'asynchronous instrumentation'
+    let traceId
+
+    function localDone () {
+      checkEventInfo(eventInfo, level, message, traceId)
+      done()
+    }
+
+    function asyncFunction (cb) {
+      traceId = ao.lastEvent.toString()
+      logger.error(message)
+      setTimeout(function () {
+        cb()
+      }, 100)
+    }
+
+    helper.test(emitter, function (done) {
+      ao.instrument(spanName, asyncFunction, done)
+    }, [
+      function (msg) {
+        msg.should.have.property('Layer', spanName)
+        msg.should.have.property('Label', 'entry')
+      },
+      function (msg) {
+        msg.should.have.property('Layer', spanName)
+        msg.should.have.property('Label', 'exit')
+      }
+    ], localDone)
+  })
+
+  it('should insert trace IDs in promise-based instrumented code', function (done) {
+    const level = 'info'
+    const message = 'promise instrumentation'
+    let traceId
+    const result = 99
+
+    function localDone () {
+      checkEventInfo(eventInfo, level, message, traceId)
+      done()
+    }
+
+    function promiseFunction () {
+      traceId = ao.lastEvent.toString()
+      logger[level](message)
+      return new Promise((resolve, reject) => {
+        setTimeout(function () {
+          resolve(result)
+        }, 25)
+      })
+    }
+
+    helper.test(
+      emitter,
+      function (done) {
+        ao.pInstrument(spanName, promiseFunction).then(r => {
+          expect(r).equal(result)
+          done()
+        })
+      }, [
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'entry')
+        },
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'exit')
+        }
+      ], localDone)
+  })
+
+  it('should insert trace IDs using the function directly', function (done) {
+    const level = 'info'
+    ao.cfg.insertTraceIdsIntoLogs = false
+    const message = 'helper and synchronous %s'
+    let traceId
+
+    function localDone () {
+      const m = message.replace('%s', traceId)
+      checkEventInfo(eventInfo, level, m)
+      done()
+    }
+
+    helper.test(
+      emitter,
+      function (done) {
+        ao.instrument(spanName, function () {
+          traceId = ao.lastEvent.toString()
+          logger[level](message, traceId)
+        })
+        done()
+      },
+      [
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'entry')
+        },
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'exit')
+        }
+      ],
+      localDone
+    )
+  })
+})


### PR DESCRIPTION
## Overview 

This pull request adds auto instrumentation of the [`log4js`](https://www.npmjs.com/package/log4js) logging package to the agent.

## Implementation

A new probe named `log4js` has been added.

In log4js logging is done by calling a level function (e.g `logger.debug('say something')`) which then calls the `log` function, or alternatively, by directly calling the `log` function. Insertion is done by patching the lower level `log` function to cover all cases (including custom levels).

The implementation uses a "nested wrapper". It patches the `getLogger`  function so that when it is invoked, it will patch an internal `log` function of the returned logger object.

In order to provide granular control as what layouts are auto patched, and which is left for the user to configure, The implementation patches the `configure` function so that it saves the applied configuration on the object so that it can in turn be read at instantiation time.

### Usage
When enabled and inserting (see configuration below) the probe will append a space delimited trace data string to the end of pre predefined layout types. For example, using the `basic` layout: 
`[2022-03-09T20:44:54.716] [ERROR] default - Cheese is too ripe!` will become:
`[2022-03-09T20:44:54.716] [ERROR] default - Cheese is too ripe! trace_id=d91f00e5f3cad1db5f13814aa09cfcd2 span_id=e9f3d82c1dbfb401 trace_flags=01`.

When the user is using a pattern in their layout in ANY of their appenders the probe will respect their pattern (and skill)
and will **NOT** append the trace to the end of the log line. 

Adding trace data to patterns is supported using log4js tokens and custom layouts and the newly added API method `getLogString` (see note re: naming below).

### Configuration 

Probe has basic configuration values that are set in a manner similar to all other logging probes.

 ```enabled: true```

 It obeys the global config ```insertTraceIdsIntoLogs: false``` see: [Configuration Guide](https://github.com/appoptics/appoptics-apm-node/blob/NH-5459-Support-Trace-ID-Insertion-for-log4js/CONFIGURATION.md)

### Tests

Tests added for probe. Tests include testing case where `log4js` is used as `express` middleware (using built-in `connectLogger`).

All [tests pass](https://github.com/appoptics/appoptics-apm-node/actions/runs/1961201242).

Integration testing is done using a [simple app](https://github.com/appoptics/node-instrumented/tree/main/log4js) that performs logging operations with multiple configurations. Those include all predefined configurations, configuration with multiple appenders, configuration using tokens, configuration with custome log levels as well as using built-in addContext and addLayout methods.


### Notes:
- Pull Request merges into `nh-main` branch. Agent built from `master` will stay unchanged.
- Pull request is a first in three to revamp logging probes. Final name for API method will be `getTraceStringForLog` and will be applied in a subsequent pull request.