### PR TITLE
NH-16920-Mask-Logged-Service-Key-when-Invalid

### DIFF
--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -236,7 +236,7 @@ function getUnifiedConfig () {
     const name = keyParts.join(':')
     const cleansedKey = `${key}:${cleanseServiceName(name)}`
     if (!validKey(cleansedKey)) {
-      fatals.push(`not a valid serviceKey: ${serviceKey}`)
+      fatals.push(`not a valid serviceKey: ${mask(serviceKey)}`)
       results.global.serviceKey = ''
     } else if (cleansedKey !== serviceKey) {
       // the cleansed key is valid but the original key was not
@@ -422,14 +422,25 @@ function cleanseServiceName (serviceName) {
   return serviceName.toLowerCase().replace(/ /g, '-').replace(/[^a-z0-9.:_-]/g, '')
 }
 
-// mask the service key so it's not revealed when logging. do not presume a
-// a valid service key, i.e., 64-hex-digits:1-to-255-valid-name
+// mask the service key so it's not revealed when logging.
+// DO NOT presume a valid service key, i.e., 64-hex-digits:1-to-255-valid-name
 function mask (key) {
-  const parts = key.split(':')
-  let keyOnly = parts.shift()
-  if (keyOnly.length < 8) {
-    keyOnly += '.'.repeat(8 - key.length)
+  // when no key do not create a "mask pattern"
+  // due to how config is done, key is always a string
+  // it may have actual value of 'undefined' when function is called
+  // treat that as empty key.
+  if (!key || key === 'undefined') {
+    return ''
   }
+
+  // the masking pattern is 11 chars long (ab12...34yz)
+  // anything shorter, just return as-is
+  const parts = key.split(':')
+  const keyOnly = parts.shift()
+  if (keyOnly.length < 11) {
+    return keyOnly + ':' + parts.join(':')
+  }
+
   return keyOnly.slice(0, 4) + '...' + keyOnly.slice(-4) + ':' + parts.join(':')
 }
 


### PR DESCRIPTION
## Overview

This pull request changes logging code so that it masks a service key output in the logged error even if the input value itself is not a valid service key.

## Status

When user is providing an invalid service key, application logs will contain what was provided as-is. An invalid service key may still expose a valid and usable token or part thereof.

## Change

Always mask the service key provided.

## Note

- Pull Request merges into `nh-main`. Agent built from `master` will stay unchanged.