### PR TITLE
NH-13380-Resolve-Circular-Dependencies

### DIFF
--- a/lib/log-formatters.js
+++ b/lib/log-formatters.js
@@ -1,12 +1,12 @@
 'use strict'
+
+const format = require('util').format
+
 /**
  * Define AppOptics-specific formatters for debugging and logging.
  */
 
 module.exports = function (d) {
-  const ao = require('./')
-  const format = require('util').format
-
   /**
    * format like console.log when replacing stdout, stderr
    */
@@ -50,11 +50,10 @@ module.exports = function (d) {
       return '<undefined>'
     }
 
-    if (event instanceof ao.Event) {
-      return event.Layer + ':' + event.Label + ' ' + humanID(event.event)
-    }
+    const layer = event.Layer || '?'
+    const label = event.Label || '?'
 
-    return '?:? ' + humanID(event)
+    return `${layer}:${label} ` + humanID(event)
   }
 
   /**
@@ -80,17 +79,18 @@ module.exports = function (d) {
    * Format an X-Trace ID in easier to look at format.
    */
   function humanID (x) {
-    if (x instanceof ao.addon.Event) {
+    if (x.constructor.name === 'Event' && typeof x.event === 'undefined') {
       return x.toString(1)
     }
 
+    if (x.constructor.name === 'Event' && typeof x.event !== 'undefined') {
+      return x.event.toString(1)
+    }
+
+    // TODO: that's a legacy x-trace. is this even needed?
     if (typeof x === 'string' && x.length === 60) {
       x = x.toLowerCase()
       return x.slice(0, 2) + '-' + x.slice(2, 42) + '-' + x.slice(42, 58) + '-' + x.slice(-2)
-    }
-
-    if (x instanceof ao.Event) {
-      return x.event.toString(1)
     }
 
     // not sure what it is so do the best we can.

--- a/lib/require-patch.js
+++ b/lib/require-patch.js
@@ -2,7 +2,9 @@
 
 const Module = require('module')
 const path = require('path')
-const ao = require('./index')
+
+const { loggers } = require('./loggers')
+const probeList = require('./probe-defaults')
 
 const realRequire = module.constructor.prototype.require
 const patched = new WeakMap()
@@ -89,15 +91,14 @@ function patchedRequire (name) {
     require.cache[path].exports = mod
   }
 
-  ao.loggers.patching(`patched ${name} ${v}`)
+  loggers.patching(`patched ${name} ${v}`)
 
   return mod
 }
 
-// ao.probes is generated from defaults and config
-Object.keys(ao.probes).forEach(name => {
+Object.keys(probeList).forEach(name => {
   exports.register(name, path.join(__dirname, 'probes', name))
-  ao.loggers.probes(`found ${name} probe`)
+  loggers.probes(`found ${name} probe`)
 })
 
 // abstracted probes are those known by another name, e.g. `amqplib/callback_api` is just a wrapper around
@@ -108,5 +109,5 @@ const abstractedProbes = [
 
 abstractedProbes.forEach(name => {
   exports.register(name, path.join(__dirname, 'probes', name))
-  ao.loggers.probes(`found ${name} probe`)
+  loggers.probes(`found ${name} probe`)
 })


### PR DESCRIPTION
## Overview

This pull request resolves circular dependencies in agent code.

## Status

- `/log-formatters.js` was added in https://github.com/appoptics/appoptics-apm-node/commit/8b8e19b38fbeb28cd618edf0ad5f0e7dc7716b32 and https://github.com/appoptics/appoptics-apm-node/commit/e6cff9cb0a959235e2598361e313129cc00ced16 created a circular dependency (2018).

- Running [Madge](https://www.npmjs.com/package/madge):

```
Processed 58 files (1.3s) (1 warning)

✖ Found 2 circular dependencies!

1) index.js > loggers.js > log-formatters.js
2) index.js > require-patch.js
```

## Discussion:

Node documentation says: 
> Careful planning is required to allow cyclic module dependencies to work correctly within an application. https://nodejs.org/api/modules.html#modules_cycles. 

However at this point we can assume this is not a cause of customer issues.

## Change

- [ee2f556](https://github.com/appoptics/appoptics-apm-node/pull/275/commits/ee2f55639bbbd74135397e39908896519eba1f15) Resolved circular dependencies in `require-patch` by directly requiring the specific modules needed (loggers, probe-defaults)
- [5282aff](https://github.com/appoptics/appoptics-apm-node/pull/275/commits/5282affe608eb76b73df96b7ca974d44d9585c89) Resolved circular dependencies by removing reference to ao object. Instead of compering and object `instanceof` in conditionals, now using the self evident properties of the evaluated object.

- Running [Madge](https://www.npmjs.com/package/madge):

```
Processed 58 files (1.4s) (1 warning)

✔ No circular dependency found!
```

## Notes:
- Pull Request merges into `nh-main`. Agent built from `master` will stay unchanged`.