### PR TITLE
NH-5459-Support-Trace-ID-Insertion-for-log4js (tweak)

### DIFF
--- a/lib/probes/log4js.js
+++ b/lib/probes/log4js.js
@@ -63,15 +63,18 @@ module.exports = function (log4js, info) {
         // which then calls the log function, or alternatively, by directly calling the log function.
         // patch the lower level log function to cover all cases (including custom levels).
         if (typeof instance.log === 'function') {
+          let appendTraceToEndOfLog = true
           // when the user is using a pattern in their layout in ANY of their appenders respect their pattern (and skill)
           // do NOT append the trace to the end of the log message.
           // (note: inserting for patterns is available using log4js tokens and api method getTraceStringForLog)
-          const appendTraceToEndOfLog = !Object.values(this.configuration.appenders).find(appender => {
-            return (
-              typeof appender.layout !== 'undefined' &&
-              'basic|colored|messagePassThrough|dummy'.indexOf(appender && appender.layout && appender.layout.type) === -1
-            )
-          })
+          if(this.configuration) {
+            appendTraceToEndOfLog = !Object.values(this.configuration.appenders).find(appender => {
+              return (
+                typeof appender.layout !== 'undefined' &&
+                'basic|colored|messagePassThrough|dummy'.indexOf(appender && appender.layout && appender.layout.type) === -1
+              )
+            })
+          }
 
           if (appendTraceToEndOfLog) {
             shimmer.wrap(instance, 'log', patchLog)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appoptics-apm",
-  "version": "11.0.0-nh.0",
+  "version": "11.0.0-nh.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appoptics-apm",
-      "version": "11.0.0-nh.0",
+      "version": "11.0.0-nh.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ace-context": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-apm",
-  "version": "11.0.0-nh.0",
+  "version": "11.0.0-nh.1",
   "description": "Agent for AppOptics APM",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
## Overview

This pull request is a fix to the log4js probe allowing it to work when user provides no configuration (default, not common).

See: https://github.com/appoptics/appoptics-apm-node/pull/228 for info regarding probe implementation.

## Notes
- Pull Request merges into nh-main branch. Agent built from master will stay unchanged.