### PR TITLE
NH-14040-Replace-websocket.org-in-Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appoptics-apm",
-  "version": "11.0.0-nh.0",
+  "version": "11.0.0-nh.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appoptics-apm",
-      "version": "11.0.0-nh.0",
+      "version": "11.0.0-nh.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ace-context": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "11.0.0-nh.0",
+  "version": "11.0.0-nh.1",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "files": [

--- a/test/probes/http-websocket-common.js
+++ b/test/probes/http-websocket-common.js
@@ -143,8 +143,8 @@ describe(`probes.${p} websocket`, function () {
 
   // these are constant for a given protocol.
   const prefix = p === 'http' ? 'ws' : 'wss'
-  const url = `${p}://echo.websocket.org/`
-  const wsUrl = `${prefix}://echo.websocket.org/`
+  const url = `${p}://echo.websocket.events/`
+  const wsUrl = `${prefix}://echo.websocket.events/`
   const parsedUrl = new URL(wsUrl)
 
   describe(`${p}-client`, function () {
@@ -169,7 +169,7 @@ describe(`probes.${p} websocket`, function () {
       ], done)
     })
 
-    it.skip(`${p} connect to a public server`, function (done) {
+    it(`${p} connect to a public server`, function (done) {
       this.timeout(10000)
       const options = makeOptions(parsedUrl)
 
@@ -211,7 +211,7 @@ describe(`probes.${p} websocket`, function () {
       )
     })
 
-    it.skip('WebSocket connect to a public server', function (done) {
+    it('WebSocket connect to a public server', function (done) {
       helper.test(
         emitter,
         function (xdone) {


### PR DESCRIPTION
## Overview

This pull request "unskips" web socket tests that were skipped in https://github.com/appoptics/appoptics-apm-node/commit/7c3230da467dac81640a2f1a0889c10fec086a57 replacing the now dead websocket.org with websocket.events.

websocket.events is operated by Lob and they say ["You’re also welcome to use ours at echo.websocket.events."](https://www.lob.com/blog/websocket-org-is-down-here-is-an-alternative) - so we'll do for now.

## Notes
- Pull Request merges into nh-main branch.