### PR TITLE
NH-8430-Auto-Instrument-Node-DNS (fix)

### DIFF
--- a/lib/probes/dns.js
+++ b/lib/probes/dns.js
@@ -13,7 +13,7 @@ function patchSyncMethod (dns, method) {
           const kvpairs = {
             Spec: 'dns',
             Operation: method,
-            Args: args.join(', ')
+            Args: args.map(arg => typeof arg === 'object' ? JSON.stringify(arg) : arg).join(', ')
           }
 
           return {
@@ -50,7 +50,7 @@ function patchAsyncCallbackMethod (dns, method) {
             Spec: 'dns',
             Operation: method,
             Flavor: 'callback',
-            Args: args.join(', ')
+            Args: args.map(arg => typeof arg === 'object' ? JSON.stringify(arg) : arg).join(', ')
           }
 
           return {
@@ -77,7 +77,7 @@ function patchAsyncPromiseMethod (dns, method) {
             Spec: 'dns',
             Flavor: 'promise',
             Operation: method,
-            Args: args.join(', ')
+            Args: args.map(arg => typeof arg === 'object' ? JSON.stringify(arg) : arg).join(', ')
           }
 
           return {

--- a/test/probes/dns.test.js
+++ b/test/probes/dns.test.js
@@ -303,7 +303,7 @@ describe('probes.dns', function () {
           function (msg) {
             checks.entry(msg)
             msg.should.have.property('Operation', 'setServers')
-            msg.should.have.property('Args', '4.4.4.4,2001:4860:4860::8888,4.4.4.4:1053,[2001:4860:4860::8888]:1053')
+            msg.should.have.property('Args', '["4.4.4.4","2001:4860:4860::8888","4.4.4.4:1053","[2001:4860:4860::8888]:1053"]')
           },
           function (msg) {
             checks.exit(msg)


### PR DESCRIPTION
## Overview

This pull request fixed parsing of arguments for the Arg Key Value pair so that the arguments displays correctly when they include objects.

## Change

When arguments contain objects - the JSON representation of the object is displayed in the comma delimited representation of the args array.

## Notes

- Pull Request merges into `nh-main`. Agent built from `master` will stay unchanged.
