### PR TITLE
NH-13411-Add-SQL-Sanitization-Code

### DIFF
--- a/lib/addon-sim.js
+++ b/lib/addon-sim.js
@@ -109,14 +109,6 @@ const addon = {
       }
     }
   },
-  Notifier: {
-    init () { return 0 }, // OK
-    stop () { return -1 }, // DISABLED
-    status () { return -1 }
-  },
-  Sanitizer: {
-    sanitize (s) { return s }
-  },
   Config: {
     getVersionString () { return 'not loaded' },
     getSettings () { return {} }

--- a/lib/probes/cassandra-driver.js
+++ b/lib/probes/cassandra-driver.js
@@ -4,9 +4,9 @@ const requirePatch = require('../require-patch')
 const shimmer = require('shimmer')
 const semverSatisfies = require('semver/functions/satisfies')
 const ao = require('..')
-const Sanitizer = ao.addon.Sanitizer
-const conf = ao.probes['cassandra-driver']
+const sqlSanitizer = require('../sql-sanitizer')
 
+const conf = ao.probes['cassandra-driver']
 const logMissing = ao.makeLogMissing('cassandra-driver')
 
 module.exports = function (cassandra, info) {
@@ -374,5 +374,5 @@ function maybeSanitizeList (queries) {
 }
 
 function sanitize (query) {
-  return Sanitizer.sanitize(query, Sanitizer.OBOE_SQLSANITIZE_KEEPDOUBLE)
+  return sqlSanitizer.sanitize(query)
 }

--- a/lib/probes/mysql.js
+++ b/lib/probes/mysql.js
@@ -3,6 +3,7 @@
 const shimmer = require('shimmer')
 const ao = require('..')
 const sqlTraceContext = require('../sql-trace-context')
+const sqlSanitizer = require('../sql-sanitizer')
 
 const conf = ao.probes.mysql
 const logMissing = ao.makeLogMissing('mysql')
@@ -124,7 +125,7 @@ function patchClient (proto, Query) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? ao.addon.Sanitizer.sanitize(queryStatment, ao.addon.Sanitizer.OBOE_SQLSANITIZE_KEEPDOUBLE)
+          ? sqlSanitizer.sanitize(queryStatment)
           : queryStatment
 
         // only set queryArgs when not sanitizing

--- a/lib/probes/node-cassandra-cql.js
+++ b/lib/probes/node-cassandra-cql.js
@@ -3,9 +3,9 @@
 const shimmer = require('shimmer')
 const semver = require('semver')
 const ao = require('..')
-const Sanitizer = ao.addon.Sanitizer
-const conf = ao.probes['node-cassandra-cql']
+const sqlSanitizer = require('../sql-sanitizer')
 
+const conf = ao.probes['node-cassandra-cql']
 const logMissing = ao.makeLogMissing('cassandra')
 
 module.exports = function (cassandra, info) {
@@ -113,9 +113,8 @@ function patchClientExecutors (proto, methods, consistencies) {
 
       // If no args list has been supplied, assume the worst...
       if (conf.sanitizeSql) {
-        kvpairs.Query = Sanitizer.sanitize(
-          kvpairs.Query,
-          Sanitizer.OBOE_SQLSANITIZE_KEEPDOUBLE
+        kvpairs.Query = sqlSanitizer.sanitize(
+          kvpairs.Query
         )
 
         // Keyspace is planned to be an alternative to Database.

--- a/lib/probes/oracledb.js
+++ b/lib/probes/oracledb.js
@@ -3,6 +3,7 @@
 const shimmer = require('shimmer')
 const ao = require('..')
 const sqlTraceContext = require('../sql-trace-context')
+const sanitizer = require('../sql-sanitizer')
 
 const conf = ao.probes.oracledb
 const logMissing = ao.makeLogMissing('oracledb')
@@ -161,7 +162,7 @@ function patchMethod (conn, method, oracledb, options) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? ao.addon.Sanitizer.sanitize(maybeQuery(method, queryStatment), ao.addon.Sanitizer.OBOE_SQLSANITIZE_KEEPDOUBLE)
+          ? sanitizer.sanitize(maybeQuery(method, queryStatment))
           : queryStatment
 
         // only set queryArgs when not sanitizing

--- a/lib/probes/pg.js
+++ b/lib/probes/pg.js
@@ -3,6 +3,7 @@
 const shimmer = require('shimmer')
 const ao = require('..')
 const sqlTraceContext = require('../sql-trace-context')
+const sqlSanitizer = require('../sql-sanitizer')
 
 const conf = ao.probes.pg
 const logMissing = ao.makeLogMissing('pg')
@@ -123,7 +124,7 @@ function patchClientQuery (client) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? ao.addon.Sanitizer.sanitize(queryStatment, ao.addon.Sanitizer.OBOE_SQLSANITIZE_KEEPDOUBLE)
+          ? sqlSanitizer.sanitize(queryStatment)
           : queryStatment
 
         // only set queryArgs when not sanitizing, trimming large values

--- a/lib/probes/tedious.js
+++ b/lib/probes/tedious.js
@@ -3,6 +3,7 @@
 const shimmer = require('shimmer')
 const ao = require('..')
 const sqlTraceContext = require('../sql-trace-context')
+const sqlSanitizer = require('../sql-sanitizer')
 
 const conf = ao.probes.tedious
 const logMissing = ao.makeLogMissing('tedious')
@@ -83,7 +84,7 @@ function patchMakeRequest (connection) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? ao.addon.Sanitizer.sanitize(queryStatment, ao.addon.Sanitizer.OBOE_SQLSANITIZE_KEEPDOUBLE)
+          ? sqlSanitizer.sanitize(queryStatment)
           : queryStatment
 
         // only set queryArgs when not sanitizing

--- a/lib/sql-sanitizer.js
+++ b/lib/sql-sanitizer.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/* exportable */
+
+const sanitize = (sql) => {
+  return sql
+  // sanitize single quoted strings
+
+    // match any use of apostrophe inside a single quoted string
+    // to detect such, look for a word with optionally space or apostrophe after
+    .replace(/'\w+\s?'?''?\s?\w+'/ig, '?')
+    // match any single quoted string
+    .replace(/'[^']*'/ig, '?')
+    // aggressively cleanup of (mostly invalid) apostrophe used in single quoted SQL values
+    .replace(/\?(.*?)'/ig, '?')
+    .replace(/\?(.*?)\?\?/ig, '?')
+    .replace(/\?\w+/ig, '?')
+
+  // sanitize digits
+
+    // match digits attached to space, comma, equal or open parentheses or dot
+    // will not touch digits attached to alphanumeric chars
+    .replace(/[ ,=(.]\d+/ig, (match) => match[0] + '?')
+}
+
+module.exports = {
+  sanitize
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appoptics-apm",
-  "version": "11.0.0-nh.0",
+  "version": "11.0.0-nh.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appoptics-apm",
-      "version": "11.0.0-nh.0",
+      "version": "11.0.0-nh.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ace-context": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "11.0.0-nh.0",
+  "version": "11.0.0-nh.1",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "files": [

--- a/test/probes/cassandra-driver.test.js
+++ b/test/probes/cassandra-driver.test.js
@@ -222,7 +222,7 @@ describe('probes.cassandra-driver ' + pkg.version, function () {
     helper.test(emitter, helper.run(ctx, 'cassandra-driver/sanitize'), [
       function (msg) {
         checks.entry(msg)
-        msg.should.have.property('Query', 'SELECT * from foo where bar=\'?\'')
+        msg.should.have.property('Query', 'SELECT * from foo where bar=?')
       },
       function (msg) {
         checks.info(msg)
@@ -292,7 +292,7 @@ describe('probes.cassandra-driver ' + pkg.version, function () {
         function (msg) {
           checks.entry(msg)
           msg.should.have.property('Query', 'BATCH')
-          msg.should.have.property('BatchQueries', '["INSERT INTO foo (bar) values (?)","INSERT INTO foo (bar) values (\'?\')"]')
+          msg.should.have.property('BatchQueries', '["INSERT INTO foo (bar) values (?)","INSERT INTO foo (bar) values (?)"]')
           msg.should.not.have.property('BatchQueryArgs')
         },
         function (msg) {

--- a/test/probes/mysql.test.js
+++ b/test/probes/mysql.test.js
@@ -335,7 +335,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
     }, [
       function (msg) {
         checks.entry(msg)
-        msg.should.have.property('Query', `SELECT * FROM ${ctx.t} WHERE "foo" = '?'`)
+        msg.should.have.property('Query', `SELECT * FROM ${ctx.t} WHERE "foo" = ?`)
       },
       function (msg) {
         checks.exit(msg)

--- a/test/probes/oracledb.test.js
+++ b/test/probes/oracledb.test.js
@@ -124,7 +124,7 @@ describe(`probes.oracledb ${pkg.version}`, function () {
     }, [
       function (msg) {
         checks['oracle-entry'](msg)
-        msg.should.have.property('Query', 'SELECT 0 FROM DUAL')
+        msg.should.have.property('Query', 'SELECT ? FROM DUAL')
         msg.should.not.have.property('QueryArgs')
       },
       function (msg) {

--- a/test/probes/pg/subtests.js
+++ b/test/probes/pg/subtests.js
@@ -131,7 +131,7 @@ module.exports = function (ao, ctx) {
   //
   // test sanitize
   //
-  const sanitizeQuery = `select * from "${ctx.tName}" where "foo" = '?'`
+  const sanitizeQuery = `select * from "${ctx.tName}" where "foo" = ?`
   const sanitizeChecks = [
     function (msg) {
       checks.entry(msg)

--- a/test/probes/tedious.test.js
+++ b/test/probes/tedious.test.js
@@ -164,7 +164,7 @@ describe(`probes.tedious ${pkg.version}`, function () {
     }, [
       function (msg) {
         checks['mssql-entry'](msg)
-        msg.should.have.property('Query', 'select 0, @msg')
+        msg.should.have.property('Query', 'select ?, @msg')
         msg.should.not.have.property('QueryArgs')
       },
       function (msg) {

--- a/test/sql-sanitizer.test.js
+++ b/test/sql-sanitizer.test.js
@@ -1,0 +1,276 @@
+/* global it, describe */
+'use strict'
+const expect = require('chai').expect
+const sqlSanitizer = require('../lib/sql-sanitizer')
+
+describe('sqlSanitizer basic', function () {
+  it('should sanitizes an insert list', function () {
+    const sql = "INSERT INTO `queries` (`asdf_id`, `asdf_prices`, `created_at`, `updated_at`, `blue_pill`, `yearly_tax`, `rate`, `steam_id`, `red_pill`, `dimitri`, `origin`) VALUES (19231, 3, 'cat', 'dog', 111.0, 126.0, 116.0, 79.0, 72.0, 73.0, ?, 1, 3, 229.284, ?, ?, 100, ?, 0, 3, 1, ?, NULL, NULL, ?, 4, ?)"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('INSERT INTO `queries` (`asdf_id`, `asdf_prices`, `created_at`, `updated_at`, `blue_pill`, `yearly_tax`, `rate`, `steam_id`, `red_pill`, `dimitri`, `origin`) VALUES (?, ?, ?, ?, ?.?, ?.?, ?.?, ?.?, ?.?, ?.?, ?, ?, ?, ?.?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)')
+  })
+
+  it('should sanitizes a in list', function () {
+    const sql = 'SELECT "game_types".* FROM "game_types" WHERE "game_types"."game_id" IN (1162)'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT "game_types".* FROM "game_types" WHERE "game_types"."game_id" IN (?)')
+  })
+
+  it('should sanitizes args in string', function () {
+    const sql = "SELECT \"comments\".* FROM \"comments\" WHERE \"comments\".\"commentable_id\" = 2798 AND \"comments\".\"commentable_type\" = 'Video' AND \"comments\".\"parent_id\" IS NULL ORDER BY comments.created_at DESC"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT "comments".* FROM "comments" WHERE "comments"."commentable_id" = ? AND "comments"."commentable_type" = ? AND "comments"."parent_id" IS NULL ORDER BY comments.created_at DESC')
+  })
+
+  it('should sanitizes a mixture of situations', function () {
+    const sql = "SELECT `assets`.* FROM `assets` WHERE `assets`.`type` IN ('Picture') AND (updated_at >= '2015-07-08 19:22:00') AND (updated_at <= '2015-07-08 19:23:00') LIMIT 31 OFFSET ?"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT `assets`.* FROM `assets` WHERE `assets`.`type` IN (?) AND (updated_at >= ?) AND (updated_at <= ?) LIMIT ? OFFSET ?')
+  })
+
+  it('should sanitizes quoted stuff', function () {
+    const sql = "SELECT `users`.* FROM `users` WHERE (mobile IN ('234 234 234') AND email IN ('a_b_c@hotmail.co.uk'))"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT `users`.* FROM `users` WHERE (mobile IN (?) AND email IN (?))')
+  })
+
+  it('should sanitizes complicated quoted stuff', function () {
+    const sql = "SELECT `users`.* FROM `users` WHERE (mobile IN ('2342423') AND email IN ('a_b_c@hotmail.co.uk')) LIMIT 5"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT `users`.* FROM `users` WHERE (mobile IN (?) AND email IN (?)) LIMIT ?')
+  })
+
+  it('should adapt to = spacing', function () {
+    const sql = "UPDATE my_table SET col1=10, col2=20, col3=30 WHERE col1=1"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('UPDATE my_table SET col1=?, col2=?, col3=? WHERE col1=?')
+  })
+
+  it('should adapt to , spacing', function () {
+    const sql = "INSERT INTO `queries` (`asdf_id`, `asdf_prices`, `created_at`, `updated_at`, `blue_pill`, `yearly_tax`, `rate`, `steam_id`, `red_pill`, `dimitri`, `origin`) VALUES (19231,3,'cat','dog', 111.0, 126.0, 116.0, 79.0, 72.0, 73.0, ?, 1, 3, 229.284, ?, ?, 100, ?, 0, 3, 1, ?, NULL,NULL, ?, 4, ?)"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('INSERT INTO `queries` (`asdf_id`, `asdf_prices`, `created_at`, `updated_at`, `blue_pill`, `yearly_tax`, `rate`, `steam_id`, `red_pill`, `dimitri`, `origin`) VALUES (?,?,?,?, ?.?, ?.?, ?.?, ?.?, ?.?, ?.?, ?, ?, ?, ?.?, ?, ?, ?, ?, ?, ?, ?, ?, NULL,NULL, ?, ?, ?)')
+  })
+
+  it('should not remove numbers from column names', function () {
+    const sql = 'UPDATE my_table SET col1 = 10, col2 = 20, col3 = 30 WHERE col1 = 1'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('UPDATE my_table SET col1 = ?, col2 = ?, col3 = ? WHERE col1 = ?')
+  })
+
+  it('should handle multi line SQL', function () {
+    const sql = `
+      SELECT
+        First_Name,
+        Nickname
+      FROM
+        Friends
+      WHERE
+        Nickname LIKE '%brain%';
+      `
+    const result = sqlSanitizer.sanitize(sql)
+    const expected = `
+      SELECT
+        First_Name,
+        Nickname
+      FROM
+        Friends
+      WHERE
+        Nickname LIKE ?;
+      `
+    expect(result).equal(expected)
+  })
+})
+
+/* eslint-disable no-useless-escape */
+describe('sqlSanitizer multi single quote', function () {
+  it('should properly handle \'', function () {
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake's' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle double \'', function () {
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake''s' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle triple \'', function () {
+    // note: SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake'''s' GROUP BY tbl1.name is NOT valid SQL
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake'''s' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle quadrupedal \'', function () {
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake''''s' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle \' with following space', function () {
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake' s' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle \' with preceding space', function () {
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake 's' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle \' with surrounding space', function () {
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake ' s' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle quadrupedal \' with space', function () {
+    // note: SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake'' ''s' GROUP BY tbl1.name is valid SQL
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake'' ''s' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle double double \'', function () {
+    // note: SELECT * FROM test_table tbl1 WHERE tbl1.name = 'can sanitize this''can sanitize this' GROUP BY tbl1.name" in NOT valid SQL
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'can sanitize this''can sanitize this' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ?? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle \' after quoted value', function () {
+    const sql = "SELECT 'jack' FROM test_table tbl1 WHERE tbl1.name = 'jake's' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT ? FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle \' in and after quoted value', function () {
+    const sql = "SELECT 'jack's' FROM test_table tbl1 WHERE tbl1.name = 'jake's' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT ? FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+})
+
+describe('sqlSanitizer multi single quote (escape notation)', function () {
+  it('should properly handle escaped \'', function () {
+    const sql = 'SELECT * FROM test_table tbl1 WHERE tbl1.name = \'jake\'s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle double escaped \'', function () {
+    const sql = 'SELECT * FROM test_table tbl1 WHERE tbl1.name = \'jake\'\'s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle triple escaped \'', function () {
+    // note: SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake'''s' GROUP BY tbl1.name is NOT valid SQL
+    const sql = 'SELECT * FROM test_table tbl1 WHERE tbl1.name = \'jake\'\'\'s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle quadrupedal escaped \'', function () {
+    const sql = 'SELECT * FROM test_table tbl1 WHERE tbl1.name = \'jake\'\'\'\'s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle escaped \' with following space', function () {
+    const sql = 'SELECT * FROM test_table tbl1 WHERE tbl1.name = \'jake\' s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle escaped \' with preceding space', function () {
+    const sql = 'SELECT * FROM test_table tbl1 WHERE tbl1.name = \'jake \'s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle escaped \' with surrounding space', function () {
+    const sql = 'SELECT * FROM test_table tbl1 WHERE tbl1.name = \'jake \' s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle quadrupedal escaped \' with space', function () {
+    // note: SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake'' ''s' GROUP BY tbl1.name is valid SQL
+    const sql = 'SELECT * FROM test_table tbl1 WHERE tbl1.name = \'jake\'\' \'\'s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle escape double double \'', function () {
+    // note: SELECT * FROM test_table tbl1 WHERE tbl1.name = 'can sanitize this''can sanitize this' GROUP BY tbl1.name" in NOT valid SQL
+    const sql = 'SELECT * FROM test_table tbl1 WHERE tbl1.name = \'can sanitize this\'\'can sanitize this\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ?? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle escaped \' after quoted value', function () {
+    const sql = 'SELECT \'jack\' FROM test_table tbl1 WHERE tbl1.name = \'jake\'s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT ? FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle escaped \' in and after quoted value', function () {
+    const sql = 'SELECT \'jack\'s\' FROM test_table tbl1 WHERE tbl1.name = \'jake\'s\' GROUP BY tbl1.name'
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT ? FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+})
+
+describe('sqlSanitizer cleanup of dangle \'', function () {
+  it('should properly handle triple \' with space (\'can sanitize this\'\')', function () {
+    // note: SELECT * FROM test_table tbl1 WHERE tbl1.name = 'can sanitize this'' GROUP BY tbl1.name is NOT valid SQL
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'can sanitize this'' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+
+  it('should properly handle triple \' with space (\'\'can sanitize this\')', function () {
+    // note: SELECT * FROM test_table tbl1 WHERE tbl1.name = ''can sanitize this' GROUP BY tbl1.name is NOT valid SQL
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = ''can sanitize this' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name')
+  })
+})
+
+describe('sqlSanitizer aggressive cleanup when \' involved', function () {
+  it('should remove more rather than less', function () {
+    // note: SELECT P.FirstName FROM \"[ Int'l Sales]\" P WHERE P.FirstName =  'Jake' is NOT valid SQL
+    // the sanitizer "sees" most statement inside single ' and aggressively trims
+    const sql = "SELECT P.FirstName FROM \"[ Int'l Sales]\" P WHERE P.FirstName =  'Jake'"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT P.FirstName FROM "[ Int?')
+  })
+
+  it('should properly handle triple \' with space (\'\'can sanitize this\') after same', function () {
+    // note: SELECT ''can sanitize this' FROM test_table tbl1 WHERE tbl1.name = ''can sanitize this' GROUP BY tbl1.name is NOT valid SQL
+    // the sanitizer "sees"  many groups and aggressively trims
+    const sql = "SELECT ''can sanitize this' FROM test_table tbl1 WHERE tbl1.name = ''can sanitize this' GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT ? GROUP BY tbl1.name')
+  })
+
+  it('should properly mishmash of \' endint clean', function () {
+    // note: SELECT 'normal' 'jake's' 'this is tow'' this is three ''' WHERE 'abc'de GROUP BY tbl1.name is NOT valid SQL
+    // the sanitizer "sees"  many groups and aggressively trims
+    const sql = "SELECT 'normal' 'jake's' 'this is tow'' this is three ''' WHERE 'abc'de GROUP BY tbl1.name"
+    const result = sqlSanitizer.sanitize(sql)
+    expect(result).equal('SELECT ?? WHERE ? GROUP BY tbl1.name')
+  })
+
+  it('should properly mishmash of \' ending in mishmash', function () {
+    // note: SELECT 'normal' 'jake's' 'this is tow'' this is three ''' WHERE 'abc'de GROUP BY 'wait'what'sthat' is NOT valid SQL
+    const sql = "SELECT 'normal' 'jake's' 'this is tow'' this is three ''' WHERE 'abc'de GROUP BY 'wait'what'sthat'"
+    const result = sqlSanitizer.sanitize(sql)
+    console.log(result)
+    expect(result).equal('SELECT ?')
+  })
+})


### PR DESCRIPTION
## Overview

This pull request adds SQL Sanitization functionality to the agent.

## Status

SQL sanitazation (in this context) is the removal of user data from query strings (e.g. removing `Jake` and `13` from `SELECT * FROM users WHERE name = 'Jake' AND age > 13`).

Sanitization was added to the agent via the [bindings](https://github.com/appoptics/appoptics-bindings-node/commit/d82692bb8d57b106114dbac7f4efc878054fc214). It is an FSM written in C++ ["copied" from PHP agent](https://github.com/librato/oboe/blob/834a1afb4cfafa2c38e7b8f3bbcf35b528c35ab2/contrib/php_oboe/php-oboe/php-8/sql_parser.cc).

The Ruby Agent uses a [simple regex](https://github.com/appoptics/appoptics-apm-ruby/blob/3a96150e6991c0d61b8ca859d62ebb16c9fa587f/lib/rails/generators/solarwinds_apm/templates/solarwinds_apm_initializer.rb#L168) to achieve similar (but not identical) results.

## Change

- An SQL Sanitizer module that uses a regex expressions to "sanitize" data out of strings (assumed to be SQL queries) was added. Implementation is similar to the one used in the ruby agent, but handles removal of data in more edge cases.

- Sanitization via regex (following ruby agent lead) differs from what the original implementation was. Removing `Jake` and `13` from `SELECT * FROM users WHERE name = 'Jake' AND age > 13` will now result in `SELECT * FROM users WHERE name = ? AND age > ?` when previously it resulted in `SELECT * FROM users WHERE name = '?' AND age > 0`.

- The six probes that use sanitization (`cassandra-driver`, `node-cassandra-cql`, `mysql`, `oracledb`, `pg`, `tedious`) were modified to use internal SQL Sanitizer module.

- All six probes originally used the `OBOE_SQLSANITIZE_KEEPDOUBLE` option. There no such "option" anymore (again following ruby agent lead). SQL Sanitizer implementation always keeps double quoted data.

- The is no user customization of the sanitization function (departing from ruby agent lead).

## Notes
- Removal of code from bindings is done in: https://github.com/appoptics/appoptics-bindings-node/pull/117
- Pull Request merges into nh-main branch. Bindings built from master will stay unchanged.
