### PR TITLE
NH-14130-Fix-http-Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appoptics-apm",
-  "version": "11.0.0-nh.0",
+  "version": "11.0.0-nh.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appoptics-apm",
-      "version": "11.0.0-nh.0",
+      "version": "11.0.0-nh.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ace-context": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "11.0.0-nh.0",
+  "version": "11.0.0-nh.1",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "files": [

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -180,18 +180,19 @@ describe(`probes.${p}`, function () {
           expect(msg).property('Status', 200)
         }
       ], function () {
-        server.close(done)
+        server.close()
       })
 
       server.listen(function () {
         port = server.address().port
         axios(
-          `${p}://localhost:${port}/foo?bar=baz`,
-          function (error, response, body) {
-            expect(response.headers).exist()
-            expect(response.headers).property('x-trace')
-          }
-        )
+          `${p}://localhost:${port}/foo?bar=baz`
+        ).then(function (response) {
+          expect(response.headers).property('x-trace')
+          done()
+        }).catch(function (err) {
+          done(err)
+        })
       })
     })
 
@@ -204,20 +205,16 @@ describe(`probes.${p}`, function () {
         res.end('done')
       })
 
-      let trasportXtrace = ''
-
       helper.doChecks(emitter, [
         function (msg) {
           check.server.entry(msg)
           expect(msg).not.have.property('Edge')
-
-          trasportXtrace = msg['X-Trace']
         },
         function (msg) {
           check.server.exit(msg)
         }
       ], function () {
-        server.close(done)
+        server.close()
       })
 
       server.listen(function () {
@@ -225,11 +222,12 @@ describe(`probes.${p}`, function () {
         axios({
           url: `${p}://localhost:${port}`,
           headers: {}
-        },
-        function (error, response, body) {
-          expect(response.headers).exist()
+        }).then(function (response) {
           expect(response.headers).property('x-trace')
-          expect(trasportXtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
+          expect(baseTraceparent.slice(0, 35)).not.equal(response.headers['x-trace'].slice(0, 35))
+          done()
+        }).catch(function (err) {
+          done(err)
         })
       })
     })
@@ -239,20 +237,16 @@ describe(`probes.${p}`, function () {
         res.end('done')
       })
 
-      let trasportXtrace = ''
-
       helper.doChecks(emitter, [
         function (msg) {
           check.server.entry(msg)
-          expect(msg).not.have.property('Edge')
-
-          trasportXtrace = msg['X-Trace']
+          expect(msg).property('Edge', baseTracestateSpanId.toUpperCase())
         },
         function (msg) {
           check.server.exit(msg)
         }
       ], function () {
-        server.close(done)
+        server.close()
       })
 
       server.listen(function () {
@@ -262,11 +256,12 @@ describe(`probes.${p}`, function () {
           headers: {
             traceparent: baseTraceparent
           }
-        },
-        function (error, response, body) {
-          expect(response.headers).exist()
+        }).then(function (response) {
           expect(response.headers).property('x-trace')
-          expect(trasportXtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
+          expect(baseTraceparent.slice(0, 35)).equal(response.headers['x-trace'].slice(0, 35))
+          done()
+        }).catch(function (err) {
+          done(err)
         })
       })
     })
@@ -276,19 +271,15 @@ describe(`probes.${p}`, function () {
         res.end('done')
       })
 
-      let trasportXtrace = ''
-
       helper.doChecks(emitter, [
         function (msg) {
           expect(msg).property('Edge', baseTracestateSpanId.toUpperCase())
-
-          trasportXtrace = msg['X-Trace']
         },
         function (msg) {
           check.server.exit(msg)
         }
       ], function () {
-        server.close(done)
+        server.close()
       })
 
       server.listen(function () {
@@ -299,11 +290,12 @@ describe(`probes.${p}`, function () {
             traceparent: baseTraceparent,
             tracestate: baseTracestateOrgPart
           }
-        },
-        function (error, response, body) {
-          expect(response.headers).exist()
+        }).then(function (response) {
           expect(response.headers).property('x-trace')
-          expect(trasportXtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
+          expect(baseTraceparent.slice(0, 35)).equal(response.headers['x-trace'].slice(0, 35))
+          done()
+        }).catch(function (err) {
+          done(err)
         })
       })
     })
@@ -313,22 +305,18 @@ describe(`probes.${p}`, function () {
         res.end('done')
       })
 
-      let trasportXtrace = ''
-
       helper.doChecks(emitter, [
         function (msg) {
           // the edge in "Continuation" is from trace parent.
           expect(msg).property('Edge', otherTracestateOrgPart.slice(3).split('-')[0].toUpperCase())
           expect(msg).property('sw.tracestate_parent_id')
           expect(msg).property('sw.w3c.tracestate')
-
-          trasportXtrace = msg['X-Trace']
         },
         function (msg) {
           check.server.exit(msg)
         }
       ], function () {
-        server.close(done)
+        server.close()
       })
 
       server.listen(function () {
@@ -339,11 +327,12 @@ describe(`probes.${p}`, function () {
             traceparent: baseTraceparent,
             tracestate: otherTracestateOrgPart
           }
-        },
-        function (error, response, body) {
-          expect(response.headers).exist()
+        }).then(function (response) {
           expect(response.headers).property('x-trace')
-          expect(trasportXtrace.slice(0, 42)).equal(response.headers['x-trace'].slice(0, 42))
+          expect(baseTraceparent.slice(0, 35)).equal(response.headers['x-trace'].slice(0, 35))
+          done()
+        }).catch(function (err) {
+          done(err)
         })
       })
     })
@@ -402,7 +391,7 @@ describe(`probes.${p}`, function () {
           check.server.exit(msg)
         }
       ], function () {
-        server.close(done)
+        server.close()
       })
 
       server.listen(function () {
@@ -413,11 +402,12 @@ describe(`probes.${p}`, function () {
             traceparent,
             tracestate: baseTracestateOrgPart
           }
-        },
-        function (error, response, body) {
-          expect(response.headers).exist()
+        }).then(function (response) {
           expect(response.headers).property('x-trace')
-          expect(origin.taskId).not.equal(response.headers['x-trace'].slice(2, 42))
+          expect(origin.taskId).not.equal(response.headers['x-trace'].slice(3, 35))
+          done()
+        }).catch(function (err) {
+          done(err)
         })
       })
     })
@@ -439,7 +429,7 @@ describe(`probes.${p}`, function () {
           check.server.exit(msg)
         }
       ], function () {
-        server.close(done)
+        server.close()
       })
 
       server.listen(function () {
@@ -447,11 +437,12 @@ describe(`probes.${p}`, function () {
         axios({
           url: `${p}://localhost:${port}`,
           headers: { tracestate: baseTracestateOrgPart }
-        },
-        function (error, response, body) {
-          expect(response.headers).exist()
+        }).then(function (response) {
           expect(response.headers).property('x-trace')
-          expect(origin.taskId).not.equal(response.headers['x-trace'].slice(2, 42))
+          expect(origin.taskId).not.equal(response.headers['x-trace'].slice(3, 35))
+          done()
+        }).catch(function (err) {
+          done(err)
         })
       })
     })

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -307,7 +307,7 @@ describe(`probes.${p}`, function () {
 
       helper.doChecks(emitter, [
         function (msg) {
-          // the edge in "Continuation" is from trace parent.
+          // the edge in "Continuation" is from tracestate.
           expect(msg).property('Edge', otherTracestateOrgPart.slice(3).split('-')[0].toUpperCase())
           expect(msg).property('sw.tracestate_parent_id')
           expect(msg).property('sw.w3c.tracestate')


### PR DESCRIPTION
## Overview
This pull request fixes the http probe tests so that they actually run as expected.

## Status

Since the tests did not run as expected, an issue with bindings/liboboe trace continuation when Downstream was not detected.

## Change

With the fixed tests, a test will fail when using bindings below version `12.0.0-nh.2` (comes with liboboe `10.5.0`).

See: https://github.com/appoptics/appoptics-apm-node/runs/6713249942?check_suite_focus=true
```
57 suites in 5 groups passed
2 suites in 1 group failed
    PROBES:
    test/probes/http.test.js
    test/probes/https.test.js
```
All tests will pass once https://github.com/appoptics/appoptics-bindings-node/pull/118 is merged and the updated bindings are installed in the agent `nh-main` branch from the bindings `nh-main` branch. see: https://github.com/appoptics/appoptics-apm-node/actions/runs/2429881575

## Notes
- Pull Request merges into nh-main branch. Bindings built from master will stay unchanged.
- Binding change will arrive at SolarWinds APM in next release.