### PR TITLE
AO-21093-Update-Dependencies-to-Latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "cls-hooked": "^4.2.2",
     "debug-custom": "^1.1.0",
     "glob": "^7.0.3",
-    "methods": "~1.1.0",
+    "methods": "^1.1.2",
     "minimist": "^1.2.6",
     "semver": "^7.3.5",
     "shimmer": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "glob": "^7.0.3",
     "methods": "~1.1.0",
     "minimist": "^1.2.6",
-    "semver": "^7.3.2",
+    "semver": "^7.3.5",
     "shimmer": "^1.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "array-flatten": "^2.1.2",
     "cls-hooked": "^4.2.2",
     "debug-custom": "^1.1.0",
-    "glob": "^7.0.3",
+    "glob": "^7.2.0",
     "methods": "^1.1.2",
     "minimist": "^1.2.6",
     "semver": "^7.3.5",


### PR DESCRIPTION
## Overview

This pull request upgrades dependencies to latest where available and possible.
Updated:
- `semver` to `7.3.5`
- `methods` to `1.1.2`
- `glob` to `7.2.0`


## Notes
- Since these are dependencies, a patch release of agent is warranted.
- `array-flatten` is “stuck” at `2.1.2`. Latest at `3.0.0` is breaking. Dependency removed for in `nh-main` branch.