### PR TITLE
AO-20917-Patch

### DIFF
--- a/lib/span.js
+++ b/lib/span.js
@@ -839,6 +839,18 @@ function isRealObject (v) {
 Span.prototype.error = function (error) {
   log.span(`span.error on ${this.name}`)
 
+  // when there is an aborted incoming request (e.g. user pressed stop in their browser)
+  // the error will be on top span and there will be no lastEvent.
+  // (note:there can also be an aborted connection on an outgoing request on a lower span)
+  // reporting error (via _internal method of span) without lastEvent will fail.
+  // that failure will create an error level log entry.
+  // logging an "error in reporting an error" is too much and leads to end user confusion.
+  // thus, log the issue at the span level and return gracefully.
+  if (this.topSpan && error && error.code === 'ECONNRESET') {
+    log.span('Connection reset', error)
+    return
+  }
+
   try {
     const orig = error
     error = Span.toError(error)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "10.2.1",
+  "version": "10.2.2-internal.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "10.2.1",
+  "version": "10.2.2-internal.0",
   "appoptics": {
     "version-suffix": "lambda-1"
   },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "amqplib": "^0.8.0",
     "appoptics-auto-lambda": "git+https://github.com/appoptics/apm-node-auto-lambda.git#2130a7b8be77fe3689edef9007552dfbdd903f7b",
     "aws-sdk": "^2.440.0",
-    "axios": "^0.21.4",
+    "axios": "^0.26.1",
     "bcrypt": "^5.0.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.18.3",

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -627,6 +627,35 @@ describe(`probes.${p}`, function () {
     })
 
     //
+    // Test error when connection is aborted
+    //
+    it('should gracefully exit with no error when connection is aborted', function (done) {
+      let port
+      const server = createServer(options, function (req, res) {
+        // server will never response and client will abort after 500 ms
+      })
+
+      helper.doChecks(emitter, [
+        // there will only be an entry event as there is no response
+        function (msg) {
+          check.server.entry(msg)
+        }
+      ], function () {
+        server.close(done)
+      })
+
+      const controller = new AbortController()
+      server.listen(function () {
+        port = server.address().port
+        axios(`${p}://localhost:${port}/foo?bar=baz`, { signal: controller.signal })
+        setTimeout(() => {
+          // cancel the request
+          controller.abort()
+        }, 500)
+      })
+    })
+
+    //
     // Validate that server.setTimeout(...) exits correctly
     //
     it('should exit when timed out', function (done) {


### PR DESCRIPTION
## Overview
This pull request modifies the span error reporting behavior  so that it will not log an error when a connection is aborted by user.

## Status
- Currently when there is an aborted incoming request (e.g. user pressed stop in their browser) the error (`ECONNRESET`) will be on the top span and there will be no lastEvent (note that there can also be a case of an aborted connection on an outgoing request on a lower span).
- Reporting error without lastEvent will fail, and that failure will create an error level log entry: `appoptics:error nodejs span error call could not find last event`
- Logging an "error in reporting an error" is too much and leads to end user confusion.

## Change
The above issue is now logged at the `span` level and terminates gracefully.