### PR TITLE
NH-5414-Update-Dependencies-devDependencies-3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "cls-hooked": "^4.2.2",
         "debug-custom": "^1.1.0",
         "glob": "^7.2.0",
-        "minimist": "^1.2.6",
         "semver": "^7.3.5",
         "shimmer": "^1.2.1"
       },
@@ -59,6 +58,7 @@
         "log4js": "^6.4.2",
         "memcached": "^2.2.2",
         "method-override": "^2.3.10",
+        "minimist": "^1.2.6",
         "mkdirp": "^0.5.1",
         "mocha": "^9.1.3",
         "mongodb": "^3.7.0",
@@ -6419,7 +6419,8 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/minipass": {
       "version": "3.1.6",
@@ -15367,7 +15368,8 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "minipass": {
       "version": "3.1.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "cls-hooked": "^4.2.2",
     "debug-custom": "^1.1.0",
     "glob": "^7.2.0",
-    "minimist": "^1.2.6",
     "semver": "^7.3.5",
     "shimmer": "^1.2.1"
   },
@@ -98,6 +97,7 @@
     "log4js": "^6.4.2",
     "memcached": "^2.2.2",
     "method-override": "^2.3.10",
+    "minimist": "^1.2.6",
     "mkdirp": "^0.5.1",
     "mocha": "^9.1.3",
     "mongodb": "^3.7.0",


### PR DESCRIPTION
### Overview:

This pull request removes `minimist` from dependencies and moving it to devDependencies (where it is only used for utility by the, currently gracefully disabled, lambda implementation).

`minimist` was added as dependency in https://github.com/appoptics/appoptics-apm-node/commit/ce5890d2ab0e8be98b7ebae047c32f3c3de74e2f

### Status:

Need for package was removed in #241

### Notes:
- Pull Request merges into `nh-main`. Agent built from `master` will maintain dependency`.