### PR TITLE
NH-9492-Refactor-Morgan-Probe

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -34,7 +34,6 @@ The configuration file can supply the following properties, showing their defaul
   runtimeMetrics: true,
   transactionSettings: undefined,
   insertTraceIdsIntoLogs: false,
-  createTraceIdsToken: undefined,
   proxy: undefined,
   probes: {
     // probe-specific defaults. see lib/probe-defaults.js for details
@@ -56,7 +55,6 @@ The configuration file can supply the following properties, showing their defaul
 |transactionSettings|`undefined`|An array of transactions to exclude. Each array element is an object of the form `{type: 'url', string: 'pattern', tracing: trace-setting}` or `{type: 'url', regex: /regex/, tracing: trace-setting}`. When the specified type (currently only `'url'` is implemented) matches the string or regex then tracing for that url is set to trace-setting, overriding the global traceMode. N.B. if inserting a regex into a JSON configuration file you must enter the string that is expected by the `RegExp` constructor because JSON has no representation of a `RegExp` object. `trace-setting` is either `'enabled'` or `'disabled'`.|
 |ec2MetadataTimeout|`1000`|Milliseconds to wait for the ec2/openstack metadata service to respond|
 |insertTraceIdsIntoLogs|`false`|Insert trace IDs into supported logging packages' output. Options are `true`, `'traced'`, `'sampledOnly'`, and `'always'`. The default, `false`, does not insert trace ids. `true` and `'traced'` insert the ID when AppOptics is tracing. `'sampledOnly'` inserts the ID when the trace is sampled. `'always'` inserts an empty trace ID value (all-zeroes) even when not tracing.|
-|createTraceIdsToken|`undefined`|Create a token that can be used in a logging package's format string. If set to `'morgan'` the token `sw-auto-trace-id` will be created and `:sw-auto-trace-id` can be used in morgan format strings.|
 |triggerTraceEnabled|`true`|Enable or disable the trigger-trace feature. Option values are `true` and `false`|
 
 

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -35,7 +35,6 @@ function getUnifiedConfig () {
     // end-user focused, config file only
     domainPrefix: { location: 'c', type: 'b' },
     insertTraceIdsIntoLogs: { location: 'c', type: 'b' },
-    createTraceIdsToken: { location: 'c', type: { morgan: 'morgan' } },
 
     // end-user focused, both env var and config file
     enabled: { location: 'b', type: 'b', default: true },

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,11 +145,6 @@ if (alreadyLoaded.length && ao.execEnv.nodeEnv === 'production') {
   log.warn('the following files were loaded before appoptics-apm:', alreadyLoaded)
 }
 
-// if inserting into morgan then a token must be created.
-if (config.insertTraceIdsIntoLogs) {
-  config.createTraceIdsToken = 'morgan'
-}
-
 //
 // there isn't really a better place to put this
 // it takes an http request object argument.

--- a/lib/probes/morgan.js
+++ b/lib/probes/morgan.js
@@ -12,7 +12,7 @@ module.exports = function (morgan, info) {
 
   // insertion into predefined formats is done by adding a token to the predefined format string
   // user can also use token in their own formats
-  const autoToken = ':sw-auto-trace-id'
+  const autoToken = ':trace'
 
   // morgan tokens are functions
   // define a token function at load time

--- a/lib/probes/morgan.js
+++ b/lib/probes/morgan.js
@@ -1,135 +1,42 @@
 'use strict'
 
 const ao = require('..')
+const shimmer = require('shimmer')
 
 const logMissing = ao.makeLogMissing('morgan')
 
-let token
-
-//
-// patch morgan so the arguments can be mucked with. this is a proxy
-// because 1) morgan is typically only called once or maybe twice and
-// 2) it will let us intercept token and format calls at some point if
-// we choose to do so.
-//
-module.exports = function (morgan) {
+module.exports = function (morgan, info) {
   if (!ao.probes.morgan.enabled) {
     return morgan
   }
 
-  const pmorgan = new Proxy(morgan, {
-    // call target/morgan as a function
-    apply (target, thisArg, argumentsList) {
-      if (ao.cfg.insertTraceIdsIntoLogs) {
-        argumentsList = tryInsertion(morgan, argumentsList)
-      } else if (ao.cfg.createTraceIdsToken === 'morgan') {
-        if (!token) {
-          token = createToken(morgan)
-        }
-      }
-      return Reflect.apply(morgan, thisArg, argumentsList)
-    }
+  // insertion into predefined formats is done by adding a token to the predefined format string
+  // user can also use token in their own formats
+  const autoToken = ':sw-auto-trace-id'
+
+  // morgan tokens are functions
+  // define a token function at load time
+  morgan.token(autoToken.slice(1), () => ao.getTraceStringForLog())
+
+  // do format modification
+  const predefineds = ['combined', 'common', 'short', 'tiny']
+  predefineds.forEach(predefined => {
+    morgan.format(predefined, `${morgan[predefined]} ${autoToken}`)
   })
 
-  return pmorgan
-}
+  if (typeof morgan.dev === 'function') {
+    // the dev predefined format is a compiled function. thus there is no access to the format string
+    // wrap it to modify function result
+    shimmer.wrap(morgan, 'dev', function (original) {
+      return function wrappedDev (tokens, req, res) {
+        const str = original.apply(this, arguments)
 
-//
-// token creation
-//
-const autoToken = ':sw-auto-trace-id'
-
-function createToken (morgan) {
-  return morgan.token(`${autoToken.slice(1)}`, () => ` ${ao.getTraceStringForLog()}`)
-}
-
-//
-// try to insert the trace ID. this is where morgan's various calling
-// sequences get decoded.
-//
-function tryInsertion (morgan, args) {
-  // make sure the token is defined
-  if (!token) {
-    token = createToken(morgan)
-  }
-
-  // the first argument can be a string name, a string format, or a custom format function.
-  // it can also be an options argument (deprecated).
-  //
-  // the following code is modeled directly after the morgan code to try to handle arguments
-  // as correctly as possible.
-  const [format, options] = args
-  let fmt = format
-  let opts = options || {}
-
-  if (format && typeof format === 'object') {
-    opts = format
-    fmt = opts.format || 'default'
-  }
-
-  if (fmt === undefined) {
-    fmt = 'default'
-  }
-
-  if (typeof fmt === 'function') {
-    // the caller is passing a custom format function
-    const wrapped = function () {
-      // generate the log line.
-      const string = fmt.apply(this, arguments)
-
-      return `${string} ${ao.getTraceStringForLog()}`
-    }
-    // substitute the wrapper for the caller's function.
-    args[0] = wrapped
-    args[1] = opts
-  } else if (fmt in morgan) {
-    // the format exists in morgan. it's kind of fragile though, morgan stores all
-    // tokens, formats, and it's own functions as properties on the morgan object so
-    // the fmt name could exist yet not be a format. but that's the way it works. if
-    // it's a function it could be a token, one of morgan's functions, or a compiled
-    // format. either way, all that can be done here is to wrap it. this is particularly
-    // true for the 'dev' format that is precompiled.
-    let needsWrapped = true
-    if (typeof morgan[fmt] === 'function') {
-      // dev is the only precompiled format so it's the only one that needs to be wrapped.
-      if (fmt === 'dev' && needsWrapped) {
-        const dev = morgan.dev
-        const wrapped = function () {
-          const string = dev.apply(this, arguments)
-          if (!string.endsWith(autoToken)) {
-            return `${string}${autoToken}`
-          }
-          return string
-        }
-        morgan[fmt] = wrapped
-        args[0] = 'dev'
-        args[1] = opts
-        needsWrapped = false
+        return `${str} ${ao.getTraceStringForLog()}`
       }
-    } else if (typeof fmt === 'string') {
-      // the format doesn't exist so this must be a format string or the property name for
-      // one of morgan's predefined format strings. that's the way morgan is going to interpret
-      // it regardless. that means that there is not going to be a referenceable function to
-      // wrap so the only way to insert our trace ID is to modify the format string by adding
-      // our token at the end. in this case modify the calling signature to the standard form
-      // of morgan('format', options) not matter how it was originally called.
-      if (typeof morgan[fmt] === 'string') {
-        if (!morgan[fmt].endsWith(autoToken)) {
-          morgan[fmt] = `${morgan[fmt]}${autoToken}`
-        }
-      } else {
-        // not sure we should do this. if the caller is supplying their own format they can
-        // insert :ao-trace-id on their own. if they choose not to should we be inserting it?
-        // TODO BAM note - this also applies to calling 'morgan.format' to define a format.
-        // args[0] = `${fmt} ao.traceId=:ao-trace-id`;
-        // args[1] = opts;
-        ao.loggers.debug('morgan.tryInsertion() - no action taken')
-      }
-    } else {
-      logMissing(`expected fmt type (got ${typeof fmt})`)
-    }
+    })
+  } else {
+    logMissing('dev')
   }
 
-  // return the possibly modified args.
-  return args
+  return morgan
 }

--- a/test/get-unified-config.test.js
+++ b/test/get-unified-config.test.js
@@ -265,13 +265,12 @@ describe('get-unified-config', function () {
     })
 
     it('should not set keys with invalid values', function () {
-      const config = { ec2MetadataTimeout: 'hello', createTraceIdsToken: 'bruce' }
+      const config = { ec2MetadataTimeout: 'hello' }
       writeConfigJSON(config)
 
       const cfg = guc()
 
       const warnings = [
-        'invalid configuration file value createTraceIdsToken: bruce',
         'invalid configuration file value ec2MetadataTimeout: hello'
       ]
       doChecks(cfg, { warnings })
@@ -288,7 +287,6 @@ describe('get-unified-config', function () {
         '  domainPrefix: false,',
         '  serviceKey,',
         '  insertTraceIdsIntoLogs: undefined,',
-        '  createTraceIdsToken: false,',
         '  probes: {',
         '    fs: {',
         '      enabled: true',
@@ -313,7 +311,6 @@ describe('get-unified-config', function () {
       const cfg = guc()
 
       const warnings = [
-        'invalid configuration file value createTraceIdsToken: false',
         'traceMode is deprecated; it will be invalid in the future'
       ]
       const overrides = {

--- a/test/probes/morgan.test.js
+++ b/test/probes/morgan.test.js
@@ -20,36 +20,20 @@ const { EventEmitter } = require('events')
 
 let debugging = false
 
-function checkEventInfo (eventInfo, req, res, traceId) {
-  const method = req.method
-  const url = req.url
-  const status = res.statusCode
-
-  if (debugging) {
-    console.log('checkEventInfo()', eventInfo)
-  }
-
-  const reString = `${method} ${url} ${status} 42 - \\d+\\.\\d{3} ms( (trace_id=[a-f0-9]{32} span_id=[a-f0-9]{16} trace_flags=0(0|1)))?`
+function checkEventInfo (eventInfo, level, message, traceId) {
+  // console.log(eventInfo)
+  const reString = 'trace_id=[a-f0-9]{32} span_id=[a-f0-9]{16} trace_flags=0(0|1)'
   const re = new RegExp(reString)
   const m = eventInfo.match(re)
-
-  // output some debugging help if these don't match
-  if (!m) {
-    console.log('eventInfo', eventInfo, 'match', m)
-  }
-
-  expect(m).ok
-  expect(m.length).equal(4)
-
   if (traceId) {
     const parts = traceId.split('-')
-    expect(m[2]).equal(`trace_id=${parts[1]} span_id=${parts[2]} trace_flags=${parts[3]}`)
-    expect(m[3]).ok
+    expect(m[0]).equal(`trace_id=${parts[1]} span_id=${parts[2]} trace_flags=${parts[3]}`)
   } else {
-    expect(m[2]).not.ok
-    expect(m[3]).not.ok
+    expect(m).equal(null)
   }
 }
+
+const insertModes = [false, true, 'traced', 'sampledOnly', 'always']
 
 //
 // create a fake stream that emits the object to be logged so it can be checked.
@@ -72,8 +56,6 @@ class TestStream extends EventEmitter {
     }
   }
 }
-
-const insertModes = [false, true, 'traced', 'sampledOnly', 'always']
 
 //= ================================
 // morgan tests
@@ -279,29 +261,194 @@ describe(`probes.morgan ${version}`, function () {
   })
 
   //
-  // for each mode verify that insert works in sampled code
+  // for each mode verify that insert works with predefined strings
+  //
+  const predefineds = ['combined', 'common', 'short', 'tiny']
+  predefineds.forEach(predefined => {
+    insertModes.forEach(mode => {
+      const maybe = mode === false ? 'not ' : ''
+      eventInfo = undefined
+
+      it(`should ${maybe}insert in sync sampled code when mode=${mode} using ${predefined}`, function (done) {
+        let traceId
+
+        // this gets reset in beforeEach() so set it in the test.
+        ao.cfg.insertTraceIdsIntoLogs = mode
+        logger = makeLogger(predefined)
+
+        function localDone () {
+          checkEventInfo(eventInfo, fakeReq, fakeRes, mode === false ? undefined : traceId)
+          done()
+        }
+
+        helper.test(emitter, function (done) {
+          ao.instrument(spanName, function () {
+            traceId = ao.requestStore.get('topSpan').events.exit.event.toString()
+            // log
+            logger(fakeReq, fakeRes, function (err) {
+              expect(err).not.ok
+            })
+            fakeRes.writeHead(200)
+            fakeRes.finished = true
+          })
+          done()
+        }, [
+          function (msg) {
+            msg.should.have.property('Layer', spanName)
+            msg.should.have.property('Label', 'entry')
+          },
+          function (msg) {
+            msg.should.have.property('Layer', spanName)
+            msg.should.have.property('Label', 'exit')
+          }
+        ], localDone)
+      })
+    })
+  })
+
+  //
+  // for each mode verify that insert works with predefined string dev (referring a function)
   //
   insertModes.forEach(mode => {
     const maybe = mode === false ? 'not ' : ''
     eventInfo = undefined
 
-    it(`should ${maybe}insert in when mode=${mode} using a format function`, function (done) {
+    it(`should ${maybe}insert in sync sampled code when mode=${mode} using dev precomplied`, function (done) {
       let traceId
 
       // this gets reset in beforeEach() so set it in the test.
       ao.cfg.insertTraceIdsIntoLogs = mode
-      logger = makeLogger(function () { return 'xyzzy' })
+      logger = makeLogger('dev')
 
       function localDone () {
-        const parts = traceId.split('-')
-        const expected = mode === false ? '' : ` trace_id=${parts[1]} span_id=${parts[2]} trace_flags=${parts[3]}`
-        expect(eventInfo).equal(`xyzzy${expected}\n`)
+        checkEventInfo(eventInfo, fakeReq, fakeRes, mode === false ? undefined : traceId)
         done()
       }
 
       helper.test(emitter, function (done) {
         ao.instrument(spanName, function () {
           traceId = ao.requestStore.get('topSpan').events.exit.event.toString()
+          // log
+          logger(fakeReq, fakeRes, function (err) {
+            expect(err).not.ok
+          })
+          fakeRes.writeHead(200)
+          fakeRes.finished = true
+        })
+        done()
+      }, [
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'entry')
+        },
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'exit')
+        }
+      ], localDone)
+    })
+  })
+
+  //
+  // for each mode verify that insert works with format string
+  //
+  insertModes.forEach(mode => {
+    const maybe = mode === false ? 'not ' : ''
+    eventInfo = undefined
+
+    it(`should ${maybe}insert in sync when mode=${mode} using a format string`, function (done) {
+      let traceId
+
+      // this gets reset in beforeEach() so set it in the test.
+      ao.cfg.insertTraceIdsIntoLogs = mode
+      logger = makeLogger(':method :sw-auto-trace-id :url :status :res[content-length]')
+
+      function localDone () {
+        checkEventInfo(eventInfo, fakeReq, fakeRes, mode === false ? undefined : traceId)
+        done()
+      }
+
+      helper.test(emitter, function (done) {
+        ao.instrument(spanName, function () {
+          traceId = ao.requestStore.get('topSpan').events.exit.event.toString()
+          // log
+          logger(fakeReq, fakeRes, function (err) {
+            expect(err).not.ok
+          })
+          fakeRes.writeHead(200)
+          fakeRes.finished = true
+        })
+        done()
+      }, [
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'entry')
+        },
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'exit')
+        }
+      ], localDone)
+    })
+  })
+
+  //
+  // for each mode verify that insert works with format string when no insertion is requested
+  //
+  insertModes.forEach(mode => {
+    eventInfo = undefined
+
+    it(`should never insert in sync when mode=${mode} using a format string and no insertion is requested`, function (done) {
+      // this gets reset in beforeEach() so set it in the test.
+      ao.cfg.insertTraceIdsIntoLogs = mode
+      logger = makeLogger(':method :url :status :res[content-length]')
+
+      function localDone () {
+        checkEventInfo(eventInfo, fakeReq, fakeRes, null)
+        done()
+      }
+
+      helper.test(emitter, function (done) {
+        ao.instrument(spanName, function () {
+          // log
+          logger(fakeReq, fakeRes, function (err) {
+            expect(err).not.ok
+          })
+          fakeRes.writeHead(200)
+          fakeRes.finished = true
+        })
+        done()
+      }, [
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'entry')
+        },
+        function (msg) {
+          msg.should.have.property('Layer', spanName)
+          msg.should.have.property('Label', 'exit')
+        }
+      ], localDone)
+    })
+  })
+
+  //
+  // for each mode verify that insert works with format function
+  //
+  insertModes.forEach(mode => {
+    eventInfo = undefined
+
+    it(`should never insert in sync when mode=${mode} using a format function`, function (done) {
+      // this gets reset in beforeEach() so set it in the test.
+      ao.cfg.insertTraceIdsIntoLogs = mode
+      logger = makeLogger(function () { return 'xyzzy' })
+
+      function localDone () {
+        checkEventInfo(eventInfo, fakeReq, fakeRes, null)
+        done()
+      }
+
+      helper.test(emitter, function (done) {
+        ao.instrument(spanName, function () {
           // log
           logger(fakeReq, fakeRes, function (err) {
             expect(err).not.ok
@@ -428,21 +575,16 @@ describe(`probes.morgan ${version}`, function () {
   })
 
   it('should insert trace IDs using the function directly', function (done) {
-    ao.cfg.insertTraceIdsIntoLogs = false
+    // test does not have last span - thus force a "zeroed" trace id
+    ao.cfg.insertTraceIdsIntoLogs = 'always'
     let traceId
 
     logger = makeLogger('traceThis::my-trace-id')
 
-    const myTraceId = () => {
-      const parts = ao.lastEvent ? ao.lastEvent.toString().split('-') : ['00', '0'.repeat(32), '0'.repeat(16), '0'.repeat(2)]
-      return `trace_id=${parts[1]} span_id=${parts[2]} trace_flags=${parts[3]}`
-    }
-    morgan.token('my-trace-id', myTraceId)
+    morgan.token('my-trace-id', () => ao.getTraceStringForLog())
 
     function localDone () {
-      const parts = traceId.split('-')
-      const expected = `trace_id=${parts[1]} span_id=${parts[2]} trace_flags=${parts[3]}`
-      expect(eventInfo).equal(`traceThis:${expected}\n`)
+      checkEventInfo(eventInfo, fakeReq, fakeRes, traceId)
       done()
     }
 

--- a/test/probes/morgan.test.js
+++ b/test/probes/morgan.test.js
@@ -361,7 +361,7 @@ describe(`probes.morgan ${version}`, function () {
 
       // this gets reset in beforeEach() so set it in the test.
       ao.cfg.insertTraceIdsIntoLogs = mode
-      logger = makeLogger(':method :sw-auto-trace-id :url :status :res[content-length]')
+      logger = makeLogger(':method :trace :url :status :res[content-length]')
 
       function localDone () {
         checkEventInfo(eventInfo, fakeReq, fakeRes, mode === false ? undefined : traceId)


### PR DESCRIPTION
## Overview

This pull request refactors the `morgan` probe.

## Issues

- Probe is implemented in a unique manner using a Proxy. It does not use the [shimmer third party package](https://www.npmjs.com/package/shimmer) used by all other probes. It’s a nice concept, but it “breaks the pattern”.
- Probe uses a probe specific config `createTraceIdsToken` that is conditionally nested under (now deprecated) `insertTraceIdsIntoMorgan`, a pattern none of the other probes use. The need for that specific setting is also unclear as creating a morgan token is part of the "normal flow" of instrumentation.
- Trace data insertion into predefined format is done with a token, but is then unnecessarily conditionally checked each time logging is invoked.
- Trace insertion into the predefined dev format (which is a compiled function) does not actually work.
- Does not have test coverage for all config options (cases), hence test pass, but should not.
- Tests test for things that are test specific and those may change when all config options are tested.

## Refactor Implementation

Implementation greatly simplifies how the probe works.

When the morgan probe is enabled, at patch time, and regardless of `insertTraceIdsIntoLogs` setting, a morgan token named :`trace` is created. It is used for all insertions, both automatic and and user defined (see below).

Because the dev predefined format is a compiled function, there is no access to the format string. To archive insertion the function is patched.

User defined format strings and functions are untouched.

### Usage

When enabled and inserting the probe will append a space delimited trace data string to the end of pre predefined layout types. 
For example, using the `combined` layout: 
- `::ffff:172.27.0.1 - - [10/Mar/2022:19:39:46 +0000] "GET / HTTP/1.1" 200 - "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36"` 

will become:
- `::ffff:172.27.0.1 - - [10/Mar/2022:19:39:46 +0000] "GET / HTTP/1.1" 200 - "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36" trace_id=1331bc8c4d2eb26343234948e2ce3ac8 span_id=3588288099552501 trace_flags=01`.

When the user is using a string pattern the probe will respect their pattern (and skill) and will **NOT** append the trace to the end of the log line. User can use the `:trace` token in custom format strings (e.g. `:method :url :trace`) to add the trace data, as well as in custom functions (e.g. `tokens.trace()`).

### Configuration 

Probe has basic configuration values that are set in a manner **similar to all other logging probes**.

 ```enabled: true```

 It obeys the global config ```insertTraceIdsIntoLogs: false``` see: [Configuration Guide](https://github.com/appoptics/appoptics-apm-node/blob/NH-5459-Support-Trace-ID-Insertion-for-log4js/CONFIGURATION.md)

### Tests

Test coverage was significantly increased and test setup has been (mildly) simplified.

All [tests pass](https://github.com/appoptics/appoptics-apm-node/runs/5514511552?check_suite_focus=true).

Integration testing is done using a [simple app](https://github.com/appoptics/node-instrumented/tree/main/morgan) that performs logging operations with multiple configurations. Those include all predefined configurations (including precompiled `dev`), configuration using a custom string pattern (with and without token), and configuration using a custom function (with and without using the token method).

### Notes:
- Pull Request merges into `nh-main` branch. Agent built from `master` will stay unchanged.