### PR TITLE
Revert "NH-14040-Replace-websocket.org-in-Tests"

### DIFF
--- a/test/probes/http-websocket-common.js
+++ b/test/probes/http-websocket-common.js
@@ -143,8 +143,8 @@ describe(`probes.${p} websocket`, function () {
 
   // these are constant for a given protocol.
   const prefix = p === 'http' ? 'ws' : 'wss'
-  const url = `${p}://echo.websocket.events/`
-  const wsUrl = `${prefix}://echo.websocket.events/`
+  const url = `${p}://echo.websocket.org/`
+  const wsUrl = `${prefix}://echo.websocket.org/`
   const parsedUrl = new URL(wsUrl)
 
   describe(`${p}-client`, function () {
@@ -169,7 +169,7 @@ describe(`probes.${p} websocket`, function () {
       ], done)
     })
 
-    it(`${p} connect to a public server`, function (done) {
+    it.skip(`${p} connect to a public server`, function (done) {
       this.timeout(10000)
       const options = makeOptions(parsedUrl)
 
@@ -211,7 +211,7 @@ describe(`probes.${p} websocket`, function () {
       )
     })
 
-    it('WebSocket connect to a public server', function (done) {
+    it.skip('WebSocket connect to a public server', function (done) {
       helper.test(
         emitter,
         function (xdone) {


### PR DESCRIPTION
Reverts appoptics/appoptics-apm-node#266

Tests fail randomly too many times while running in GitHub Actions.