### PR TITLE
NH-11224-Gracefully-Disable-Lambda-Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "appoptics-apm",
   "version": "10.2.2-nh.0",
-  "appoptics": {
-    "version-suffix": "lambda-1"
-  },
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "bin": {
@@ -63,7 +60,6 @@
     "@hapi/hapi": "^20.1.5",
     "@hapi/vision": "^6.1.0",
     "amqplib": "^0.8.0",
-    "appoptics-auto-lambda": "git+https://github.com/appoptics/apm-node-auto-lambda.git#2130a7b8be77fe3689edef9007552dfbdd903f7b",
     "aws-sdk": "^2.1057.0",
     "axios": "^0.26.1",
     "bcrypt": "^5.0.0",

--- a/test.sh
+++ b/test.sh
@@ -39,6 +39,7 @@ SUITES_SKIPPED=0
 # it's best to start with "test/" and provide as much of the path as possible.
 SKIP="test/a-test-you-might-want-to-skip $SKIP"
 SKIP="test/lambda/remote $SKIP" # timeout too long to run with group
+SKIP="test/lambda/local $SKIP" # timeout too long to run with group
 
 skipThis() {
   for s in $SKIP


### PR DESCRIPTION
## Overview

The lambda implementation suffers form several issues (AO-19620, AO-19603, AO-19911, AO-20761) and thus serverless support would not initially ship for `solarwinds-apm`.

## Change

This pull request removes:
- The version suffix used by lambda from package.json. 
- The `appoptics-auto-lambda` dependency from package.json
- Skips lambda tests.

All other lambda related functionality, added in #124, #127, #131, #143 is left as-is.

## Notes
- Pull Request merges into `nh-main` branch. Bindings built from `master` will stay unchanged.
- Functionality also gracefully disabled in bindings https://github.com/appoptics/appoptics-bindings-node/pull/109