### PR TITLE
NH-5414-Update-Dependencies-devDependencies-5 (cls-hooked) 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -213,23 +213,10 @@ Object.defineProperty(ao, 'modeToStringMap', {
 })
 
 //
-// Load continuation-local-storage
+// Load context provider
 //
-const contextProviders = {
-  clsHooked: 'cls-hooked',
-  aceContext: 'ace-context'
-}
-// if set via environment variable use that context provider otherwise
-if (env.AO_CONTEXT in contextProviders) {
-  ao.contextProvider = contextProviders[env.AO_CONTEXT]
-} else {
-  ao.contextProvider = contextProviders.aceContext
-}
-
-log.debug('using context provider:', ao.contextProvider)
-// load the context provider
 try {
-  ao.cls = require(ao.contextProvider)
+  ao.cls = require('ace-context')
 } catch (e) {
   enabled = false
   log.error('Can\'t load %s', ao.contextProvider, e.stack)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "ace-context": "^1.0.1",
-        "cls-hooked": "^4.2.2",
         "debug-custom": "^1.1.0",
         "semver": "^7.3.5",
         "shimmer": "^1.2.1"
@@ -2199,27 +2198,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "dependencies": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
-      }
-    },
-    "node_modules/cls-hooked/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/co": {
@@ -12033,23 +12011,6 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
-    },
-    "cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "requires": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
     },
     "co": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "ace-context": "^1.0.1",
-    "cls-hooked": "^4.2.2",
     "debug-custom": "^1.1.0",
     "semver": "^7.3.5",
     "shimmer": "^1.2.1"

--- a/test/integrity.test.js
+++ b/test/integrity.test.js
@@ -40,7 +40,7 @@ describe('integrity', function () {
     // load all and filter out keys that are not api.
     // TODO: when cyclic is solved can revert to pattern as used for api-sim
     const aoApi = require('../lib/')
-    const notApi = '_stats, version, g, root, omitTraceId, logger, loggers, logLevel, logLevelAdd, logLevelRemove, probes, specialUrls, execEnv, cfg, getDomainPrefix, makeLogMissing, modeMap, modeToStringMap, contextProvider, cls, addon, reporter, control, startup, debugLogging, traceMode, sampleRate, tracing, traceId, lastEvent, lastSpan, maps, requestStore, resetRequestStore, clsCheck, stack, backtrace, bind, bindEmitter, setCustomTxNameFunction, wrappedFlag, fs'
+    const notApi = '_stats, version, g, root, omitTraceId, logger, loggers, logLevel, logLevelAdd, logLevelRemove, probes, specialUrls, execEnv, cfg, getDomainPrefix, makeLogMissing, modeMap, modeToStringMap, cls, addon, reporter, control, startup, debugLogging, traceMode, sampleRate, tracing, traceId, lastEvent, lastSpan, maps, requestStore, resetRequestStore, clsCheck, stack, backtrace, bind, bindEmitter, setCustomTxNameFunction, wrappedFlag, fs'
     const apiKeys = new Set([...new Set([...Object.getOwnPropertyNames(aoApi)])].filter(item => notApi.indexOf(item) === -1))
 
     const aoSim = require('../lib/api-sim')(Object.assign({}, skeletalAo))

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -157,14 +157,7 @@ describe('probes.fs', function () {
         if (mode === 'sync') {
           return [span('open'), span('ftruncate'), span('close')]
         } else {
-          const expected = [span('open')]
-          // TODO: revisit
-          // when using continuation-local-storage the 'close' span
-          // doesn't appear.
-          if (ao.contextProvider !== 'continuation-local-storage') {
-            expected.push(span('close'))
-          }
-          return expected
+          return [span('open'), span('close')]
         }
       }
     },


### PR DESCRIPTION
## Overview

This pull request removes `cls-hooked` from dependencies.

The package is redundant. Context is managed with `ace-context`.

## History:

- `ace-context` is a fork of `cls-hooked`, `cls-hooked` is a fork of `continuation-local-storage`

- Managing context using [`continuation-local-storage`](https://www.npmjs.com/package/continuation-local-storage) was added in one of the early commits as part of a "quick-and-dirty port of trace and log functionality from oboe-ruby"  (See: https://github.com/appoptics/appoptics-apm-node/commit/1b5c028c00752dd86ac47c7aff8fbae79f58d467)


- `continuation-local-storage` was replaced with a fork called [`cls-hooked`](https://www.npmjs.com/package/cls-hooked) 4 years later in: https://github.com/appoptics/appoptics-apm-node/commit/4345f61d3fb30ff4cdd2e2e4f746ccf95cd6bb58

- A fork of `cls-hooked` named [`ace-context`](https://www.npmjs.com/package/ace-context) was added in parallel in: https://github.com/appoptics/appoptics-apm-node/commit/75fccbd6831da4d31cfde3da526b227a27fe4649 and was `ace-context` was placed out of "alpha" in: https://github.com/appoptics/appoptics-apm-node/commit/27505b52e1fb000693da908108ad8036dc0f9fac

## Discussion

- As of June 13, 2022
`continuation-local-storage` Last published 5 years ago and has 1,843,808 Weekly Downloads
`cls-hooked` was Last published 5 years ago and has 1,246,792 Weekly Downloads
`ace-context` was last published 3 years ago and has 2,885 Weekly Downloads.

- Ideally, if a dependency is required, it is better to use one that is well maintained, popular *and* is by itself original work (i.e. not a fork). Thus, in theory, in such a chain of forks, it would be wise to unbundle the forked packages back to `continuation-local-storage`.
- However, since none of the packages is currently actively maintained, and since reverting back up the fork chain will introduce development risk, the current dependency (`ace-context`) stays.
 
## Change

- Dependency removed.
- Debug code that allowed for the user to configure the package used for context has been removed (`cls-hooked` and `ace-context` are NOT interchangeable).

## Notes:
- The repo link in the `ace-context` (https://www.npmjs.com/package/ace-context) package does NOT lead to the actual source. The source is at: https://github.com/appoptics/ace-context and the mistaken link is from here: https://github.com/appoptics/ace-context/blob/master/package.json#L19
- Pull Request merges into `nh-main`. Agent built from `master` will maintain dependency`.