### PR TITLE
AO-21089-Patch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -263,16 +263,14 @@ if (env.AO_CONTEXT in contextProviders) {
   ao.contextProvider = contextProviders.aceContext
 }
 
-if (enabled) {
-  log.debug('using context provider:', ao.contextProvider)
-  // load the context provider
-  try {
-    ao.cls = require(ao.contextProvider)
-  } catch (e) {
-    enabled = false
-    log.error('Can\'t load %s', ao.contextProvider, e.stack)
-    errors.push('context provider not loaded')
-  }
+log.debug('using context provider:', ao.contextProvider)
+// load the context provider
+try {
+  ao.cls = require(ao.contextProvider)
+} catch (e) {
+  enabled = false
+  log.error('Can\'t load %s', ao.contextProvider, e.stack)
+  errors.push('context provider not loaded')
 }
 
 //

--- a/test.sh
+++ b/test.sh
@@ -124,6 +124,11 @@ if [ "$group_to_run" = "CORE" ] || [ ! "$group_to_run" ]; then executeTestGroup 
 if [ "$group_to_run" = "NO-ADDON" ] || [ ! "$group_to_run" ]; then executeTestGroup "NO-ADDON" "test/no-addon/*.test.js" "$timeout"; fi
 
 #
+# run unit tests without the addon disabled
+#
+if [ "$group_to_run" = "NO-SERVICE-KEY" ] || [ ! "$group_to_run" ]; then executeTestGroup "NO-SERVICE-KEY" "test/no-service-key/*.test.js" "$timeout"; fi
+
+#
 # originally these tests were the only ones to run one-at-a-time
 # because it's not possible to change the oboe logging level after
 # initialization time. now they don't really need to be separate.

--- a/test/no-service-key/custom.test.js
+++ b/test/no-service-key/custom.test.js
@@ -1,7 +1,7 @@
 /* global it, describe */
 'use strict'
 
-process.env.AO_TEST_NO_BINDINGS = '1'
+process.env.APPOPTICS_SERVICE_KEY = ''
 
 const ao = require('../..')
 const aob = ao.addon
@@ -18,9 +18,9 @@ function psoon () {
 
 const xtrace = '2B4FC9017BA3404828F253638A697DC7CF1A6BB1A4A544D5B98159B55501'
 
-// Without the native liboboe bindings present,
+// Without the service key present,
 // the custom instrumentation should be a no-op
-describe('custom (without native bindings present)', function () {
+describe('custom (without service key present)', function () {
   it('should have a bindings version of \'not loaded\'', function () {
     assert(ao.addon.version === 'not loaded')
   })
@@ -137,9 +137,9 @@ describe('custom (without native bindings present)', function () {
     assert(typeof o === 'object')
     assert(Object.keys(o).length === 0)
 
-    o = ao.insertLogObject({ existing: 'bruce' })
+    o = ao.insertLogObject({ existing: 'ron' })
     assert(typeof o === 'object')
     assert(Object.keys(o).length === 1)
-    assert(o.existing === 'bruce')
+    assert(o.existing === 'ron')
   })
 })


### PR DESCRIPTION
## Overview
This pull request modifies the conditions under which the context store package is required in order to fix errors experienced by users.

## Status

- When the agent is disabled (for any number of reasons), auto instrumentation probes are *not* loaded. 

-  Custom instrumentation however may be written in such a way that it is called even when the agent is disabled. The agent thus provides an ["api simulator"](https://github.com/appoptics/appoptics-apm-node/blob/AO-21089-Patch/lib/api-sim.js) with a signature similar to that of the "real" api. That "api simulator" is [loaded instead of the "real" api](https://github.com/appoptics/appoptics-apm-node/blob/AO-21089-Patch/lib/index.js#L364) when the agent is initialized.

- To maintain context during async operations the agent relies on a 3rd party package. The [api](https://github.com/appoptics/appoptics-apm-node/blob/AO-21089-Patch/lib/api.js#L248), and [api-sim](https://github.com/appoptics/appoptics-apm-node/blob/AO-21089-Patch/lib/api-sim.js#L155), are dependent on that package.

- Currently the package is **not** loaded when the agent is disabled. As a result **context store operations using the api-sim result in an error*.*

- Customer reported getting `"TypeError: Cannot read properties of undefined (reading 'getNamespace')","    at Object.get (/opt/****/****/node_modules/appoptics-apm/lib/api-sim.js:155:25)"` when running custom instrumentation without supplying a Service Key.


## History

- Originally the context store was always loaded.

- In 5173825d1ffd4882fd54e68b579472fa191aa074 a comment was added ["// TODO BAM consider not loading these at all if not enabled."](https://github.com/appoptics/appoptics-apm-node/commit/5173825d1ffd4882fd54e68b579472fa191aa074#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R258)


- In 258c8ecfed4dc924fdd8a44b5728ee23f027adb0 the conditional was implemented. [put context provider loading behind "enabled"](https://github.com/appoptics/appoptics-apm-node/commit/258c8ecfed4dc924fdd8a44b5728ee23f027adb0#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R271)

- Implementation of conditional was merged in #124, and shipped in [v9.1.0-lambda-1](https://github.com/appoptics/appoptics-apm-node/releases/tag/v9.1.0-lambda-1)


## Change

The conditional that put context provider loading behind "enabled" has been removed. Context provider is now always loaded including when the agent is disabled, thus allowing the api-sim to function correctly.