### PR TITLE
NH-14027-Fix-q-Probe

### DIFF
--- a/lib/probes/q.js
+++ b/lib/probes/q.js
@@ -6,7 +6,9 @@ const ao = require('..')
 function patchThen (proto) {
   if (typeof proto.then !== 'function') return
   shimmer.wrap(proto, 'then', then => function (...args) {
-    return then.apply(this, args.map(ao.bind))
+    return then.apply(this, args.map( arg => {
+      return ao.lastEvent ? ao.bind(arg) : arg
+    }))
   })
 }
 

--- a/test/probes/promises/index.js
+++ b/test/probes/promises/index.js
@@ -37,9 +37,6 @@ module.exports = function (Promise) {
   it('should support promises via delay', function (done) {
     const t = indirectDone(done)
     ao.requestStore.run(function () {
-      // Hack to look like there's a previous span
-      // ao.requestStore.set('lastSpan', true)
-
       ao.requestStore.set('foo', 'bar')
       delay(100).then(function () {
         return delay(100)
@@ -57,9 +54,6 @@ module.exports = function (Promise) {
   it('should support promises via fs.readFile', function (done) {
     const t = indirectDone(done)
     ao.requestStore.run(function () {
-      // Hack to look like there's a previous span
-      // ao.requestStore.set('lastSpan', true)
-
       ao.requestStore.set('foo', 'bar')
       const p = new Promise(function (resolve, reject) {
         fs.readFile('./package.json', 'utf8', function (err, data) {
@@ -85,15 +79,11 @@ module.exports = function (Promise) {
     d.on('error', done)
     d.run(function () {
       ao.requestStore.run(function () {
-        // Hack to look like there's a previous span
-        // ao.requestStore.set('lastSpan', true)
-
         ao.requestStore.set('foo', 'bar')
         delay(100).then(function () {
           const foo = ao.requestStore.get('foo')
           should.exist(foo)
           foo.should.equal('bar')
-          // ao.requestStore.get('foo').should.equal('bar')
           t.done()
         }, done)
       })
@@ -110,9 +100,6 @@ module.exports = function (Promise) {
   it('should support progress callbacks', function (done) {
     const t = indirectDone(done)
     ao.requestStore.run(function () {
-      // Hack to look like there's a previous span
-      // ao.requestStore.set('lastSpan', true)
-
       ao.requestStore.set('foo', 'bar')
       delay(100).then(function () {
         t.done()


### PR DESCRIPTION
## Overview

This pull request fixes issues with the `q` probe so that it only binds when tracing (i.e. in the context of an http request).

## Status

- The probe generated excessive logging when used outside the context of an http request. It that was apparent in test runs and caused customer concern. 
- A fix similar to the one in the pull request was [implemented in the `bluebird` probe](https://github.com/appoptics/appoptics-apm-node/commit/4cbb3a60e36160dbd40e9324223134cc310294d1) a while back.

## Change

Probe was changed to only bind functions when tracing. Tests were cleaned.

## Notes
- Pull Request merges into `nh-main`. Agent built from `master` will stay "unfixed"`.
