### PR TITLE
NH-9432-Refactor-Logging-Probes-API

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -34,7 +34,6 @@ The configuration file can supply the following properties, showing their defaul
   runtimeMetrics: true,
   transactionSettings: undefined,
   insertTraceIdsIntoLogs: false,
-  insertTraceIdsIntoMorgan: false,
   createTraceIdsToken: undefined,
   proxy: undefined,
   probes: {
@@ -57,7 +56,6 @@ The configuration file can supply the following properties, showing their defaul
 |transactionSettings|`undefined`|An array of transactions to exclude. Each array element is an object of the form `{type: 'url', string: 'pattern', tracing: trace-setting}` or `{type: 'url', regex: /regex/, tracing: trace-setting}`. When the specified type (currently only `'url'` is implemented) matches the string or regex then tracing for that url is set to trace-setting, overriding the global traceMode. N.B. if inserting a regex into a JSON configuration file you must enter the string that is expected by the `RegExp` constructor because JSON has no representation of a `RegExp` object. `trace-setting` is either `'enabled'` or `'disabled'`.|
 |ec2MetadataTimeout|`1000`|Milliseconds to wait for the ec2/openstack metadata service to respond|
 |insertTraceIdsIntoLogs|`false`|Insert trace IDs into supported logging packages' output. Options are `true`, `'traced'`, `'sampledOnly'`, and `'always'`. The default, `false`, does not insert trace ids. `true` and `'traced'` insert the ID when AppOptics is tracing. `'sampledOnly'` inserts the ID when the trace is sampled. `'always'` inserts an empty trace ID value (all-zeroes) even when not tracing.|
-|insertTraceIdsIntoMorgan|`false`|Append trace IDs to morgan log lines. Because morgan does not output JSON the morgan formats must be modified to enable the trace IDs to be appended. This is a more invasive approach than inserting a property in a JSON object so it requires this explicit setting. The options are the same as for `insertTraceIdsIntoLogs`.|
 |createTraceIdsToken|`undefined`|Create a token that can be used in a logging package's format string. If set to `'morgan'` the token `sw-auto-trace-id` will be created and `:sw-auto-trace-id` can be used in morgan format strings.|
 |triggerTraceEnabled|`true`|Enable or disable the trigger-trace feature. Option values are `true` and `false`|
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -606,7 +606,7 @@ ao.sendMetrics(
 <a name="ao.getTraceObjecForLog"></a>
 
 ### ao.getTraceObjecForLog() ⇒ <code>object</code>
-Return and object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
+Return an object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
 to insert custom tokens in log packages.
 
 **Kind**: static method of [<code>ao</code>](#ao)  

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,8 +53,8 @@
     * [.reportInfo(data)](#ao.reportInfo)
     * ~~[.sendMetric(name, [options])](#ao.sendMetric) ⇒ <code>number</code>~~
     * [.sendMetrics(metrics, [gopts])](#ao.sendMetrics) ⇒ [<code>SendMetricsReturn</code>](#SendMetricsReturn)
-    * [.insertLogObject([object])](#ao.insertLogObject) ⇒ <code>object</code>
-    * [.getLogString([delimiter])](#ao.getLogString) ⇒ <code>string</code>
+    * [.getTraceObjecForLog()](#ao.getTraceObjecForLog) ⇒ <code>object</code>
+    * [.getTraceStringForLog([delimiter])](#ao.getTraceStringForLog) ⇒ <code>string</code>
     * [.wrapLambdaHandler([handler])](#ao.wrapLambdaHandler) ⇒ <code>function</code>
 
 <a name="ao.logLevel"></a>
@@ -603,53 +603,38 @@ ao.sendMetrics(
   {tags: {class: 'status'}}
 );
 ```
-<a name="ao.insertLogObject"></a>
+<a name="ao.getTraceObjecForLog"></a>
 
-### ao.insertLogObject([object]) ⇒ <code>object</code>
-Insert the appoptics object containing a trace ID into an object. The primary intended use for this is
-to auto-insert traceIds into JSON-like logs; it's documented so it can be used for unsupported logging
-packages or by those wishing a higher level of control.
+### ao.getTraceObjecForLog() ⇒ <code>object</code>
+Return and object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
+to insert custom tokens in log packages.
 
 **Kind**: static method of [<code>ao</code>](#ao)  
-**Returns**: <code>object</code> - - the object with the an additional properties, ao, e.g.
-object.sw === {trace_id:..., span_id: ..., trace_flages: ...}.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| [object] | <code>object</code> | into which an sw log object containing trace_id, span_id, trace_flags properties is inserted when conditions are met. |
-
+**Returns**: <code>object</code> - - the trace log  object (e.g. { trace_id:..., span_id: ..., trace_flages: ...})  
 **Example**  
 ```js
-const ao = require('appoptics-apm');
-const logger = require('pino')();
-
-// with no object as an argument ao.insertLogObject returns {ao: {traceId: ...}}
-logger.info(ao.insertLogObject(), 'not-so-important message');
-```
-**Example**  
-```js
-const ao = require('appoptics-apm');
-const winston = require('winston');
-const logger = winston.createLogger({
-    level: 'info',
-    format: winston.format.combine(
-      winston.format.splat(),
-      winston.format.json()
-    ),
-    defaultMeta: {service: 'ao-log-example'},
-    transports: [...]
+log4js.addLayout('json', function (config) {
+  return function (logEvent) {
+    logEvent.context = { ...logEvent.context, ...ao.getTraceObjecForLog() }
+    return JSON.stringify(logEvent)
+  }
 })
-
-logger.info(ao.insertLogObject({
-    message: 'this object is being modified by insertLogObject',
-    more: 'there will be an added sw property'
-}))
+log4js.configure({
+  appenders: {
+    out: { type: 'stdout', layout: { type: 'json' } }
+  },
+  categories: {
+    default: { appenders: ['out'], level: 'info' }
+  }
+})
+const logger = log4js.getLogger()
+logger.info('doing something.')
 ```
-<a name="ao.getLogString"></a>
+<a name="ao.getTraceStringForLog"></a>
 
-### ao.getLogString([delimiter]) ⇒ <code>string</code>
+### ao.getTraceStringForLog([delimiter]) ⇒ <code>string</code>
 Return text delimited representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
-to custom tokens in log packages.
+to insert custom tokens in log packages.
 
 **Kind**: static method of [<code>ao</code>](#ao)  
 **Returns**: <code>string</code> - - the trace log string (e.g. trace_id:... span_id: ..., trace_flages: ...)  
@@ -672,7 +657,7 @@ log4js.configure({
             return 'Jake'
           },
           trace: function () {
-            return typeof ao !=='undefined' ? ao.getLogString() : ''
+            return typeof ao !=='undefined' ? ao.getTraceStringForLog() : ''
           }
         }
       }

--- a/lib/api-sim.js
+++ b/lib/api-sim.js
@@ -73,8 +73,10 @@ module.exports = function (appoptics) {
     reportInfo,
     sendMetric,
     sendMetrics,
-    insertLogObject,
-    getLogString,
+
+    // log instrumentation
+    getTraceObjecForLog,
+    getTraceStringForLog,
 
     // lambda
     wrapLambdaHandler
@@ -685,46 +687,70 @@ function sendMetrics (metrics) {
 }
 
 /**
- * Insert the appoptics object containing a trace ID into an object. The primary intended use for this is
- * to auto-insert traceIds into JSON-like logs; it's documented so it can be used for unsupported logging
- * packages or by those wishing a higher level of control.
+ * Return and object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
+ * to insert custom tokens in log packages.
  *
- * @method ao.insertLogObject
- * @param {object} [object] - inserts an ao log object containing a traceId property when conditions are met.
- * @returns {object} - the object with the an additional property, ao, e.g., object.ao === {traceId: ...}.
- *
+ * @method ao.getTraceObjecForLog
+ * @returns {object} - the trace log  object (e.g. { trace_id:..., span_id: ..., trace_flages: ...})
+
  * @example
  *
- * const ao = require('appoptics-apm');
- * const logger = require('pino')();
- *
- * // with no object as an argument ao.insertLogObject returns {ao: {traceId: ...}}
- * logger.info(ao.insertLogObject(), 'not-so-important message');
- *
- * @example
- *
- * const ao = require('appoptics-apm');
- * const winston = require('winston');
- * const logger = winston.createLogger({
- *     level: 'info',
- *     format: winston.format.combine(
- *       winston.format.splat(),
- *       winston.format.json()
- *     ),
- *     defaultMeta: {service: 'ao-log-example'},
- *     transports: [...]
+ * log4js.addLayout('json', function (config) {
+ *   return function (logEvent) {
+ *     logEvent.context = { ...logEvent.context, ...ao.getTraceObjecForLog() }
+ *     return JSON.stringify(logEvent)
+ *   }
  * })
- *
- * logger.info(ao.insertLogObject({
- *     message: 'this object is being modified by insertLogObject',
- *     more: 'there will be an added ao property'
- * }))
+
+ * log4js.configure({
+ *   appenders: {
+ *     out: { type: 'stdout', layout: { type: 'json' } }
+ *   },
+ *   categories: {
+ *     default: { appenders: ['out'], level: 'info' }
+ *   }
+ * })
+ * const logger = log4js.getLogger()
+ * logger.info('doing something.')
  */
-function insertLogObject (o = {}) {
-  return o
+function getTraceObjecForLog () {
+  return {}
 }
 
-function getLogString () {
+/**
+ * Return text delimited representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
+ * to insert custom tokens in log packages.
+ *
+ * @method ao.getTraceStringForLog
+ * @param {string} [delimiter] - the delimiter to use
+ *
+ * @returns {string} - the trace log string (e.g. trace_id:... span_id: ..., trace_flages: ...)
+ *
+ * @example
+ * log4js.configure({
+ *   appenders: {
+ *     out: {
+ *       type: 'stdout',
+ *       layout: {
+ *         type: 'pattern',
+ *         pattern: '%d %p %c %x{user} says: %m is: %x{trace} %n',
+ *         tokens: {
+ *           user: function (logEvent) {
+ *             return 'Jake'
+ *           },
+ *           trace: function () {
+ *             return typeof ao !=='undefined' ? ao.getTraceStringForLog() : ''
+ *           }
+ *         }
+ *       }
+ *     }
+ *   },
+ *   categories: { default: { appenders: ['out'], level: 'info' } }
+ * })
+ * const logger = log4js.getLogger()
+ * logger.info('token from api')
+ */
+function getTraceStringForLog () {
   return ''
 }
 

--- a/lib/api-sim.js
+++ b/lib/api-sim.js
@@ -687,7 +687,7 @@ function sendMetrics (metrics) {
 }
 
 /**
- * Return and object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
+ * Return an object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
  * to insert custom tokens in log packages.
  *
  * @method ao.getTraceObjecForLog

--- a/lib/api.js
+++ b/lib/api.js
@@ -74,8 +74,10 @@ module.exports = function (appoptics) {
     reportInfo,
     sendMetric,
     sendMetrics,
-    insertLogObject,
-    getLogString,
+
+    // log instrumentation
+    getTraceObjecForLog,
+    getTraceStringForLog,
 
     // lambda
     wrapLambdaHandler // wrap user handler
@@ -1399,72 +1401,60 @@ function sendMetrics (metrics, gopts = {}) {
 }
 
 /**
- * Insert the appoptics object containing a trace ID into an object. The primary intended use for this is
- * to auto-insert traceIds into JSON-like logs; it's documented so it can be used for unsupported logging
- * packages or by those wishing a higher level of control.
+ * Return and object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
+ * to insert custom tokens in log packages.
  *
- * @method ao.insertLogObject
- * @param {object} [object] - into which an sw log object containing trace_id, span_id, trace_flags
- * properties is inserted when conditions are met.
- *
- * @returns {object} - the object with the an additional properties, ao, e.g.
- * object.sw === {trace_id:..., span_id: ..., trace_flages: ...}.
- *
+ * @method ao.getTraceObjecForLog
+ * @returns {object} - the trace log  object (e.g. { trace_id:..., span_id: ..., trace_flages: ...})
+
  * @example
  *
- * const ao = require('appoptics-apm');
- * const logger = require('pino')();
- *
- * // with no object as an argument ao.insertLogObject returns {ao: {traceId: ...}}
- * logger.info(ao.insertLogObject(), 'not-so-important message');
- *
- * @example
- *
- * const ao = require('appoptics-apm');
- * const winston = require('winston');
- * const logger = winston.createLogger({
- *     level: 'info',
- *     format: winston.format.combine(
- *       winston.format.splat(),
- *       winston.format.json()
- *     ),
- *     defaultMeta: {service: 'ao-log-example'},
- *     transports: [...]
+ * log4js.addLayout('json', function (config) {
+ *   return function (logEvent) {
+ *     logEvent.context = { ...logEvent.context, ...ao.getTraceObjecForLog() }
+ *     return JSON.stringify(logEvent)
+ *   }
  * })
- *
- * logger.info(ao.insertLogObject({
- *     message: 'this object is being modified by insertLogObject',
- *     more: 'there will be an added sw property'
- * }))
+
+ * log4js.configure({
+ *   appenders: {
+ *     out: { type: 'stdout', layout: { type: 'json' } }
+ *   },
+ *   categories: {
+ *     default: { appenders: ['out'], level: 'info' }
+ *   }
+ * })
+ * const logger = log4js.getLogger()
+ * logger.info('doing something.')
  */
-function insertLogObject (o = {}) {
+function getTraceObjecForLog () {
   // if truthy and tracing insert it based on sample setting. otherwise if 'always'
   // then insert a trace ID regardless. No explicit check for 'traced' is required.
   let last
-  if ((ao.cfg.insertTraceIdsIntoLogs || ao.cfg.insertTraceIdsIntoMorgan) && (last = ao.lastEvent)) {
+  if ((ao.cfg.insertTraceIdsIntoLogs) && (last = ao.lastEvent)) {
     if (ao.cfg.insertTraceIdsIntoLogs !== 'sampledOnly' || last.event.getSampleFlag()) {
       const parts = last.toString().split('-')
-      o.sw = {
+      return {
         trace_id: parts[1],
         span_id: parts[2],
         trace_flags: parts[3]
       }
     }
-  } else if (ao.cfg.insertTraceIdsIntoLogs === 'always' || ao.cfg.insertTraceIdsIntoMorgan === 'always') {
-    o.sw = {
+  } else if (ao.cfg.insertTraceIdsIntoLogs === 'always') {
+    return {
       trace_id: '0'.repeat(32),
       span_id: '0'.repeat(16),
       trace_flags: '0'.repeat(2)
     }
   }
-  return o
+  return null
 }
 
 /**
  * Return text delimited representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
- * to custom tokens in log packages.
+ * to insert custom tokens in log packages.
  *
- * @method ao.getLogString
+ * @method ao.getTraceStringForLog
  * @param {string} [delimiter] - the delimiter to use
  *
  * @returns {string} - the trace log string (e.g. trace_id:... span_id: ..., trace_flages: ...)
@@ -1482,7 +1472,7 @@ function insertLogObject (o = {}) {
  *             return 'Jake'
  *           },
  *           trace: function () {
- *             return typeof ao !=='undefined' ? ao.getLogString() : ''
+ *             return typeof ao !=='undefined' ? ao.getTraceStringForLog() : ''
  *           }
  *         }
  *       }
@@ -1493,9 +1483,9 @@ function insertLogObject (o = {}) {
  * const logger = log4js.getLogger()
  * logger.info('token from api')
  */
-function getLogString (delimiter = ' ') {
-  const obj = ao.insertLogObject()
-  return obj.sw ? Object.entries(obj.sw).map(([k, v]) => `${k}=${v}`).join(delimiter) : ''
+function getTraceStringForLog (delimiter = ' ') {
+  const obj = ao.getTraceObjecForLog()
+  return obj ? Object.entries(obj).map(([k, v]) => `${k}=${v}`).join(delimiter) : ''
 }
 
 /**

--- a/lib/api.js
+++ b/lib/api.js
@@ -1401,7 +1401,7 @@ function sendMetrics (metrics, gopts = {}) {
 }
 
 /**
- * Return and object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
+ * Return an object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
  * to insert custom tokens in log packages.
  *
  * @method ao.getTraceObjecForLog

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -35,7 +35,6 @@ function getUnifiedConfig () {
     // end-user focused, config file only
     domainPrefix: { location: 'c', type: 'b' },
     insertTraceIdsIntoLogs: { location: 'c', type: 'b' },
-    insertTraceIdsIntoMorgan: { location: 'c', type: 'b' },
     createTraceIdsToken: { location: 'c', type: { morgan: 'morgan' } },
 
     // end-user focused, both env var and config file

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,7 +146,7 @@ if (alreadyLoaded.length && ao.execEnv.nodeEnv === 'production') {
 }
 
 // if inserting into morgan then a token must be created.
-if (config.insertTraceIdsIntoMorgan) {
+if (config.insertTraceIdsIntoLogs) {
   config.createTraceIdsToken = 'morgan'
 }
 

--- a/lib/probes/bunyan.js
+++ b/lib/probes/bunyan.js
@@ -1,14 +1,13 @@
 'use strict'
 
 const ao = require('..')
-
 const shimmer = require('shimmer')
 const semver = require('semver')
 
 const logMissing = ao.makeLogMissing('bunyan')
 
 function patchEmit (_emit) {
-  return function emitWithLogObject (rec, noemit) {
+  return function wrappedEmit (rec, noemit) {
     const logObject = ao.getTraceObjecForLog()
     if (logObject) {
       rec.sw = logObject

--- a/lib/probes/bunyan.js
+++ b/lib/probes/bunyan.js
@@ -9,7 +9,11 @@ const logMissing = ao.makeLogMissing('bunyan')
 
 function patchEmit (_emit) {
   return function emitWithLogObject (rec, noemit) {
-    ao.insertLogObject(rec)
+    const logObject = ao.getTraceObjecForLog()
+    if (logObject) {
+      rec.sw = logObject
+    }
+
     return _emit.apply(this, arguments)
   }
 }

--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -12,7 +12,7 @@ function patchLog (log) {
   // third argument (passThrough) is optional.
   // when it is supplied, it is appended to msg (second argument) using a space.
   return function LogWithLogObject (_, msg, passThrough) {
-    const str = ao.getLogString()
+    const str = ao.getTraceStringForLog()
 
     // when no insertion is needed (or when not possible) the returned str will be empty
     // assume that msg is supplied by user as a string
@@ -60,7 +60,7 @@ module.exports = function (log4js, info) {
         if (typeof instance.log === 'function') {
           // when the user is using a pattern in their layout in ANY of their appenders respect their pattern (and skill)
           // do NOT append the trace to the end of the log message.
-          // (note: inserting for patterns is available using log4js tokens and api method getLogString)
+          // (note: inserting for patterns is available using log4js tokens and api method getTraceStringForLog)
           const appendTraceToEndOfLog = !Object.values(this.configuration.appenders).find(appender => {
             return (
               typeof appender.layout !== 'undefined' &&

--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -11,7 +11,7 @@ function patchLog (log) {
   // first argument received by the log method is the level object which will not be touched.
   // third argument (passThrough) is optional.
   // when it is supplied, it is appended to msg (second argument) using a space.
-  return function LogWithLogObject (_, msg, passThrough) {
+  return function wrappedLog (_, msg, passThrough) {
     const str = ao.getTraceStringForLog()
 
     // when no insertion is needed (or when not possible) the returned str will be empty
@@ -36,21 +36,26 @@ module.exports = function (log4js, info) {
     return log4js
   }
 
-  shimmer.wrap(log4js, 'configure', function (original) {
-    return function () {
-      // save the applied configuration on the object so it can be read at instantiation time.
-      // otherwise it is not currently possible to read what config was applied.
-      // side note: can be nice addition to the log4js api.
-      this.configuration = arguments[0]
-      return original.apply(this, arguments)
-    }
-  })
+  if (typeof log4js.configure === 'function') {
+    shimmer.wrap(log4js, 'configure', function (original) {
+      return function wrappedConfigure () {
+        // save the applied configuration on the object so it can be read at instantiation time.
+        // otherwise it is not currently possible to read what config was applied.
+        // side note: can be nice addition to the log4js api.
+        this.configuration = arguments[0]
+        return original.apply(this, arguments)
+      }
+    })
+  } else {
+    logMissing('configure')
+  }
 
-  if (typeof log4js.getLogger === 'function') {
+  // do not patch the logger constructor if not function or if did not patch the configure method
+  if (typeof log4js.getLogger === 'function' && typeof log4js.configure === 'function') {
     // getLogger is called on a configured log4js object
     // wrap the logger instantiation function to get the correct configuration.
     shimmer.wrap(log4js, 'getLogger', function (original) {
-      return function () {
+      return function wrappedGetLogger () {
         // create an instance
         const instance = original.apply(this, arguments)
 

--- a/lib/probes/morgan.js
+++ b/lib/probes/morgan.js
@@ -20,7 +20,7 @@ module.exports = function (morgan) {
   const pmorgan = new Proxy(morgan, {
     // call target/morgan as a function
     apply (target, thisArg, argumentsList) {
-      if (ao.cfg.insertTraceIdsIntoMorgan) {
+      if (ao.cfg.insertTraceIdsIntoLogs) {
         argumentsList = tryInsertion(morgan, argumentsList)
       } else if (ao.cfg.createTraceIdsToken === 'morgan') {
         if (!token) {
@@ -35,38 +35,12 @@ module.exports = function (morgan) {
 }
 
 //
-// get the string to insert into the morgan log output
-//
-function getAutoTraceTokenString () {
-  const last = ao.lastEvent
-  const mode = ao.cfg.insertTraceIdsIntoMorgan
-
-  // return empty string
-  if ((!last && mode !== 'always') || !mode) {
-    return ''
-  }
-
-  if (mode === 'sampledOnly' && !last.event.getSampleFlag()) {
-    return ''
-  }
-
-  // via api obtain a log object
-  const o = ao.insertLogObject()
-  // return formatted string - a space delimited representation of the log object with a space at the start
-
-  // examples:
-  // trace_id=00000000000000000000000000000000 span_id=0000000000000000 trace_flags=00
-  // trace_id=df4b26272a52bd608a78b2cb440ccff1 span_id=86eae58ab790f1da trace_flags=01
-  return ' ' + Object.entries(o.sw).map(item => item.join('=')).join(' ')
-}
-
-//
 // token creation
 //
 const autoToken = ':sw-auto-trace-id'
 
 function createToken (morgan) {
-  return morgan.token(`${autoToken.slice(1)}`, () => getAutoTraceTokenString())
+  return morgan.token(`${autoToken.slice(1)}`, () => ` ${ao.getTraceStringForLog()}`)
 }
 
 //
@@ -103,7 +77,7 @@ function tryInsertion (morgan, args) {
       // generate the log line.
       const string = fmt.apply(this, arguments)
 
-      return `${string}${getAutoTraceTokenString()}`
+      return `${string} ${ao.getTraceStringForLog()}`
     }
     // substitute the wrapper for the caller's function.
     args[0] = wrapped

--- a/lib/probes/pino.js
+++ b/lib/probes/pino.js
@@ -1,14 +1,13 @@
 'use strict'
 
 const ao = require('..')
-
 const shimmer = require('shimmer')
 const semver = require('semver')
 
 const logMissing = ao.makeLogMissing('pino')
 
 function patchWrite (write) {
-  return function writeWithLogObject (obj, msg, num) {
+  return function wrappedWrite (obj, msg, num) {
     const logObject = ao.getTraceObjecForLog()
 
     if (logObject) {

--- a/lib/probes/pino.js
+++ b/lib/probes/pino.js
@@ -9,8 +9,12 @@ const logMissing = ao.makeLogMissing('pino')
 
 function patchWrite (write) {
   return function writeWithLogObject (obj, msg, num) {
-    arguments[0] = obj = obj || {}
-    ao.insertLogObject(obj)
+    const logObject = ao.getTraceObjecForLog()
+
+    if (logObject) {
+      arguments[0] = { sw: logObject }
+    }
+
     return write.apply(this, arguments)
   }
 }

--- a/lib/probes/winston.js
+++ b/lib/probes/winston.js
@@ -1,18 +1,18 @@
 'use strict'
 
 const ao = require('..')
-
-const requirePatch = require('../require-patch')
 const shimmer = require('shimmer')
 const semver = require('semver')
 
 const logMissing = ao.makeLogMissing('winston')
 
+const requirePatch = require('../require-patch')
+
 //
 // patch the write function (version 3)
 //
 function patchWrite (write) {
-  return function addTraceId (o, encoding, cb) {
+  return function wrappedWrite (o, encoding, cb) {
     const logObject = ao.getTraceObjecForLog()
     if (logObject) {
       o.sw = logObject
@@ -29,7 +29,7 @@ function patchLog (log) {
     return log
   }
 
-  return function addTraceId (level, message, meta, cb) {
+  return function wrappedLog (level, message, meta, cb) {
     // if there is an object argument (meta) add the trace ID to it
     for (let i = 0; i < arguments.length; i++) {
       if (typeof arguments[i] === 'object') {

--- a/lib/probes/winston.js
+++ b/lib/probes/winston.js
@@ -13,7 +13,10 @@ const logMissing = ao.makeLogMissing('winston')
 //
 function patchWrite (write) {
   return function addTraceId (o, encoding, cb) {
-    ao.insertLogObject(o)
+    const logObject = ao.getTraceObjecForLog()
+    if (logObject) {
+      o.sw = logObject
+    }
     return write.apply(this, arguments)
   }
 }
@@ -30,7 +33,10 @@ function patchLog (log) {
     // if there is an object argument (meta) add the trace ID to it
     for (let i = 0; i < arguments.length; i++) {
       if (typeof arguments[i] === 'object') {
-        ao.insertLogObject(arguments[i])
+        const logObject = ao.getTraceObjecForLog()
+        if (logObject) {
+          arguments[i].sw = logObject
+        }
         return log.apply(this, arguments)
       }
     }
@@ -38,7 +44,7 @@ function patchLog (log) {
     // no meta object so we need to insert one
     cb = arguments[arguments.length - 1]
     const ix = typeof cb === 'function' ? arguments.length - 1 : arguments.length
-    Array.prototype.splice.call(arguments, ix, 0, ao.insertLogObject())
+    Array.prototype.splice.call(arguments, ix, 0, { sw: ao.getTraceObjecForLog() })
     return log.apply(this, arguments)
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "koa-route": "^3.2.0",
         "koa-router": "^10.1.1",
         "level": "^7.0.0",
+        "log4js": "^6.4.2",
         "memcached": "^2.2.2",
         "method-override": "^2.3.10",
         "mkdirp": "^0.5.1",
@@ -69,7 +70,7 @@
         "oracledb": "^5.2.0",
         "pg": "^8.7.1",
         "pg-native": "^3.0.0",
-        "pino": "^5.17.0",
+        "pino": "^7.8.0",
         "q": "^1.5.1",
         "raw-body": "^2.4.1",
         "redis": "^3.1.2",
@@ -78,8 +79,8 @@
         "supertest": "^3.4.2",
         "tedious": "^14.0.0",
         "testeachversion": "^9.0.0",
-        "winston": "^3.3.3",
-        "winston-transport": "^4.3.0",
+        "winston": "^3.6.0",
+        "winston-transport": "^4.5.0",
         "ws": "^7.2.0"
       },
       "optionalDependencies": {
@@ -2759,6 +2760,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/date-format": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.4.tgz",
+      "integrity": "sha512-/jyf4rhB17ge328HJuJjAcmRtCsGd+NDeAtahRBTaK6vSPR6MO5HlrAit3Nn7dVjaa6sowW0WXt8yQtLyZQFRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -3075,6 +3085,41 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -3152,6 +3197,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enquirer": {
@@ -3826,19 +3880,13 @@
       "dev": true
     },
     "node_modules/fast-redact": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.1.0.tgz",
-      "integrity": "sha512-0LkHpTLyadJavq9sRzzyqIoMZemWli77K2/MGOkafrR64B9ItrvZ9aT+jluvNDsv0YEHjSNhlMBtbokuoqii4A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==",
       "dev": true,
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
     },
     "node_modules/fecha": {
       "version": "4.2.1",
@@ -3985,12 +4033,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
-      "dev": true
-    },
     "node_modules/flatted": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
@@ -4063,6 +4105,29 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs-minipass": {
@@ -4243,6 +4308,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "dev": true
     },
     "node_modules/growl": {
       "version": "1.10.5",
@@ -5229,6 +5300,27 @@
       "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
       "dev": true
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -5953,6 +6045,45 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/log4js": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.2.tgz",
+      "integrity": "sha512-k80cggS2sZQLBwllpT1p06GtfvzMmSdUCkW96f0Hj83rKGJDAu2vZjt9B9ag2vx8Zz1IXzxoLgqvRJCdMKybGg==",
+      "dev": true,
+      "dependencies": {
+        "date-format": "^4.0.4",
+        "debug": "^4.3.3",
+        "flatted": "^3.2.5",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/log4js/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/log4js/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/logform": {
       "version": "2.4.0",
@@ -7004,6 +7135,12 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+      "dev": true
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -7368,26 +7505,40 @@
       }
     },
     "node_modules/pino": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
-      "integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.8.0.tgz",
+      "integrity": "sha512-Ynw2HRVapiyj+ZGfUcpms+SRgDKFIy0ztaFUf3X6IHh+vsysMvn+tpV/Ej3gyutPp4n9tgH6ZkkCAelSvP5zmQ==",
       "dev": true,
       "dependencies": {
-        "fast-redact": "^2.0.0",
-        "fast-safe-stringify": "^2.0.7",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^2.4.2",
-        "quick-format-unescaped": "^3.0.3",
-        "sonic-boom": "^0.7.5"
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.13.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dev": true,
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
     "node_modules/pino-std-serializers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
-      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
       "dev": true
     },
     "node_modules/pluralize": {
@@ -7457,6 +7608,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
       "dev": true
     },
     "node_modules/progress": {
@@ -7555,9 +7712,9 @@
       ]
     },
     "node_modules/quick-format-unescaped": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "dev": true
     },
     "node_modules/randombytes": {
@@ -7655,6 +7812,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis": {
@@ -8078,6 +8244,12 @@
         "node": "*"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -8444,13 +8616,12 @@
       "dev": true
     },
     "node_modules/sonic-boom": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
-      "integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.6.0.tgz",
+      "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
       "dev": true,
       "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/sort-array": {
@@ -8708,6 +8879,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
+    },
     "node_modules/stream-transform": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
@@ -8725,6 +8902,43 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/streamroller": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.4.tgz",
+      "integrity": "sha512-GI9NzeD+D88UFuIlJkKNDH/IsuR+qIN7Qh8EsmhoRZr9bQoehTraRgwtLUkZbpcAw+hLPfHOypmppz8YyGK68w==",
+      "dev": true,
+      "dependencies": {
+        "date-format": "^4.0.4",
+        "debug": "^4.3.3",
+        "fs-extra": "^10.0.1"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/streamroller/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/streamroller/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -9251,6 +9465,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.13.2.tgz",
+      "integrity": "sha512-woZFt0cLFkPdhsa+IGpRo1jiSouaHxMIljzTgt30CMjBWoUYbbcHqnunW5Yv+BXko9H05MVIcxMipI3Jblallw==",
+      "dev": true,
+      "dependencies": {
+        "real-require": "^0.1.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -12166,6 +12389,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-format": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.4.tgz",
+      "integrity": "sha512-/jyf4rhB17ge328HJuJjAcmRtCsGd+NDeAtahRBTaK6vSPR6MO5HlrAit3Nn7dVjaa6sowW0WXt8yQtLyZQFRg==",
+      "dev": true
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -12413,6 +12642,40 @@
         "nan": "^2.14.0"
       }
     },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -12480,6 +12743,15 @@
         "inherits": "^2.0.3",
         "level-codec": "^10.0.0",
         "level-errors": "^3.0.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "enquirer": {
@@ -13006,15 +13278,9 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.1.0.tgz",
-      "integrity": "sha512-0LkHpTLyadJavq9sRzzyqIoMZemWli77K2/MGOkafrR64B9ItrvZ9aT+jluvNDsv0YEHjSNhlMBtbokuoqii4A==",
-      "dev": true
-    },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==",
       "dev": true
     },
     "fecha": {
@@ -13133,12 +13399,6 @@
         "rimraf": "^3.0.2"
       }
     },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
-      "dev": true
-    },
     "flatted": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
@@ -13185,6 +13445,25 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
     },
     "fs-minipass": {
       "version": "2.1.0",
@@ -13319,6 +13598,12 @@
       "requires": {
         "type-fest": "^0.20.2"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -14043,6 +14328,24 @@
       "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
       "dev": true
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -14631,6 +14934,36 @@
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "log4js": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.2.tgz",
+      "integrity": "sha512-k80cggS2sZQLBwllpT1p06GtfvzMmSdUCkW96f0Hj83rKGJDAu2vZjt9B9ag2vx8Zz1IXzxoLgqvRJCdMKybGg==",
+      "dev": true,
+      "requires": {
+        "date-format": "^4.0.4",
+        "debug": "^4.3.3",
+        "flatted": "^3.2.5",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.0.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "logform": {
@@ -15453,6 +15786,12 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
+    "on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -15739,23 +16078,37 @@
       }
     },
     "pino": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
-      "integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.8.0.tgz",
+      "integrity": "sha512-Ynw2HRVapiyj+ZGfUcpms+SRgDKFIy0ztaFUf3X6IHh+vsysMvn+tpV/Ej3gyutPp4n9tgH6ZkkCAelSvP5zmQ==",
       "dev": true,
       "requires": {
-        "fast-redact": "^2.0.0",
-        "fast-safe-stringify": "^2.0.7",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^2.4.2",
-        "quick-format-unescaped": "^3.0.3",
-        "sonic-boom": "^0.7.5"
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.13.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
       }
     },
     "pino-std-serializers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
-      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
       "dev": true
     },
     "pluralize": {
@@ -15807,6 +16160,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
       "dev": true
     },
     "progress": {
@@ -15868,9 +16227,9 @@
       "dev": true
     },
     "quick-format-unescaped": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "dev": true
     },
     "randombytes": {
@@ -15955,6 +16314,12 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "dev": true
     },
     "redis": {
       "version": "3.1.2",
@@ -16283,6 +16648,12 @@
       "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc=",
       "dev": true
     },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -16577,13 +16948,12 @@
       "dev": true
     },
     "sonic-boom": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
-      "integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.6.0.tgz",
+      "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
       "dev": true,
       "requires": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
+        "atomic-sleep": "^1.0.0"
       }
     },
     "sort-array": {
@@ -16785,6 +17155,12 @@
         }
       }
     },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
+    },
     "stream-transform": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
@@ -16799,6 +17175,34 @@
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
       "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
       "dev": true
+    },
+    "streamroller": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.4.tgz",
+      "integrity": "sha512-GI9NzeD+D88UFuIlJkKNDH/IsuR+qIN7Qh8EsmhoRZr9bQoehTraRgwtLUkZbpcAw+hLPfHOypmppz8YyGK68w==",
+      "dev": true,
+      "requires": {
+        "date-format": "^4.0.4",
+        "debug": "^4.3.3",
+        "fs-extra": "^10.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -17218,6 +17622,15 @@
       "dev": true,
       "requires": {
         "thenify": ">= 3.1.0 < 4"
+      }
+    },
+    "thread-stream": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.13.2.tgz",
+      "integrity": "sha512-woZFt0cLFkPdhsa+IGpRo1jiSouaHxMIljzTgt30CMjBWoUYbbcHqnunW5Yv+BXko9H05MVIcxMipI3Jblallw==",
+      "dev": true,
+      "requires": {
+        "real-require": "^0.1.0"
       }
     },
     "to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -118,8 +118,8 @@
     "supertest": "^3.4.2",
     "tedious": "^14.0.0",
     "testeachversion": "^9.0.0",
-    "winston": "^3.3.3",
-    "winston-transport": "^4.3.0",
+    "winston": "^3.6.0",
+    "winston-transport": "^4.5.0",
     "ws": "^7.2.0"
   },
   "optionalDependencies": {

--- a/test/get-unified-config.test.js
+++ b/test/get-unified-config.test.js
@@ -288,7 +288,6 @@ describe('get-unified-config', function () {
         '  domainPrefix: false,',
         '  serviceKey,',
         '  insertTraceIdsIntoLogs: undefined,',
-        '  insertTraceIdsIntoMorgan: undefined,',
         '  createTraceIdsToken: false,',
         '  probes: {',
         '    fs: {',
@@ -303,8 +302,7 @@ describe('get-unified-config', function () {
         hostnameAlias: '',
         domainPrefix: false,
         serviceKey: '',
-        insertTraceIdsIntoLogs: false,
-        insertTraceIdsIntoMorgan: false
+        insertTraceIdsIntoLogs: false
       }
 
       writeConfigJs(literal.join('\n'))

--- a/test/no-addon/custom.test.js
+++ b/test/no-addon/custom.test.js
@@ -124,13 +124,10 @@ describe('custom (without native bindings present)', function () {
     assert(ao.reportInfo('this is info') === undefined)
     assert(ao.sendMetric() === -1)
 
-    let o = ao.insertLogObject()
+    const o = ao.getTraceObjecForLog()
     assert(typeof o === 'object')
     assert(Object.keys(o).length === 0)
 
-    o = ao.insertLogObject({ existing: 'bruce' })
-    assert(typeof o === 'object')
-    assert(Object.keys(o).length === 1)
-    assert(o.existing === 'bruce')
+    assert(ao.getTraceStringForLog() === '')
   })
 })

--- a/test/probes/log4js.test.js
+++ b/test/probes/log4js.test.js
@@ -12,7 +12,6 @@ const { version } = require('log4js/package.json')
 const { EventEmitter } = require('events')
 
 function checkEventInfo (eventInfo, level, message, traceId) {
-  // console.log(eventInfo)
   const reString = 'trace_id=[a-f0-9]{32} span_id=[a-f0-9]{16} trace_flags=0(0|1)'
   const re = new RegExp(reString)
   const m = eventInfo.match(re)

--- a/test/probes/log4js.test.js
+++ b/test/probes/log4js.test.js
@@ -568,7 +568,7 @@ describe(`log4js v${version}`, function () {
     })
     const logger = log4js.getLogger()
     logger.addContext('user', 'charlie')
-    logger.addContext('trace', function () { return ao.getLogString() })
+    logger.addContext('trace', function () { return ao.getTraceStringForLog() })
 
     function localDone () {
       checkEventInfo(eventInfo, level, message, traceId)
@@ -602,7 +602,7 @@ describe(`log4js v${version}`, function () {
 
     log4js.addLayout('json', function (config) {
       return function (logEvent) {
-        logEvent.context = { ...logEvent.context, ...ao.insertLogObject() }
+        logEvent.context = { ...logEvent.context, sw: ao.getTraceObjecForLog() }
         return JSON.stringify(logEvent)
       }
     })
@@ -665,7 +665,7 @@ describe(`log4js v${version}`, function () {
                 return 'Jake'
               },
               age: 45,
-              trace: function () { return ao.getLogString() }
+              trace: function () { return ao.getTraceStringForLog() }
             }
           }
         }

--- a/test/probes/morgan.test.js
+++ b/test/probes/morgan.test.js
@@ -170,7 +170,7 @@ describe(`probes.morgan ${version}`, function () {
     ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
     ao.traceMode = 'always'
     // default to the simple 'true'
-    ao.cfg.insertTraceIdsIntoMorgan = true
+    ao.cfg.insertTraceIdsIntoLogs = true
 
     debugging = false
 
@@ -206,7 +206,7 @@ describe(`probes.morgan ${version}`, function () {
       let traceId
 
       // this gets reset in beforeEach() so set it in the test.
-      ao.cfg.insertTraceIdsIntoMorgan = mode
+      ao.cfg.insertTraceIdsIntoLogs = mode
       logger = makeLogger()
 
       function localDone () {
@@ -248,7 +248,7 @@ describe(`probes.morgan ${version}`, function () {
       let traceId
 
       // reset in beforeEach() so set in each test.
-      ao.cfg.insertTraceIdsIntoMorgan = mode
+      ao.cfg.insertTraceIdsIntoLogs = mode
       logger = makeLogger()
       ao.traceMode = 0
       ao.sampleRate = 0
@@ -289,7 +289,7 @@ describe(`probes.morgan ${version}`, function () {
       let traceId
 
       // this gets reset in beforeEach() so set it in the test.
-      ao.cfg.insertTraceIdsIntoMorgan = mode
+      ao.cfg.insertTraceIdsIntoLogs = mode
       logger = makeLogger(function () { return 'xyzzy' })
 
       function localDone () {
@@ -331,7 +331,7 @@ describe(`probes.morgan ${version}`, function () {
       const traceId = `00-${'0'.repeat(32)}-${'0'.repeat(16)}-${'0'.repeat(2)}`
       ao.lastEvent = undefined
 
-      ao.cfg.insertTraceIdsIntoMorgan = 'always'
+      ao.cfg.insertTraceIdsIntoLogs = 'always'
       logger = makeLogger()
       ao.traceMode = 0
       ao.sampleRate = 0
@@ -428,7 +428,7 @@ describe(`probes.morgan ${version}`, function () {
   })
 
   it('should insert trace IDs using the function directly', function (done) {
-    ao.cfg.insertTraceIdsIntoMorgan = false
+    ao.cfg.insertTraceIdsIntoLogs = false
     let traceId
 
     logger = makeLogger('traceThis::my-trace-id')

--- a/test/probes/winston.test.js
+++ b/test/probes/winston.test.js
@@ -118,7 +118,8 @@ function checkEventInfo2 (eventInfo, level, message, traceId) {
   expect(eventInfo[0]).equal(level, 'levels don\'t match')
   expect(eventInfo[1]).equal(message, 'messages don\'t match')
   if (traceId) {
-    expect(eventInfo[2]).deep.equal({ ao: { traceId } }, 'ao object doesn\'t match')
+    const parts = traceId.toString().split('-')
+    expect(eventInfo[2]).deep.equal({ sw: { trace_id: parts[1], span_id: parts[2], trace_flags: parts[3] } })
   }
 }
 
@@ -126,7 +127,8 @@ function checkEventInfo1 (eventInfo, level, message, traceId) {
   expect(eventInfo[0]).equal(level, 'levels don\'t match')
   expect(eventInfo[1]).equal(message, 'messages don\'t match')
   if (traceId) {
-    expect(eventInfo[2]).deep.equal({ ao: { traceId } }, 'ao object doesn\'t match')
+    const parts = traceId.toString().split('-')
+    expect(eventInfo[2]).deep.equal({ sw: { trace_id: parts[1], span_id: parts[2], trace_flags: parts[3] } })
   }
 }
 //


### PR DESCRIPTION
## Overview

This pull request refactors Logging API and the logging probes (`bunyan`, `log4js`, `morgan`, `pino`, `winston`) that use said API.

### Replace `insertLogObject` API method with `getTraceObjecForLog`


Method is used in the logging probes.

It augments a passed object with additional keys. This is an anti-pattern.

`getTraceObjecForLog` will allow user (or probe developer) to get the log object (essentially the trace object but also with a "zeroed" option) and then decide what to do with it (which is usually just plugging it into the log object).

It pairs with `getTraceStringForLog` (renamed from `getLogString` to match naming of sibling method) that is introduced for text log insertion in https://github.com/appoptics/appoptics-apm-node/pull/228 

### Replace `insertTraceIdsIntoMorgan` configuration setting with `insertTraceIdsIntoLogs`

Currently there are two config options: `insertTraceIdsIntoLogs` and `insertTraceIdsIntoMorgan`.

The need for the second one is explained:

> Append trace IDs to morgan log lines. Because morgan does not output JSON the morgan formats must be modified to enable the trace IDs to be appended. This is a more invasive approach than inserting a property in a JSON object so it requires this explicit setting. The options are the same as for insertTraceIdsIntoLogs.

**Why is morgan “more invasive”?**

Yes, it’s the text insertion, but also the “auto logging”.

Usually when using a logger as-is the developer will explicitly log things (e.g. with `pino` or `log4js` one would/could place an explicit log command in the request handler say: `logger.info('hello world')`. `morgan` however is HTTP request logger middleware (mainly for `express`) - as such once `morgan` is "enabled", the logging happens without an explicit function call. The same functionality is provided by `log4js` and `pino` but it is done via an additional developer “step” (e.g. using something like [`express-pino-logger`](https://www.npmjs.com/package/express-pino-logger)).

**Why one var is enough?**

The only reason to have two config settings is for someone using two loggers in same application (this sounds a little over the top, but... *"this is ~~sparta~~ node.js!"*.).

However:
1. We provide the ability to enable/disable (and also register/deregister) specific probes. That option was added *after* the config setting was added. Thus, the user now has granular control of the probes via the config file that was not available when the original config was introduced. 
2. Additional instrumentation (`logs4js`) also modifies text output, thus this is no longer a "morgan only" capability.
3. `insertTraceIdsIntoLogs` is false by default. Trace in logs has to be explicitly enabled - so when enabling it - user can be expected to understand what is it that they enable...

### Tests

Tests where modified to use updated API.

All [tests pass](https://github.com/appoptics/appoptics-apm-node/actions/runs/1965669018).

### Notes:
- Pull Request merges into `nh-main` branch. Agent built from `master` will stay unchanged.
- Pull request is a second in three to revamp logging probes.